### PR TITLE
ci(devops): add pr validation workflow and wait for checks before merge

### DIFF
--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-changes
-version: 1.2.0
+version: 1.3.0
 description: >
   End-to-end workflow that reviews working tree changes, creates a
   feature branch, commits with strict Conventional Commits format,
@@ -359,9 +359,22 @@ gh pr edit <pr_number> --add-assignee "@me" \
   --add-label "<label>"
 ```
 
-## Step 13: Merge the Pull Request
+## Step 13: Wait for Status Checks and Merge
 
-Use the GitHub MCP `merge_pull_request` tool to merge:
+Before merging, wait for all required PR status checks to pass.
+
+Poll the check status using the GitHub MCP
+`pullRequestStatusChecks` tool or the `gh` CLI:
+
+```bash
+gh pr checks <pr_number> --watch --interval 15
+```
+
+This command blocks until all checks complete. If any check
+fails, stop and report the failure to the user — do not merge.
+
+Once all checks pass, use the GitHub MCP `merge_pull_request`
+tool to merge:
 
 - **owner**: repository owner
 - **repo**: repository name

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,53 @@
+name: PR Validate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-markdown:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint Markdown files
+        run: npx markdownlint-cli2 "**/*.md"
+
+  validate-commit-message:
+    name: Validate Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate PR title as Conventional Commit
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|security|revert)(\(.+\))?!?: .+$'
+          if [[ ! "$TITLE" =~ $PATTERN ]]; then
+            echo "::error::PR title does not follow Conventional Commits format."
+            echo "Expected: <type>(<scope>): <description>"
+            echo "Got: $TITLE"
+            exit 1
+          fi
+          if [[ ${#TITLE} -gt 72 ]]; then
+            echo "::error::PR title exceeds 72 characters (${#TITLE})."
+            exit 1
+          fi
+          echo "PR title is valid: $TITLE"


### PR DESCRIPTION
Adds a GitHub Actions workflow (.github/workflows/pr-validate.yml)
that runs on pull requests to main. It validates markdown linting
and checks the PR title follows Conventional Commits format.
Updates ship-changes skill Step 13 to poll and wait for all PR
status checks to pass before merging. Bumps skill to v1.3.0.