### PR TITLE
feat(workflow): add issue triage and agent planning automation

### DIFF
--- a/.claude/skills/find-work/SKILL.md
+++ b/.claude/skills/find-work/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: find-work
+version: 1.0.0
+description: >
+  Queries GitHub Issues to find the next available issue to work on.
+  Respects team authorization, priority ordering, and assignment
+  rules from AGENTS.md. Use this skill when you need to discover
+  what to work on next.
+author: "@idp-maintain"
+domain: devops
+tags:
+  - github
+  - issues
+  - discovery
+  - workflow
+  - automation
+depends_on: []
+inputs:
+  - name: domain
+    type: string
+    required: false
+    description: >
+      Filter issues by domain label (e.g., ai, api, security).
+      If omitted, returns issues across all domains.
+  - name: max_results
+    type: number
+    required: false
+    default: 5
+    description: Maximum number of issues to return.
+outputs:
+  - name: issues
+    type: array
+    description: >
+      Sorted list of eligible issues with number, title, priority,
+      labels, and assignee.
+  - name: recommended
+    type: number
+    description: >
+      The issue number recommended as the next item to work on,
+      based on priority ordering.
+---
+
+# Find Work
+
+Discovers the next available issue to work on by querying GitHub
+Issues, filtering by authorization and status, and sorting by the
+priority rules defined in AGENTS.md.
+
+## Step 1: Query Open Issues
+
+Use the GitHub MCP `list_issues` tool to fetch open issues for the
+repository with the following filters:
+
+- **state**: `open`
+- **labels**: `ready` (issues must be triaged and approved)
+
+If the `domain` input is provided, also filter by that domain label.
+
+**Fallback**: If the MCP tool is unavailable, use the `gh` CLI:
+
+```bash
+gh issue list --state open --label "ready" --json number,title,labels,assignees,author,createdAt --limit 50
+```
+
+If `domain` is provided, add `--label "<domain>"` to the command.
+
+## Step 2: Filter Issues
+
+From the results, exclude issues that:
+
+1. Have the `in-progress` label (already being worked on).
+2. Have the `blocked` label.
+3. Are assigned to someone else (unless they have been idle for more
+   than 7 days with no recent comments).
+
+Also check for the `agent-eligible` label. Issues without this label
+are available for human work but should be listed with a note that
+they are not flagged for agent processing.
+
+## Step 3: Sort by Priority
+
+Sort the remaining issues using the AGENTS.md priority ordering:
+
+1. Issues assigned by `@idp-admin` members (highest priority)
+2. Issues assigned by `@idp-maintain` members
+3. Issues created by `@idp-admin` members
+4. Issues created by `@idp-maintain` members
+5. By priority label: `p0-critical` > `p1-high` > `p2-medium` >
+   `p3-low`
+6. By creation date (oldest first) as a tiebreaker
+
+## Step 4: Format and Return Results
+
+Return up to `max_results` issues (default: 5) as a formatted list
+showing:
+
+- Issue number and title
+- Priority and domain labels
+- Whether it is `agent-eligible`
+- Current assignee (if any)
+- Age (days since creation)
+
+Set `recommended` to the issue number of the top-ranked result.
+
+If no eligible issues are found, report that clearly and suggest
+checking for issues with `needs-triage` that may need a maintainer
+to approve.

--- a/.claude/skills/plan-work/SKILL.md
+++ b/.claude/skills/plan-work/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: plan-work
+version: 1.0.0
+description: >
+  Reads a GitHub Issue, analyzes the requirements, explores the
+  codebase for relevant context, and produces a structured
+  implementation plan posted as a comment on the issue. Always
+  stops after posting the plan -- a maintainer must approve before
+  implementation begins. Use this skill when an issue is ready
+  for work and needs a plan before coding starts.
+author: "@idp-maintain"
+domain: devops
+tags:
+  - github
+  - issues
+  - planning
+  - workflow
+  - automation
+depends_on: []
+inputs:
+  - name: issue_number
+    type: number
+    required: true
+    description: The GitHub Issue number to plan work for.
+outputs:
+  - name: plan
+    type: object
+    description: >
+      Structured implementation plan including files to modify,
+      approach, risks, and estimated complexity.
+  - name: ready_to_implement
+    type: boolean
+    description: >
+      Whether the plan is complete enough for implementation.
+      Always true when the skill completes successfully.
+---
+
+# Plan Work
+
+Reads a GitHub Issue, explores the codebase, and creates an
+implementation plan posted as a comment for maintainer approval.
+This skill never implements code -- it only plans.
+
+## Step 1: Fetch the Issue
+
+Use the GitHub MCP `get_issue` tool to retrieve the full issue
+body, labels, assignee, and all comments for the given
+`issue_number`.
+
+**Fallback**: If the MCP tool is unavailable, use the `gh` CLI:
+
+```bash
+gh issue view <issue_number> --json number,title,body,labels,assignees,comments,author,state
+```
+
+If the issue is closed, stop and report that the issue is already
+resolved.
+
+## Step 2: Verify Authorization and Status
+
+Check the issue labels and state:
+
+1. The issue must have the `ready` label. If it only has
+   `needs-triage`, stop and report that the issue needs maintainer
+   approval first.
+2. If the issue has `in-progress` label, check the comments for a
+   prior plan. If a plan already exists:
+   - Compare the current issue body to the plan's assumptions. If
+     the issue has been edited since the plan was posted, note the
+     changes and create an **updated plan** rather than a duplicate.
+   - If the plan is unchanged, report that a plan already exists
+     and link to the existing comment.
+3. If the issue has `blocked` label, stop and report the blocker.
+
+## Step 3: Claim the Issue
+
+Add the `in-progress` label to the issue to signal that planning
+is underway. This prevents duplicate work by other agents.
+
+Use the GitHub MCP `update_issue` tool or:
+
+```bash
+gh issue edit <issue_number> --add-label "in-progress"
+```
+
+## Step 4: Analyze Requirements
+
+Parse the issue body to extract:
+
+- **Description**: What needs to be built or fixed
+- **Acceptance Criteria**: Testable conditions for completion
+- **Priority**: From the priority label
+- **Domain**: From the domain label
+- **Constraints**: Any noted limitations or requirements
+
+If the issue is unclear or missing acceptance criteria, post a
+comment asking for clarification and add the `blocked` label.
+Remove `in-progress`. Stop and report.
+
+## Step 5: Explore the Codebase
+
+Based on the requirements and domain:
+
+1. Search for existing files, functions, and patterns relevant to
+   the change.
+2. Identify files that will need modification.
+3. Check for existing tests, documentation, or configuration that
+   should be updated.
+4. Look for reusable utilities, components, or patterns to follow.
+5. Review AGENTS.md for architectural guidelines relevant to the
+   domain.
+
+## Step 6: Create the Implementation Plan
+
+Produce a structured plan covering:
+
+1. **Summary**: One-paragraph overview of the approach.
+2. **Files to Create or Modify**: List each file with a brief
+   description of the changes needed.
+3. **Approach**: Step-by-step implementation strategy.
+4. **Existing Patterns to Follow**: Reference existing code that
+   should be used as a model.
+5. **Risks and Open Questions**: Anything uncertain or potentially
+   problematic.
+6. **Verification**: How to test that the implementation is correct.
+7. **Estimated Complexity**: Low / Medium / High based on the
+   number of files, conceptual complexity, and risk.
+
+## Step 7: Post the Plan to the Issue
+
+Use the GitHub MCP `add_issue_comment` tool to post the plan as a
+formatted comment on the issue.
+
+**Fallback**: If the MCP tool is unavailable, use the `gh` CLI:
+
+```bash
+gh issue comment <issue_number> --body "<plan>"
+```
+
+The comment should start with a clear header:
+
+```markdown
+## Implementation Plan
+
+> Posted by AI agent. Maintainer approval required before
+> implementation begins.
+```
+
+## Step 8: Update Issue Labels
+
+Replace `in-progress` with `needs-review` to signal that the plan
+is ready for maintainer review:
+
+```bash
+gh issue edit <issue_number> --remove-label "in-progress" --add-label "needs-review"
+```
+
+## Step 9: Report Results
+
+Output the structured plan and set `ready_to_implement` to `true`.
+
+Remind the user that implementation should not begin until a
+maintainer approves the plan by commenting on the issue. After
+approval, use the `/ship-changes` skill with the `issue_number`
+input to complete the cycle.
+
+## Handling Issue Changes After Planning
+
+If this skill is invoked again for an issue that already has a
+plan:
+
+1. Compare the current issue body and comments against the
+   previous plan.
+2. If the issue has changed, create a new plan comment noting
+   what changed and how the plan is updated.
+3. If the issue is unchanged, report that the existing plan is
+   still valid and link to it.
+
+This ensures the workflow is idempotent and resilient to mid-flight
+changes in requirements.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug or unexpected behavior.
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: What steps trigger the bug?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen?
+    validations:
+      required: false
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What happens instead?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this?
+      options:
+        - p3-low
+        - p2-medium
+        - p1-high
+        - p0-critical
+    validations:
+      required: false
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Primary area affected.
+      options:
+        - ai
+        - api
+        - devops
+        - docs
+        - infrastructure
+        - mcp
+        - plugin
+        - security
+        - ui
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: agent-eligible
+    attributes:
+      label: Agent Processing
+      options:
+        - label: This issue is suitable for autonomous AI agent processing.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Project Guidelines
+    url: https://github.com/ourchitecture/idp/blob/main/AGENTS.md
+    about: Read the project guidelines before contributing.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,61 @@
+name: Feature Request
+description: Propose a new feature or capability.
+labels: ["requirement", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should be built and why?
+      placeholder: Describe the feature and the problem it solves.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How will we know this is done?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this?
+      options:
+        - p3-low
+        - p2-medium
+        - p1-high
+        - p0-critical
+    validations:
+      required: false
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Primary area affected.
+      options:
+        - ai
+        - api
+        - devops
+        - docs
+        - infrastructure
+        - mcp
+        - plugin
+        - security
+        - ui
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: agent-eligible
+    attributes:
+      label: Agent Processing
+      options:
+        - label: This issue is suitable for autonomous AI agent processing.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,63 @@
+name: Task
+description: A maintenance task, spike, chore, or design proposal.
+labels: ["needs-triage"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Task Type
+      description: What kind of work is this?
+      options:
+        - task
+        - spike
+        - chore
+        - design
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why?
+      placeholder: Describe the task.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent is this?
+      options:
+        - p3-low
+        - p2-medium
+        - p1-high
+        - p0-critical
+    validations:
+      required: false
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      description: Primary area affected.
+      options:
+        - ai
+        - api
+        - devops
+        - docs
+        - infrastructure
+        - mcp
+        - plugin
+        - security
+        - ui
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: agent-eligible
+    attributes:
+      label: Agent Processing
+      options:
+        - label: This issue is suitable for autonomous AI agent processing.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Pull Request
+
+## Summary
+
+<!-- What changed and why? Keep it brief. -->
+
+## Issue Reference
+
+<!-- Link the issue this PR addresses. Use "Closes #N" to auto-close. -->
+
+Closes #
+
+## Changes
+
+<!-- Bullet list of notable changes. -->
+
+-
+
+## Verification
+
+<!-- Check off what you verified before requesting review. -->
+
+- [ ] Changes are limited to what the issue requires
+- [ ] Markdown linting passes (`npm run lint:md`)
+- [ ] No secrets, credentials, or sensitive data included

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,126 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    name: Triage Issue
+    runs-on: ubuntu-latest
+    # Skip if the actor is a bot to avoid feedback loops
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Parse issue form fields and apply labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set -euo pipefail
+
+          # --- Helper: extract form field value by heading ---
+          extract_field() {
+            local heading="$1"
+            echo "$ISSUE_BODY" | awk -v h="### ${heading}" '
+              $0 == h { found=1; next }
+              found && /^### / { exit }
+              found && /^[[:space:]]*$/ { next }
+              found { print; exit }
+            '
+          }
+
+          # --- Helper: idempotent label add (no error if exists) ---
+          add_label() {
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$1" 2>/dev/null || true
+          }
+
+          # --- Helper: idempotent label remove (no error if missing) ---
+          remove_label() {
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "$1" 2>/dev/null || true
+          }
+
+          # --- Parse priority ---
+          PRIORITY=$(extract_field "Priority")
+          if [[ -n "$PRIORITY" && "$PRIORITY" =~ ^p[0-3] ]]; then
+            # Remove any existing priority labels first (idempotent on edit)
+            for p in p0-critical p1-high p2-medium p3-low; do
+              remove_label "$p"
+            done
+            add_label "$PRIORITY"
+            echo "Applied priority: $PRIORITY"
+          fi
+
+          # --- Parse domain ---
+          DOMAIN=$(extract_field "Domain")
+          if [[ -n "$DOMAIN" ]]; then
+            # Remove any existing domain labels first (idempotent on edit)
+            for d in security ai mcp infrastructure plugin api ui devops docs; do
+              remove_label "$d"
+            done
+            add_label "$DOMAIN"
+            echo "Applied domain: $DOMAIN"
+          fi
+
+          # --- Parse task type (task template only) ---
+          TASK_TYPE=$(extract_field "Task Type")
+          if [[ -n "$TASK_TYPE" ]]; then
+            for t in task spike chore design; do
+              remove_label "$t"
+            done
+            add_label "$TASK_TYPE"
+            echo "Applied task type: $TASK_TYPE"
+          fi
+
+          # --- Parse agent-eligible checkbox ---
+          if echo "$ISSUE_BODY" | grep -q '\[X\].*suitable for autonomous AI agent'; then
+            AGENT_CHECKED="true"
+          else
+            AGENT_CHECKED="false"
+            # Remove agent-eligible if unchecked on edit (idempotent)
+            remove_label "agent-eligible"
+          fi
+
+          # --- Check author team membership ---
+          IS_TEAM_MEMBER="false"
+          for TEAM in idp-admin idp-maintain; do
+            STATUS=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "orgs/${REPO%%/*}/teams/${TEAM}/members/${ISSUE_AUTHOR}" \
+              --silent -i 2>&1 | head -1 | grep -o '[0-9]\{3\}' | head -1) || true
+            if [[ "$STATUS" == "200" ]]; then
+              IS_TEAM_MEMBER="true"
+              break
+            fi
+          done
+
+          echo "Author '${ISSUE_AUTHOR}' is team member: ${IS_TEAM_MEMBER}"
+
+          # --- Apply status labels based on authorization ---
+          if [[ "$IS_TEAM_MEMBER" == "true" ]]; then
+            # Authorized: mark ready, apply agent-eligible if checked
+            remove_label "needs-triage"
+            add_label "ready"
+            if [[ "$AGENT_CHECKED" == "true" ]]; then
+              add_label "agent-eligible"
+            fi
+            echo "Issue triaged as ready (authorized author)."
+          else
+            # External: keep needs-triage, strip agent-eligible
+            remove_label "ready"
+            remove_label "agent-eligible"
+            add_label "needs-triage"
+
+            # Post a triage comment only on 'opened' (not on every edit)
+            if [[ "${{ github.event.action }}" == "opened" ]]; then
+              gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+                "Thank you for opening this issue! A maintainer from \`@ourchitecture/idp-maintain\` will review and triage it before work can begin."
+            fi
+            echo "Issue awaiting triage (external contributor)."
+          fi

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   lint-markdown:
@@ -36,18 +37,56 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check PR author team membership
+        id: author-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          IS_TEAM_MEMBER="false"
+
+          # Check idp-admin and idp-maintain team membership
+          for TEAM in idp-admin idp-maintain; do
+            STATUS=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "orgs/${{ github.repository_owner }}/teams/${TEAM}/members/${AUTHOR}" \
+              --silent -i 2>&1 | head -1 | grep -o '[0-9]\{3\}' | head -1) || true
+            if [[ "$STATUS" == "200" ]]; then
+              IS_TEAM_MEMBER="true"
+              break
+            fi
+          done
+
+          echo "is_team_member=${IS_TEAM_MEMBER}" >> "$GITHUB_OUTPUT"
+          echo "Author '${AUTHOR}' is team member: ${IS_TEAM_MEMBER}"
+
       - name: Validate PR title as Conventional Commit
+        env:
+          IS_TEAM_MEMBER: ${{ steps.author-check.outputs.is_team_member }}
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|security|revert)(\(.+\))?!?: .+$'
+
           if [[ ! "$TITLE" =~ $PATTERN ]]; then
-            echo "::error::PR title does not follow Conventional Commits format."
-            echo "Expected: <type>(<scope>): <description>"
-            echo "Got: $TITLE"
-            exit 1
+            if [[ "$IS_TEAM_MEMBER" == "true" ]]; then
+              echo "::error::PR title does not follow Conventional Commits format."
+              echo "Expected: <type>(<scope>): <description>"
+              echo "Got: $TITLE"
+              exit 1
+            else
+              echo "::notice::PR title does not follow Conventional Commits format, but this is not required for external contributors. A maintainer will set the final commit message on merge."
+              exit 0
+            fi
           fi
+
           if [[ ${#TITLE} -gt 72 ]]; then
-            echo "::error::PR title exceeds 72 characters (${#TITLE})."
-            exit 1
+            if [[ "$IS_TEAM_MEMBER" == "true" ]]; then
+              echo "::error::PR title exceeds 72 characters (${#TITLE})."
+              exit 1
+            else
+              echo "::notice::PR title exceeds 72 characters (${#TITLE}), but this is not enforced for external contributors."
+              exit 0
+            fi
           fi
+
           echo "PR title is valid: $TITLE"

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -1,0 +1,60 @@
+name: Setup Labels
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  create-labels:
+    name: Create Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bootstrap repository labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          create_label() {
+            gh label create "$1" --color "$2" --description "$3" \
+              --repo "$REPO" --force
+          }
+
+          # Type labels
+          create_label "requirement" "0075ca" "New feature or capability"
+          create_label "bug"         "d73a4a" "Something is not working"
+          create_label "task"        "006b75" "Maintenance or operational work"
+          create_label "spike"       "d4c5f9" "Time-boxed research or investigation"
+          create_label "design"      "c2e0c6" "Design proposal or discussion"
+          create_label "epic"        "3e4b9e" "Groups related issues"
+          create_label "chore"       "ededed" "Routine maintenance"
+
+          # Priority labels
+          create_label "p0-critical" "b60205" "Must fix immediately"
+          create_label "p1-high"     "d93f0b" "Fix in current cycle"
+          create_label "p2-medium"   "fbca04" "Plan for upcoming cycle"
+          create_label "p3-low"      "0e8a16" "Nice to have"
+
+          # Domain labels
+          create_label "security"       "ee0701" "Security domain"
+          create_label "ai"             "1d76db" "AI domain"
+          create_label "mcp"            "5319e7" "MCP domain"
+          create_label "infrastructure" "bfd4f2" "Infrastructure domain"
+          create_label "plugin"         "c5def5" "Plugin domain"
+          create_label "api"            "0052cc" "API domain"
+          create_label "ui"             "f9d0c4" "UI domain"
+          create_label "devops"         "b4a8d1" "DevOps domain"
+          create_label "docs"           "0075ca" "Documentation domain"
+
+          # Status labels
+          create_label "needs-triage"  "e4e669" "Awaiting maintainer review"
+          create_label "ready"         "0e8a16" "Triaged and ready for work"
+          create_label "in-progress"   "1d76db" "Actively being worked on"
+          create_label "blocked"       "b60205" "Blocked by dependency or question"
+          create_label "needs-review"  "fbca04" "Awaiting review or approval"
+
+          # Agent label
+          create_label "agent-eligible" "6f42c1" "Suitable for autonomous AI agent processing"
+
+          echo "All labels created or updated successfully."

--- a/.github/workflows/work-issue.yml
+++ b/.github/workflows/work-issue.yml
@@ -1,0 +1,81 @@
+name: Work Issue
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to signal for agent processing
+        required: true
+        type: number
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  signal-ready:
+    name: Signal Issue Ready for Agent
+    runs-on: ubuntu-latest
+    # Only run when agent-eligible label is added via event,
+    # or on manual dispatch
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'agent-eligible'
+    steps:
+      - name: Determine issue number
+        id: issue
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "number=${{ github.event.inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify issue is ready
+        id: verify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+            --json labels --jq '.labels[].name' 2>/dev/null) || true
+
+          if echo "$LABELS" | grep -q "^ready$"; then
+            echo "is_ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Issue #${ISSUE_NUMBER} does not have the 'ready' label. Skipping."
+            echo "is_ready=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check if a signal comment was already posted (idempotent)
+          EXISTING=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+            --json comments --jq '.comments[].body' 2>/dev/null \
+            | grep -c "ready for agent processing" || true)
+
+          if [[ "$EXISTING" -gt 0 ]]; then
+            echo "Signal comment already posted. Skipping duplicate."
+            echo "already_signaled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_signaled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post ready signal
+        if: >
+          steps.verify.outputs.is_ready == 'true' &&
+          steps.verify.outputs.already_signaled == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body \
+            "This issue is **ready for agent processing**. An agent can pick this up by running:
+
+          \`\`\`
+          /plan-work issue_number=${ISSUE_NUMBER}
+          \`\`\`
+
+          Or find it automatically with \`/find-work\`."


### PR DESCRIPTION
Introduce issue templates, triage automation, and maintainer-oriented planning skills so issue intake and work selection follow a consistent, authorized process. This establishes a repeatable path from issue creation to agent-ready planning while keeping external submissions in maintainer review until approved.

Update PR validation to enforce Conventional Commit titles for maintainers while allowing non-blocking guidance for external contributors. Add label bootstrap and ready-signal workflows to reduce manual triage overhead and keep issue state transitions consistent across repository events.