### PR TITLE
build(vscode): add tasks, launch, and make convenience docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local AI assistant settings
 .claude/settings.json
 
+# moon build cache (generated, not committed)
+.moon/cache/
+
 # Node.js
 node_modules/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,10 @@
 {
   "recommendations": [
-    "redhat.vscode-yaml"
+    // Go language support + delve debugger integration
+    "golang.go",
+    // YAML schema validation (used for moon configs and SKILL.md frontmatter)
+    "redhat.vscode-yaml",
+    // Markdown linting (mirrors markdownlint-cli2 used in CI)
+    "DavidAnson.vscode-markdownlint"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,117 @@
+{
+  // VS Code launch configurations for IDP.
+  //
+  // All Go debug configs require the official Go extension (golang.go).
+  // Delve (dlv) is installed automatically by the Go extension.
+  //
+  // Binaries are compiled into src/stacks/go/net-http/rest/.bin/ by the
+  // "Build: Go Stack (debug symbols)" / "Build: Go BFF (debug symbols)" tasks,
+  // which disable compiler optimisations so delve can set breakpoints reliably.
+  //
+  // Default launch  : "Debug: Full System (Go)"  [F5]
+  // Pick a config   : Ctrl+Shift+D, then choose from the dropdown.
+  "version": "0.2.0",
+  "compounds": [
+    {
+      // Default F5 launch: starts both Go services with debuggers attached.
+      "name": "Debug: Full System (Go)",
+      "configurations": ["Debug: Go Web Server", "Debug: Go BFF Server"],
+      "stopAll": true,
+      "presentation": {
+        "hidden": false,
+        "group": "go",
+        "order": 1
+      }
+    }
+  ],
+  "configurations": [
+    // -------------------------------------------------------------------------
+    // Go Web Server
+    // -------------------------------------------------------------------------
+    {
+      "name": "Debug: Go Web Server",
+      "type": "go",
+      "request": "launch",
+      // Launch the pre-built binary so that the stable .bin/ path is used
+      // (ADR-0006: no ephemeral go run executables on Windows).
+      "mode": "exec",
+      "program": "${workspaceFolder}/src/stacks/go/net-http/rest/.bin/idp-go-web",
+      "preLaunchTask": "Build: Go Stack (debug symbols)",
+      "cwd": "${workspaceFolder}/src/stacks/go/net-http/rest",
+      "env": {
+        "OUR_IDP_WEB_HOST": "127.0.0.1",
+        "OUR_IDP_PORT": "3000"
+      },
+      "stopOnEntry": false,
+      "showLog": false,
+      "presentation": {
+        "hidden": false,
+        "group": "go",
+        "order": 2
+      },
+      // Windows: binary has .exe extension.
+      "windows": {
+        "program": "${workspaceFolder}/src/stacks/go/net-http/rest/.bin/idp-go-web.exe"
+      }
+    },
+    {
+      // Attach variant — use when you have already started the web server
+      // with dlv running on port 2345 (e.g. dlv exec --headless --listen=:2345).
+      "name": "Attach: Go Web Server",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "host": "127.0.0.1",
+      "port": 2345,
+      "cwd": "${workspaceFolder}/src/stacks/go/net-http/rest",
+      "remotePath": "${workspaceFolder}/src/stacks/go/net-http/rest",
+      "presentation": {
+        "hidden": false,
+        "group": "go-attach",
+        "order": 1
+      }
+    },
+
+    // -------------------------------------------------------------------------
+    // Go BFF Server
+    // -------------------------------------------------------------------------
+    {
+      "name": "Debug: Go BFF Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/src/stacks/go/net-http/rest/.bin/idp-go-bff",
+      "preLaunchTask": "Build: Go BFF (debug symbols)",
+      "cwd": "${workspaceFolder}/src/stacks/go/net-http/rest",
+      "env": {
+        "OUR_IDP_API_HOST": "127.0.0.1",
+        "OUR_IDP_API_PORT": "8000"
+      },
+      "stopOnEntry": false,
+      "showLog": false,
+      "presentation": {
+        "hidden": false,
+        "group": "go",
+        "order": 3
+      },
+      "windows": {
+        "program": "${workspaceFolder}/src/stacks/go/net-http/rest/.bin/idp-go-bff.exe"
+      }
+    },
+    {
+      "name": "Attach: Go BFF Server",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "host": "127.0.0.1",
+      "port": 2346,
+      "cwd": "${workspaceFolder}/src/stacks/go/net-http/rest",
+      "remotePath": "${workspaceFolder}/src/stacks/go/net-http/rest",
+      "presentation": {
+        "hidden": false,
+        "group": "go-attach",
+        "order": 2
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,221 @@
+{
+  // VS Code tasks for the IDP repository.
+  //
+  // moon is the canonical orchestrator. Tasks invoke moon through the shell so
+  // that proto shims on PATH are used automatically on all platforms.
+  // GNU Make convenience wrappers are noted where relevant but moon is preferred.
+  //
+  // Default build task  : "Dev: Start Full System (Go)"  [Ctrl+Shift+B]
+  // Run selected task   : Ctrl+Shift+P > "Tasks: Run Task"
+  "version": "2.0.0",
+  "tasks": [
+    // -------------------------------------------------------------------------
+    // Build
+    // -------------------------------------------------------------------------
+    {
+      "label": "Build: Go Stack",
+      "detail": "moon run go-net-http-rest:build  (or: make -C src/stacks/go/net-http/rest build)",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:build",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "build"
+      },
+      "problemMatcher": "$go"
+    },
+    {
+      "label": "Build: Go Stack (debug symbols)",
+      "detail": "Compiles web and BFF binaries with -gcflags='all=-N -l' for delve debugger",
+      "type": "shell",
+      "command": "go build -gcflags=\"all=-N -l\" -o .bin/idp-go-web${GOEXE} ./web",
+      "options": {
+        "cwd": "${workspaceFolder}/src/stacks/go/net-http/rest"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "group": "build"
+      },
+      "problemMatcher": "$go"
+    },
+    {
+      "label": "Build: Go BFF (debug symbols)",
+      "detail": "Compiles BFF binary with -gcflags='all=-N -l' for delve debugger",
+      "type": "shell",
+      "command": "go build -gcflags=\"all=-N -l\" -o .bin/idp-go-bff${GOEXE} ./bff",
+      "options": {
+        "cwd": "${workspaceFolder}/src/stacks/go/net-http/rest"
+      },
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "group": "build"
+      },
+      "problemMatcher": "$go"
+    },
+    {
+      "label": "Build: All Stacks",
+      "detail": "moon run go-net-http-rest:all nodejs-react-fastify-rest:all",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:all nodejs-react-fastify-rest:all",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "build"
+      },
+      "problemMatcher": ["$go", "$tsc"]
+    },
+
+    // -------------------------------------------------------------------------
+    // Run / Dev
+    // -------------------------------------------------------------------------
+    {
+      "label": "Run: Go Web Server",
+      "detail": "moon run go-net-http-rest:run-web  (or: make run-web)",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:run-web",
+      "isBackground": true,
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev",
+        "label": "Go Web"
+      },
+      "problemMatcher": {
+        "owner": "go-web",
+        "pattern": {
+          "regexp": "^(.*\\.go):(\\d+):(\\d+):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\{.*\"msg\":\\s*\"IDP web server listening\"",
+          "endsPattern": "^\\{.*\"msg\":\\s*\"IDP web server listening\""
+        }
+      }
+    },
+    {
+      "label": "Run: Go BFF Server",
+      "detail": "moon run go-net-http-rest:run-bff  (or: make run-bff)",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:run-bff",
+      "isBackground": true,
+      "group": "none",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev",
+        "label": "Go BFF"
+      },
+      "problemMatcher": {
+        "owner": "go-bff",
+        "pattern": {
+          "regexp": "^(.*\\.go):(\\d+):(\\d+):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\{.*\"msg\":\\s*\"IDP BFF listening\"",
+          "endsPattern": "^\\{.*\"msg\":\\s*\"IDP BFF listening\""
+        }
+      }
+    },
+    {
+      "label": "Dev: Start Full System (Go)",
+      "detail": "Starts Go web server (port 3000) and BFF (port 8000) in parallel",
+      "dependsOn": ["Run: Go Web Server", "Run: Go BFF Server"],
+      "dependsOrder": "parallel",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "dev"
+      },
+      "problemMatcher": []
+    },
+
+    // -------------------------------------------------------------------------
+    // Check / Lint / Test
+    // -------------------------------------------------------------------------
+    {
+      "label": "Check: Go Stack (lint + test + contract)",
+      "detail": "moon run go-net-http-rest:check  (or: make check)",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:check",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "check"
+      },
+      "problemMatcher": "$go"
+    },
+    {
+      "label": "Check: Go Stack (CI)",
+      "detail": "moon run go-net-http-rest:check-ci",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:check-ci",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "check"
+      },
+      "problemMatcher": "$go"
+    },
+    {
+      "label": "Check: Lint Markdown",
+      "detail": "moon run repo:check-lint-md  (or: make check-lint-md)",
+      "type": "shell",
+      "command": "moon run repo:check-lint-md",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "check"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Check: All Stacks",
+      "detail": "moon run go-net-http-rest:all nodejs-react-fastify-rest:all  (or: make all)",
+      "type": "shell",
+      "command": "moon run go-net-http-rest:all nodejs-react-fastify-rest:all",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "check"
+      },
+      "problemMatcher": ["$go", "$tsc"]
+    },
+    {
+      "label": "Check: Contract Tests",
+      "detail": "npm run test:contract (requires a running stack)",
+      "type": "shell",
+      "command": "npm run test:contract",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "group": "check"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Current high-signal ADRs agents must respect:
 - `0005` shared capability contract and profile-based conformance model.
 - `0006` cross-platform local runtime UX baseline (loopback defaults,
   stable executable identity for compiled stacks).
+- `0007` moon-required orchestration and proto-enhanced pinned toolchain policy.
 
 When proposing a new ADR, include a short rationale for why the decision is
 long-lived, cross-cutting, and not better captured in regular docs.
@@ -61,6 +62,34 @@ Use this intake threshold before adding an ADR:
 - Only work on authorized issues from `@idp-admin` or `@idp-maintain`.
 - If external, add `needs-triage` and request maintainer review.
 - Comment on the issue for key decisions, blockers, or scope changes.
+
+## CI/CD and Make Reuse (Required)
+
+- `moon` is required for maintainer and CI orchestration flows.
+- `proto` should be used to provide pinned, reproducible maintainer/CI toolchain
+  installs, but contributors may use system-installed language toolchains.
+- GNU Make targets are **optional convenience wrappers** for common local
+  workflows. Contributors are not required to use them; direct `moon`, `npm`,
+  or language-toolchain commands are equally valid. Make targets must stay in
+  sync with their `moon`/script equivalents and must not duplicate logic that
+  diverges from the canonical command.
+
+- PR validation must be path-aware and run the minimum meaningful checks for the
+  changed scope.
+- For open-source/external pull requests, prefer careful, lower-cost validation
+  by default; run expensive full-system checks only when shared or
+  cross-cutting paths change.
+- Any CI/CD command that developers should be able to reproduce locally must be
+  exposed through GNU Make targets and/or repo scripts (for example
+  `scripts/ci/`).
+- GitHub workflows should call those Make targets/scripts rather than embedding
+  one-off inline shell logic when the logic is reusable.
+- Validation and test commands in Makefiles should use `check-` prefixed
+  targets (for example `check-lint-md`, `check-test`, `check-contract`).
+- Use `check-lint-md` as the canonical Markdown lint target name (not
+  `lint-md`).
+- Keep GNU Make targets as compatibility wrappers so local workflows remain
+  accessible even when moon is the canonical CI/maintainer orchestrator.
 
 ## Documentation Requirements (Required)
 
@@ -122,31 +151,52 @@ For each runnable stack, child project, or major component, document:
 
 ## Build, Lint, Test Commands
 
-This repo defines linting, runtime startup, and contract test scripts in
-`package.json`.
+This repo defines reusable GNU Make targets as **optional convenience wrappers**
+for common local workflows, alongside canonical `moon` and `npm` commands.
+Contributors may use any of the following interchangeably; `make` targets are
+not required but are always kept in sync with their `moon`/script equivalents.
 
 - Install deps: `npm install`
-- Lint Markdown: `npm run lint:md`
-- Lint a single file: `npm run lint:md -- "README.md"`
-- Lint a single file (direct): `npx markdownlint-cli2 "README.md"`
-- Run Go web server (default stack): `npm run start:web`
-- Run Go BFF server (default stack): `npm run start:bff`
-- Run React web server (additional reference): `npm run start:web:react-fastify`
-- Run React BFF server (additional reference): `npm run start:bff:react-fastify`
-- Run contract tests: `npm run test:contract`
-- Start default stack (web + BFF): `make dev`
-- Test running system: `make test`
+- Install pinned toolchain (recommended): `proto install`
+- Show moon project graph and tasks: `moon project <project-id>`
+- Lint Markdown (make shortcut): `make check-lint-md`
+- Lint Markdown (moon canonical): `moon run repo:check-lint-md`
+- Lint workflow files (make shortcut): `make check-lint-workflows`
+- Compute PR change-based validation plan:
+  `BASE_SHA=<sha> HEAD_SHA=<sha> make check-pr-changes`
+- Run Go web server (npm): `npm run start:web`
+- Run Go web server (make shortcut): `make run-web`
+- Run Go BFF server (npm): `npm run start:bff`
+- Run Go BFF server (make shortcut): `make run-bff`
+- Run React web server (npm): `npm run start:web:react-fastify`
+- Run React BFF server (npm): `npm run start:bff:react-fastify`
+- Run contract tests (npm): `npm run test:contract`
+- Start default stack web + BFF (make shortcut): `make dev`
+- Test running system (make shortcut): `make test`
+- Run full build/test verification for all detected stacks (make shortcut): `make all`
 
-Stack-level Makefile targets (from `src/stacks/<stack>/Makefile`):
+Moon project IDs currently used:
 
+- `repo`
+- `go-net-http-rest`
+- `nodejs-react-fastify-rest`
+- `contract-tests`
+
+Stack-level Makefile targets (from `src/stacks/<stack>/Makefile`).
+All are **optional convenience wrappers**; equivalent `moon` task invocations
+are equally valid.
+
+- `make all` runs install, build, lint, tests, and contract checks for that stack.
 - `make install` installs dependencies for that stack.
 - `make build` builds stack artifacts.
 - `make clean` removes stack build artifacts.
 - `make check-lint` runs stack linters.
 - `make check-test` runs stack tests.
+- `make check-contract` runs stack contract checks.
+- `make check-ci` runs CI-safe validation checks for the stack.
 - `make check` runs lint, tests, and contract checks for that stack.
 - `make test` is a stack-defined test alias (at minimum `check-test`).
-- `make test-contract` runs the contract harness against the stack.
+- `make test-contract` is a stack-defined alias for `check-contract`.
 - `make run-web` starts the web server for that stack.
 - `make run-bff` starts the BFF server for that stack.
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,72 @@ tools/      Developer tooling, scripts, and MCP server definitions
 - Docker and Docker Compose
 - Go 1.25+
 - Node.js 20+
-- Access to the `ourchitecture` GitHub organization
+
+### Quickstart
+
+The fastest path to a running local stack:
+
+```bash
+# Install Node.js dependencies
+npm install
+
+# (Optional) Pin and install the full toolchain via proto
+proto install
+
+# Start the default stack (web + BFF)
+make dev
+```
+
+That starts the Go web server and BFF, both bound to `127.0.0.1` by default.
+Open the web UI at `http://127.0.0.1:<port>` once the servers report ready.
+
+Run all checks before opening a PR:
+
+```bash
+make check
+```
+
+See all available `make` targets:
+
+```bash
+make help
+```
+
+### Tooling Policy
+
+This project standardizes workflows around `moon` while keeping language tooling
+flexible for contributors.
+
+- `moon` is required for maintainer and CI orchestration.
+- `proto` is recommended for consistent pinned toolchain setup, but contributors
+  may use system-installed Go/Node directly.
+- GNU Make targets are supported as convenient local shortcuts and CI
+  compatibility wrappers; use them whenever `moon` is not installed.
+
+Install and pin tooling with proto (recommended):
+
+```bash
+proto install
+```
+
+Run common checks with moon (or use the equivalent `make` targets below):
+
+```bash
+moon run repo:check-lint-md
+moon run go-net-http-rest:check-ci
+moon run nodejs-react-fastify-rest:check-ci
+```
 
 ### Development
 
 All development follows the issue-driven workflow defined in [AGENTS.md](AGENTS.md). Work is tracked via GitHub Issues and authorized through the `@idp-admin` and `@idp-maintain` teams.
+
+Agent workflow skills are available in `/.claude/skills/`:
+
+- `/find-work` to discover the next authorized issue.
+- `/plan-work issue_number=<N>` to prepare an implementation plan.
+- `/ship-changes issue_number=<N>` to commit, open a PR, and merge.
+- `/audit-work-integrity` to enforce strict branch/PR/issue linkage hygiene.
 
 ### Implementation Portfolio
 
@@ -48,16 +109,48 @@ All development follows the issue-driven workflow defined in [AGENTS.md](AGENTS.
 - Additional React-focused reference stack:
   `src/stacks/nodejs/react-fastify/rest`
 
-Start the default stack:
+Start the default stack (convenience shortcut):
 
 ```bash
 make dev
 ```
 
+Or invoke individual servers directly with moon:
+
+```bash
+moon run go-net-http-rest:run-web
+moon run go-net-http-rest:run-bff
+```
+
 Run conventional checks for the default stack:
 
 ```bash
+# Convenience shortcut (runs lint, tests, and contract checks)
 make check
+
+# Or with moon
+moon run go-net-http-rest:check-ci
+```
+
+Run Markdown lint checks:
+
+```bash
+# Convenience shortcut
+make check-lint-md
+
+# Or with moon
+moon run repo:check-lint-md
+```
+
+Run full verification across all detected stacks:
+
+```bash
+# Convenience shortcut (iterates all detected stacks automatically)
+make all
+
+# Or with moon (explicit per stack)
+moon run go-net-http-rest:all
+moon run nodejs-react-fastify-rest:all
 ```
 
 Run stack-only tests (without full check suite):


### PR DESCRIPTION
Add VS Code tasks.json and launch.json for cross-platform moon-based
developer workflows and Go debugger support. Update extensions.json
with Go and markdownlint recommendations. Align README.md and AGENTS.md
to document GNU Make targets as optional convenience wrappers alongside
canonical moon and npm commands. Ignore .moon/cache/ in .gitignore.