### PR TITLE
feat(mcp-tools): add MCP server adapter and mcp-profile contract tests

### DIFF
--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -5,6 +5,7 @@ projects:
     nodejs-react-fastify-rest: "stacks/nodejs/react-fastify/rest"
     contract-tests: "tests"
     docs-site: "docs"
+    mcp-tools: "tools/mcp"
 
 defaultProject: "repo"
 versionConstraint: ">=2.1.3"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,7 @@ Moon project IDs currently used:
 - `nodejs-react-fastify-rest`
 - `contract-tests`
 - `docs-site`
+- `mcp-tools`
 
 Stack-level Makefile targets (from `stacks/<stack>/Makefile`).
 All are **optional convenience wrappers**; equivalent `moon` task invocations

--- a/docs/content/testing/profiles/mcp-profile.md
+++ b/docs/content/testing/profiles/mcp-profile.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 4
+---
+
+# MCP Profile
+
+The `mcp-profile` contract validates that a Stemix IDP stack correctly exposes its capabilities
+through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/). MCP is a first-class
+interface layer in Stemix alongside REST, CLI, and UI — it lets AI agents interact with the portal
+without knowing its HTTP conventions.
+
+## Why it exists
+
+The IDP design principle "AI over MCP-First" means every capability should be reachable by an AI
+agent through a stable, discoverable protocol. The MCP profile enforces that a conforming MCP server
+can initialize, enumerate its tools, and invoke them correctly. It does not test AI reasoning — it
+tests the adapter layer that connects AI agents to the portal's capabilities.
+
+## Who must pass it
+
+Only stacks that declare both `"mcp-profile"` in `contractProfiles` **and**
+`capabilities.mcp.enabled = true` in their `stack.json` are required to pass this profile.
+
+The profile is skipped automatically when either declaration is absent.
+
+## Layer 1 spec
+
+Source: [`tests/features/mcp-profile.feature`](https://github.com/ourchitecture/idp/blob/main/tests/features/mcp-profile.feature)
+
+## Scenarios (4 total)
+
+### MCP server responds to initialize with server info and capabilities
+
+**Precondition:** The MCP server is running at `IDP_MCP_URL` (default: `http://localhost:8080`).
+
+**Assertions:**
+
+- MCP `initialize` request returns HTTP 2xx
+- JSON-RPC response contains a `result` field
+- `result.serverInfo` has a non-empty `name` and `version`
+- `result.capabilities` is present
+
+### tools/list returns the required tools with valid schemas
+
+**Precondition:** The MCP server is running.
+
+**Assertions:**
+
+- `tools/list` returns HTTP 2xx
+- `result.tools` is a non-empty array
+- Each tool has a non-empty `name`, `description`, and an `inputSchema` object
+- The list includes `get_portal_summary`
+- The list includes `check_health`
+
+### tools/call get_portal_summary returns a portal status result
+
+**Precondition:** The MCP server is running and can reach the BFF at `IDP_BFF_URL`.
+
+**Assertions:**
+
+- `tools/call get_portal_summary` returns HTTP 2xx
+- `result.content[0].type` is `"text"`
+- `result.content[0].text` is valid JSON containing a `status` field
+
+### tools/call check_health returns BFF health and readiness
+
+**Precondition:** The MCP server is running and can reach the BFF at `IDP_BFF_URL`.
+
+**Assertions:**
+
+- `tools/call check_health` returns HTTP 2xx
+- `result.content[0].type` is `"text"`
+- `result.content[0].text` is valid JSON with `health` and `readiness` fields
+- `health.status` is present
+
+## Layer 2 harness
+
+Source: [`tests/src/profiles/mcp-profile.ts`](https://github.com/ourchitecture/idp/blob/main/tests/src/profiles/mcp-profile.ts)
+
+The harness sends raw JSON-RPC 2.0 POST requests to `IDP_MCP_URL/mcp` using the existing
+zero-dependency HTTP client. It handles both `application/json` and `text/event-stream` (SSE)
+response formats to remain transport-agnostic.
+
+## Stack declarations
+
+Stacks that expose an MCP server must declare both the profile and the capability flag:
+
+```jsonc
+{
+  "contractProfiles": ["mcp-profile"],
+  "capabilities": {
+    "mcp": { "enabled": true }
+  }
+}
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IDP_MCP_URL` | `http://localhost:8080` | Base URL for the MCP server |
+| `IDP_BFF_URL` | `http://localhost:8000` | BFF URL the MCP server connects to |
+
+## Running the profile
+
+```sh
+# Start the BFF for a stack, then the MCP server, then run contract tests:
+IDP_MCP_URL=http://localhost:8080 \
+IDP_BFF_URL=http://localhost:8000 \
+IDP_STACK_PATH=tools/mcp \
+npm run test:contract
+```
+
+## Related
+
+- [Contract Test Harness](../contract-harness) — Full harness guide
+- [Core Profile](./core) — Baseline HTTP surface
+- [ADR-0005](../../architecture/decisions/shared-capability-contract-and-conformance-profiles) — Capability contract and conformance profiles
+- [ADR-0009](../../architecture/decisions/intent-specification-format) — Gherkin as Layer 1 format

--- a/tests/features/mcp-profile.feature
+++ b/tests/features/mcp-profile.feature
@@ -1,0 +1,44 @@
+Feature: MCP profile — Model Context Protocol interface contract
+  A stack that declares MCP capability must expose a compliant MCP server
+  accessible via the Streamable HTTP transport. These scenarios verify that
+  the server implements the protocol handshake, exposes the required tools,
+  and that those tools return valid, structured results.
+
+  Only stacks that declare "mcp-profile" in contractProfiles and set
+  capabilities.mcp.enabled = true are required to pass this profile.
+
+  Background:
+    Given the MCP server is running at the URL defined by IDP_MCP_URL
+
+  Scenario: MCP server responds to initialize with server info and capabilities
+    When the client sends an MCP initialize request to the MCP server
+    Then the response status code is in the 2xx range
+    And the JSON-RPC response contains a result field
+    And the result contains a "serverInfo" object with a non-empty "name" and "version"
+    And the result contains a "capabilities" object
+
+  Scenario: tools/list returns the required tools with valid schemas
+    When the client sends an MCP tools/list request to the MCP server
+    Then the response status code is in the 2xx range
+    And the JSON-RPC response contains a result field
+    And the result contains a "tools" array with at least one entry
+    And each tool has a non-empty "name", "description", and an "inputSchema" object
+    And the tools array includes a tool named "get_portal_summary"
+    And the tools array includes a tool named "check_health"
+
+  Scenario: tools/call get_portal_summary returns a portal status result
+    When the client calls the MCP tool "get_portal_summary" with no arguments
+    Then the response status code is in the 2xx range
+    And the JSON-RPC response contains a result field
+    And the result content is a non-empty array of content items
+    And content item 0 has type "text" and a non-empty text field
+    And the text is valid JSON containing a "status" field
+
+  Scenario: tools/call check_health returns BFF health and readiness
+    When the client calls the MCP tool "check_health" with no arguments
+    Then the response status code is in the 2xx range
+    And the JSON-RPC response contains a result field
+    And the result content is a non-empty array of content items
+    And content item 0 has type "text" and a non-empty text field
+    And the text is valid JSON containing "health" and "readiness" fields
+    And the "health" object contains a "status" field

--- a/tests/src/http.ts
+++ b/tests/src/http.ts
@@ -2,39 +2,73 @@ import http from "node:http";
 import https from "node:https";
 import type { ResponsePayload } from "./types";
 
+function collectResponse(res: http.IncomingMessage): Promise<ResponsePayload> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    res.on("data", (chunk) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      chunks.push(buffer);
+    });
+
+    res.on("end", () => {
+      const headers: Record<string, string> = {};
+      for (const [key, value] of Object.entries(res.headers)) {
+        if (value === undefined) {
+          continue;
+        }
+
+        headers[key.toLowerCase()] = Array.isArray(value)
+          ? value.join(", ")
+          : value;
+      }
+
+      resolve({
+        status: res.statusCode ?? 0,
+        headers,
+        body: Buffer.concat(chunks).toString("utf-8"),
+      });
+    });
+
+    res.on("error", reject);
+  });
+}
+
 export function request(url: URL): Promise<ResponsePayload> {
   const client = url.protocol === "https:" ? https : http;
 
   return new Promise((resolve, reject) => {
     const req = client.request(url, { method: "GET" }, (res) => {
-      const chunks: Buffer[] = [];
-
-      res.on("data", (chunk) => {
-        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        chunks.push(buffer);
-      });
-
-      res.on("end", () => {
-        const headers: Record<string, string> = {};
-        for (const [key, value] of Object.entries(res.headers)) {
-          if (value === undefined) {
-            continue;
-          }
-
-          headers[key.toLowerCase()] = Array.isArray(value)
-            ? value.join(", ")
-            : value;
-        }
-
-        resolve({
-          status: res.statusCode ?? 0,
-          headers,
-          body: Buffer.concat(chunks).toString("utf-8"),
-        });
-      });
+      collectResponse(res).then(resolve).catch(reject);
     });
 
     req.on("error", reject);
+    req.end();
+  });
+}
+
+export function post(url: URL, body: unknown): Promise<ResponsePayload> {
+  const client = url.protocol === "https:" ? https : http;
+  const payload = JSON.stringify(body);
+
+  return new Promise((resolve, reject) => {
+    const req = client.request(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json, text/event-stream",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        collectResponse(res).then(resolve).catch(reject);
+      }
+    );
+
+    req.on("error", reject);
+    req.write(payload);
     req.end();
   });
 }

--- a/tests/src/index.ts
+++ b/tests/src/index.ts
@@ -32,14 +32,16 @@ async function runTest(test: TestCase): Promise<void> {
 async function main(): Promise<void> {
   const webBaseUrl = resolveBaseUrl("IDP_WEB_URL", "http://localhost:3000");
   const bffBaseUrl = resolveBaseUrl("IDP_BFF_URL", "http://localhost:8000");
+  const mcpBaseUrl = resolveBaseUrl("IDP_MCP_URL", "http://localhost:8080");
 
   const stackMetadata = await loadStackMetadata();
   const requestedProfiles = resolveRequestedProfiles();
-  const orderedProfiles: ProfileName[] = ["core", "operational", "ui-profile"];
+  const orderedProfiles: ProfileName[] = ["core", "operational", "ui-profile", "mcp-profile"];
 
   const context: ContractContext = {
     webBaseUrl,
     bffBaseUrl,
+    mcpBaseUrl,
     stackMetadata,
   };
 

--- a/tests/src/profiles/index.ts
+++ b/tests/src/profiles/index.ts
@@ -1,4 +1,5 @@
 import { createCoreTests } from "./core";
+import { createMcpProfileTests } from "./mcp-profile";
 import { createOperationalTests } from "./operational";
 import { createUiProfileTests } from "./ui-profile";
 import type { ContractContext, ProfileName, TestCase } from "../types";
@@ -10,6 +11,10 @@ export function buildTestsForProfile(profile: ProfileName, context: ContractCont
 
   if (profile === "operational") {
     return createOperationalTests(context);
+  }
+
+  if (profile === "mcp-profile") {
+    return createMcpProfileTests(context);
   }
 
   return createUiProfileTests(context);

--- a/tests/src/profiles/mcp-profile.ts
+++ b/tests/src/profiles/mcp-profile.ts
@@ -1,0 +1,240 @@
+import { assert, parseJsonOrThrow } from "../assertions";
+import { post } from "../http";
+import type { ContractContext, TestCase } from "../types";
+
+const MCP_PROTOCOL_VERSION = "2024-11-05";
+
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+function mcpRequest(mcpBaseUrl: URL, payload: JsonRpcRequest): ReturnType<typeof post> {
+  return post(new URL("/mcp", mcpBaseUrl), payload);
+}
+
+/**
+ * Parse the JSON-RPC result from an MCP response body.
+ *
+ * The MCP Streamable HTTP transport may respond with either:
+ * - application/json: a direct JSON-RPC response object
+ * - text/event-stream: SSE stream with "data: {...}" lines
+ *
+ * This helper handles both formats and returns the parsed JSON-RPC envelope.
+ */
+function parseJsonRpcResponse(body: string): Record<string, unknown> {
+  const trimmed = body.trim();
+
+  // Try direct JSON first.
+  try {
+    const parsed = parseJsonOrThrow(trimmed);
+    assert(typeof parsed === "object" && parsed !== null, "JSON-RPC response must be an object");
+    return parsed as Record<string, unknown>;
+  } catch {
+    // Fall through to SSE parsing.
+  }
+
+  // Parse SSE: find the first "data: {...}" line.
+  for (const line of trimmed.split("\n")) {
+    const stripped = line.trim();
+    if (stripped.startsWith("data: ")) {
+      const data = stripped.slice(6).trim();
+      if (data && data !== "[DONE]") {
+        const parsed = parseJsonOrThrow(data);
+        assert(typeof parsed === "object" && parsed !== null, "SSE data must be a JSON object");
+        return parsed as Record<string, unknown>;
+      }
+    }
+  }
+
+  throw new Error(`Cannot parse MCP response body: ${body.slice(0, 200)}`);
+}
+
+function isMcpEnabled(context: ContractContext): boolean {
+  return context.stackMetadata?.capabilities?.mcp?.enabled === true;
+}
+
+export function createMcpProfileTests(context: ContractContext): TestCase[] {
+  if (!isMcpEnabled(context)) {
+    return [];
+  }
+
+  const { mcpBaseUrl } = context;
+  let requestId = 1;
+
+  function nextId(): number {
+    return requestId++;
+  }
+
+  return [
+    {
+      name: "mcp-profile:initialize returns server info and capabilities",
+      run: async () => {
+        const response = await mcpRequest(mcpBaseUrl, {
+          jsonrpc: "2.0",
+          id: nextId(),
+          method: "initialize",
+          params: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: { name: "idp-contract-test", version: "0.1.0" },
+          },
+        });
+
+        assert(
+          response.status >= 200 && response.status < 300,
+          `Expected 2xx from MCP initialize, got ${response.status}`
+        );
+
+        const envelope = parseJsonRpcResponse(response.body);
+        assert("result" in envelope, "MCP initialize response must contain a result field");
+
+        const result = envelope.result as Record<string, unknown>;
+        assert(
+          typeof result === "object" && result !== null,
+          "MCP initialize result must be an object"
+        );
+        assert(
+          "serverInfo" in result,
+          "MCP initialize result must contain serverInfo"
+        );
+        assert(
+          "capabilities" in result,
+          "MCP initialize result must contain capabilities"
+        );
+
+        const serverInfo = result.serverInfo as Record<string, unknown>;
+        assert(
+          typeof serverInfo.name === "string" && serverInfo.name.length > 0,
+          "MCP serverInfo.name must be a non-empty string"
+        );
+        assert(
+          typeof serverInfo.version === "string" && serverInfo.version.length > 0,
+          "MCP serverInfo.version must be a non-empty string"
+        );
+      },
+    },
+    {
+      name: "mcp-profile:tools/list returns expected tools with required fields",
+      run: async () => {
+        const response = await mcpRequest(mcpBaseUrl, {
+          jsonrpc: "2.0",
+          id: nextId(),
+          method: "tools/list",
+        });
+
+        assert(
+          response.status >= 200 && response.status < 300,
+          `Expected 2xx from MCP tools/list, got ${response.status}`
+        );
+
+        const envelope = parseJsonRpcResponse(response.body);
+        assert("result" in envelope, "MCP tools/list response must contain a result field");
+
+        const result = envelope.result as Record<string, unknown>;
+        assert(Array.isArray(result.tools), "MCP tools/list result must contain a tools array");
+
+        const tools = result.tools as unknown[];
+        assert(tools.length > 0, "MCP tools/list must return at least one tool");
+
+        for (const tool of tools) {
+          assert(typeof tool === "object" && tool !== null, "Each MCP tool must be an object");
+          const t = tool as Record<string, unknown>;
+          assert(typeof t.name === "string" && t.name.length > 0, "Each MCP tool must have a non-empty name");
+          assert(typeof t.description === "string" && t.description.length > 0, "Each MCP tool must have a non-empty description");
+          assert(typeof t.inputSchema === "object" && t.inputSchema !== null, "Each MCP tool must have an inputSchema object");
+        }
+
+        const toolNames = tools.map((t) => (t as Record<string, unknown>).name as string);
+        assert(
+          toolNames.includes("get_portal_summary"),
+          `MCP tools must include get_portal_summary (found: ${toolNames.join(", ")})`
+        );
+        assert(
+          toolNames.includes("check_health"),
+          `MCP tools must include check_health (found: ${toolNames.join(", ")})`
+        );
+      },
+    },
+    {
+      name: "mcp-profile:tools/call get_portal_summary returns portal status",
+      run: async () => {
+        const response = await mcpRequest(mcpBaseUrl, {
+          jsonrpc: "2.0",
+          id: nextId(),
+          method: "tools/call",
+          params: {
+            name: "get_portal_summary",
+            arguments: {},
+          },
+        });
+
+        assert(
+          response.status >= 200 && response.status < 300,
+          `Expected 2xx from MCP tools/call get_portal_summary, got ${response.status}`
+        );
+
+        const envelope = parseJsonRpcResponse(response.body);
+        assert("result" in envelope, "MCP tools/call response must contain a result field");
+
+        const result = envelope.result as Record<string, unknown>;
+        assert(Array.isArray(result.content), "MCP tool result must contain a content array");
+
+        const content = result.content as unknown[];
+        assert(content.length > 0, "MCP tool result content must be non-empty");
+
+        const firstItem = content[0] as Record<string, unknown>;
+        assert(firstItem.type === "text", "MCP tool result content[0] must have type 'text'");
+        assert(
+          typeof firstItem.text === "string" && firstItem.text.length > 0,
+          "MCP tool result content[0].text must be a non-empty string"
+        );
+
+        const summary = parseJsonOrThrow(firstItem.text as string) as Record<string, unknown>;
+        assert(typeof summary === "object" && summary !== null, "get_portal_summary text must be valid JSON");
+        assert("status" in summary, "get_portal_summary result must include a status field");
+      },
+    },
+    {
+      name: "mcp-profile:tools/call check_health returns BFF health envelope",
+      run: async () => {
+        const response = await mcpRequest(mcpBaseUrl, {
+          jsonrpc: "2.0",
+          id: nextId(),
+          method: "tools/call",
+          params: {
+            name: "check_health",
+            arguments: {},
+          },
+        });
+
+        assert(
+          response.status >= 200 && response.status < 300,
+          `Expected 2xx from MCP tools/call check_health, got ${response.status}`
+        );
+
+        const envelope = parseJsonRpcResponse(response.body);
+        assert("result" in envelope, "MCP tools/call response must contain a result field");
+
+        const result = envelope.result as Record<string, unknown>;
+        assert(Array.isArray(result.content), "MCP tool result must contain a content array");
+
+        const content = result.content as unknown[];
+        assert(content.length > 0, "MCP tool result content must be non-empty");
+
+        const firstItem = content[0] as Record<string, unknown>;
+        assert(firstItem.type === "text", "MCP tool result content[0] must have type 'text'");
+
+        const health = parseJsonOrThrow(firstItem.text as string) as Record<string, unknown>;
+        assert(typeof health === "object" && health !== null, "check_health text must be valid JSON");
+        assert("health" in health, "check_health result must include a health field");
+        assert("readiness" in health, "check_health result must include a readiness field");
+
+        const healthPayload = health.health as Record<string, unknown>;
+        assert("status" in healthPayload, "check_health.health must include a status field");
+      },
+    },
+  ];
+}

--- a/tests/src/runtime.ts
+++ b/tests/src/runtime.ts
@@ -19,7 +19,7 @@ function parseProfiles(raw: string | undefined): string[] {
 }
 
 function isProfileName(value: string): value is ProfileName {
-  return value === "core" || value === "operational" || value === "ui-profile";
+  return value === "core" || value === "operational" || value === "ui-profile" || value === "mcp-profile";
 }
 
 export function resolveBaseUrl(envName: string, fallback: string): URL {
@@ -168,7 +168,7 @@ export function shouldRunProfile(
     return stackMetadata.contractProfiles.includes(profile);
   }
 
-  if (profile === "ui-profile") {
+  if (profile === "ui-profile" || profile === "mcp-profile") {
     return false;
   }
 

--- a/tests/src/types.ts
+++ b/tests/src/types.ts
@@ -1,4 +1,4 @@
-export type ProfileName = "core" | "operational" | "ui-profile";
+export type ProfileName = "core" | "operational" | "ui-profile" | "mcp-profile";
 
 export type UiMode = "spa" | "ssr" | "server-rendered";
 
@@ -12,12 +12,16 @@ export type StackMetadata = {
       enabled?: boolean;
       mode?: UiMode;
     };
+    mcp?: {
+      enabled?: boolean;
+    };
   };
 };
 
 export type ContractContext = {
   webBaseUrl: URL;
   bffBaseUrl: URL;
+  mcpBaseUrl: URL;
   stackMetadata: StackMetadata | null;
 };
 

--- a/tools/mcp/Dockerfile
+++ b/tools/mcp/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+# Multi-stage build for the Stemix IDP MCP server.
+# Build context must be the tools/mcp directory.
+#
+# Build example (from tools/mcp/):
+#   docker build -t localhost/stemix-mcp-server:dev .
+
+ARG NODE_VERSION=24
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder — compile TypeScript to JavaScript
+# ---------------------------------------------------------------------------
+FROM node:${NODE_VERSION}-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci --ignore-scripts
+
+COPY src/ ./src/
+COPY tsconfig.json ./
+
+RUN npm run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime — lean Node.js image with compiled output only
+# ---------------------------------------------------------------------------
+FROM node:${NODE_VERSION}-alpine AS runtime
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev --ignore-scripts
+
+COPY --from=builder /app/dist/ ./dist/
+
+# Default to Streamable HTTP mode when running in a container.
+# Override with MCP_HTTP_PORT="" to use stdio (not useful in containers).
+ENV MCP_HTTP_PORT=8080
+
+# Connect to the BFF. Override at runtime via -e IDP_BFF_URL=...
+ENV IDP_BFF_URL=http://localhost:8000
+
+EXPOSE 8080
+
+CMD ["node", "dist/server.js"]

--- a/tools/mcp/Makefile
+++ b/tools/mcp/Makefile
@@ -1,0 +1,78 @@
+.PHONY: help all install build clean check-lint check-test check-contract check-ci check test test-contract run run-http build-container
+
+ROOT_DIR := ../..
+TOOL_PATH := tools/mcp
+MCP_TEST_HOST := 127.0.0.1
+MCP_TEST_PORT := 8580
+BFF_TEST_HOST := 127.0.0.1
+BFF_TEST_PORT := 8300
+CONTAINER_LOCAL_PREFIX := localhost
+CONTAINER_IMAGE_BASE := stemix-mcp-server
+
+help:
+	@printf "Targets:\n"
+	@printf "  all           Run full tool verification flow\n"
+	@printf "  install       Install dependencies\n"
+	@printf "  build         Compile TypeScript\n"
+	@printf "  clean         Remove build artifacts\n"
+	@printf "  check-lint    Run lint checks\n"
+	@printf "  check-test    Run type checks\n"
+	@printf "  check-contract Run contract tests against this MCP server\n"
+	@printf "  check-ci      Run CI-safe validation checks\n"
+	@printf "  check         Run lint, tests, and contract checks\n"
+	@printf "  test          Alias for check-test\n"
+	@printf "  test-contract Alias for check-contract\n"
+	@printf "  run           Start MCP server in stdio mode\n"
+	@printf "  run-http      Start MCP server in HTTP mode on port 8080\n"
+	@printf "  build-container Build container image (requires docker)\n"
+
+all: install build check
+
+install:
+	@npm install
+
+build:
+	@npm run build
+
+clean:
+	@rm -rf dist
+
+check-lint:
+	@echo "No additional lint configured for mcp-tools"
+
+check-test:
+	@npm run typecheck
+
+test: check-test
+
+check-ci: install build check-test
+
+check: check-lint check-test check-contract
+
+check-contract:
+	@npm --prefix "$(ROOT_DIR)" install; \
+	MCP_HTTP_PORT="$(MCP_TEST_PORT)" IDP_BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" node dist/server.js >/dev/null 2>&1 & MCP_PID=$$!; \
+	trap 'kill $$MCP_PID >/dev/null 2>&1 || true' EXIT; \
+	sleep 2; \
+	IDP_MCP_URL="http://$(MCP_TEST_HOST):$(MCP_TEST_PORT)" IDP_STACK_PATH="$(TOOL_PATH)" IDP_CONTRACT_PROFILES="mcp-profile" npm --prefix "$(ROOT_DIR)" run test:contract; \
+	STATUS=$$?; \
+	kill $$MCP_PID >/dev/null 2>&1 || true; \
+	wait $$MCP_PID 2>/dev/null || true; \
+	exit $$STATUS
+
+test-contract: check-contract
+
+run:
+	@node dist/server.js
+
+run-http:
+	@MCP_HTTP_PORT=8080 node dist/server.js
+
+build-container:
+	@if ! command -v docker >/dev/null 2>&1; then \
+		echo "ERROR: docker is required but not found in PATH" >&2; \
+		exit 1; \
+	fi
+	@docker build \
+		-t "$(CONTAINER_LOCAL_PREFIX)/$(CONTAINER_IMAGE_BASE):latest" \
+		.

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -1,0 +1,98 @@
+# Stemix IDP MCP Server
+
+MCP (Model Context Protocol) adapter for the Stemix Intent-Driven Portal BFF. This tool exposes
+IDP capabilities as MCP tools so that AI agents can interact with the portal without knowing its
+HTTP REST conventions.
+
+It is a thin interface adapter — all capability logic lives in the BFF. The MCP server translates
+agent requests into BFF API calls and returns structured results.
+
+## Why it exists
+
+The IDP design principle "AI over MCP-First" means every portal capability should be reachable by
+AI agents through a stable, discoverable protocol. This server is the MCP interface adapter layer.
+
+## Prerequisites
+
+- Node.js 20 or later
+- A running IDP BFF (default: `http://localhost:8000`)
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IDP_BFF_URL` | `http://localhost:8000` | Base URL of the IDP BFF to connect to |
+| `MCP_HTTP_PORT` | _(unset)_ | When set, starts Streamable HTTP server on this port; otherwise starts in stdio mode |
+
+## Install dependencies
+
+```sh
+npm install
+```
+
+## Build
+
+```sh
+npm run build
+# or
+make build
+```
+
+## Run locally
+
+### stdio mode (for use with MCP clients that manage the process)
+
+```sh
+node dist/server.js
+# or
+make run
+```
+
+### HTTP mode (for container and remote use)
+
+```sh
+MCP_HTTP_PORT=8080 node dist/server.js
+# or
+make run-http
+```
+
+The server listens at `POST /mcp` on the configured port.
+
+## Contract tests
+
+Start the BFF (e.g., `make -C stacks/go/net-http/rest run-bff`), then:
+
+```sh
+# From this directory:
+make check-contract
+
+# Or manually from repo root:
+MCP_HTTP_PORT=8580 IDP_BFF_URL=http://localhost:8000 node tools/mcp/dist/server.js &
+IDP_MCP_URL=http://localhost:8580 IDP_STACK_PATH=tools/mcp npm run test:contract
+```
+
+## Container
+
+```sh
+# Build (from tools/mcp/):
+make build-container
+
+# Run (connect to a BFF on the host):
+docker run --rm -p 8080:8080 \
+  -e IDP_BFF_URL=http://host.docker.internal:8000 \
+  localhost/stemix-mcp-server:latest
+```
+
+## Tools exposed
+
+| Tool | Description |
+|------|-------------|
+| `get_portal_summary` | Returns portal status, service health metrics, active plugins, and queued intents |
+| `check_health` | Returns BFF `/health` and `/readiness` responses |
+
+## Platform notes
+
+- The server writes structured JSON logs to `stderr` only.
+- In stdio mode, `stdout` is reserved for the MCP protocol; do not write anything else to it.
+- Default local binding is `0.0.0.0` in HTTP mode (container-friendly). For local-only use, set
+  `MCP_HTTP_HOST=127.0.0.1` if needed.

--- a/tools/mcp/moon.yml
+++ b/tools/mcp/moon.yml
@@ -1,0 +1,47 @@
+language: "typescript"
+layer: "tool"
+stack: "backend"
+
+project:
+  title: "mcp-tools"
+  description: "MCP adapter server for the Stemix Intent-Driven Portal BFF."
+
+tasks:
+  all:
+    command: ["make", "all"]
+  install:
+    command: ["make", "install"]
+  build:
+    command: ["make", "build"]
+  clean:
+    command: ["make", "clean"]
+  check-lint:
+    command: ["make", "check-lint"]
+  check-test:
+    command: ["make", "check-test"]
+  check-contract:
+    command: ["make", "check-contract"]
+  check-ci:
+    command: ["make", "check-ci"]
+    options:
+      runInCI: true
+  check:
+    command: ["make", "check"]
+  test:
+    command: ["make", "test"]
+  test-contract:
+    command: ["make", "test-contract"]
+  run:
+    command: ["make", "run"]
+    options:
+      persistent: true
+      runInCI: false
+  run-http:
+    command: ["make", "run-http"]
+    options:
+      persistent: true
+      runInCI: false
+  build-container:
+    command: ["make", "build-container"]
+    options:
+      runInCI: false

--- a/tools/mcp/package.json
+++ b/tools/mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "stemix-idp-mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "MCP adapter for the Stemix Intent-Driven Portal BFF.",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/server.js",
+    "start:http": "MCP_HTTP_PORT=8080 node dist/server.js",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.11.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "typescript": "^5.4.5"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tools/mcp/src/server.ts
+++ b/tools/mcp/src/server.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { registerCheckHealth } from "./tools/check-health.js";
+import { registerGetPortalSummary } from "./tools/get-portal-summary.js";
+
+const SERVER_NAME = "stemix-idp";
+const SERVER_VERSION = "0.1.0";
+
+function buildMcpServer(): McpServer {
+  const server = new McpServer({
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
+  });
+
+  registerGetPortalSummary(server);
+  registerCheckHealth(server);
+
+  return server;
+}
+
+async function startHttpMode(port: number): Promise<void> {
+  const httpServer = createServer(async (req, res) => {
+    if (req.url !== "/mcp") {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found. Use POST /mcp for MCP requests." }));
+      return;
+    }
+
+    // Each request gets its own stateless server + transport pair (no session state).
+    const server = buildMcpServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        process.stderr.write(
+          JSON.stringify({ level: "info", msg: "MCP session initialized", sessionId }) + "\n"
+        );
+      },
+    });
+
+    transport.onclose = () => {
+      void server.close();
+    };
+
+    await server.connect(transport);
+
+    try {
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        JSON.stringify({ level: "error", msg: "MCP request failed", error: message }) + "\n"
+      );
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Internal server error" }));
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.on("error", reject);
+    httpServer.listen(port, "0.0.0.0", () => {
+      process.stderr.write(
+        JSON.stringify({ level: "info", msg: "MCP HTTP server listening", port }) + "\n"
+      );
+      resolve();
+    });
+  });
+
+  process.once("SIGINT", () => {
+    httpServer.close(() => process.exit(0));
+  });
+
+  process.once("SIGTERM", () => {
+    httpServer.close(() => process.exit(0));
+  });
+}
+
+async function startStdioMode(): Promise<void> {
+  const server = buildMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  process.stderr.write(
+    JSON.stringify({ level: "info", msg: "MCP stdio server started", name: SERVER_NAME, version: SERVER_VERSION }) + "\n"
+  );
+}
+
+const rawPort = process.env.MCP_HTTP_PORT;
+const httpPort = rawPort !== undefined ? parseInt(rawPort, 10) : null;
+
+if (httpPort !== null && !Number.isNaN(httpPort)) {
+  startHttpMode(httpPort).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      JSON.stringify({ level: "error", msg: "MCP HTTP server startup failed", error: message }) + "\n"
+    );
+    process.exit(1);
+  });
+} else {
+  startStdioMode().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      JSON.stringify({ level: "error", msg: "MCP stdio server startup failed", error: message }) + "\n"
+    );
+    process.exit(1);
+  });
+}

--- a/tools/mcp/src/tools/check-health.ts
+++ b/tools/mcp/src/tools/check-health.ts
@@ -1,0 +1,50 @@
+import http from "node:http";
+import https from "node:https";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function resolveBffUrl(): URL {
+  const raw = process.env.IDP_BFF_URL ?? "http://localhost:8000";
+  return new URL(raw);
+}
+
+function fetchText(url: URL): Promise<string> {
+  const client = url.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const req = client.request(url, { method: "GET" }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+      });
+      res.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+export function registerCheckHealth(server: McpServer): void {
+  server.tool(
+    "check_health",
+    "Check the health and readiness status of the IDP BFF service. Returns both the IETF health check response and the readiness check response.",
+    {},
+    async () => {
+      const bffUrl = resolveBffUrl();
+
+      const [healthBody, readinessBody] = await Promise.all([
+        fetchText(new URL("/health", bffUrl)),
+        fetchText(new URL("/readiness", bffUrl)),
+      ]);
+
+      const result = {
+        health: JSON.parse(healthBody) as unknown,
+        readiness: JSON.parse(readinessBody) as unknown,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    }
+  );
+}

--- a/tools/mcp/src/tools/get-portal-summary.ts
+++ b/tools/mcp/src/tools/get-portal-summary.ts
@@ -1,0 +1,40 @@
+import http from "node:http";
+import https from "node:https";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+function resolveBffUrl(): URL {
+  const raw = process.env.IDP_BFF_URL ?? "http://localhost:8000";
+  return new URL(raw);
+}
+
+function fetchText(url: URL): Promise<string> {
+  const client = url.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const req = client.request(url, { method: "GET" }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+      });
+      res.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+export function registerGetPortalSummary(server: McpServer): void {
+  server.tool(
+    "get_portal_summary",
+    "Get the current status of the IDP portal, including service health metrics, active plugins, and queued intents.",
+    {},
+    async () => {
+      const bffUrl = resolveBffUrl();
+      const body = await fetchText(new URL("/api/portal/summary", bffUrl));
+      return {
+        content: [{ type: "text" as const, text: body }],
+      };
+    }
+  );
+}

--- a/tools/mcp/stack.json
+++ b/tools/mcp/stack.json
@@ -1,0 +1,13 @@
+{
+  "language": "typescript",
+  "framework": "mcp-sdk",
+  "interface": "mcp",
+  "contractProfiles": [
+    "mcp-profile"
+  ],
+  "capabilities": {
+    "mcp": {
+      "enabled": true
+    }
+  }
+}

--- a/tools/mcp/tsconfig.json
+++ b/tools/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds a standalone MCP (Model Context Protocol) server in tools/mcp/ that
wraps the IDP BFF, exposing two tools:
- get_portal_summary: proxies GET /api/portal/summary
- check_health: proxies GET /health and GET /readiness

The server supports both stdio transport (default, for MCP clients that
manage the process) and Streamable HTTP transport (when MCP_HTTP_PORT is
set, for container and remote use). It connects to the BFF via IDP_BFF_URL.

Extends the contract test harness with a new mcp-profile:
- Layer 1: tests/features/mcp-profile.feature (4 Gherkin scenarios)
- Layer 2: tests/src/profiles/mcp-profile.ts (JSON-RPC contract tests)
- tests/src/http.ts: adds post() helper for JSON-RPC calls
- tests/src/types.ts: adds "mcp-profile" to ProfileName and mcp capability
- tests/src/runtime.ts: adds IDP_MCP_URL / mcpBaseUrl support
- tests/src/index.ts: passes mcpBaseUrl through ContractContext

Registers mcp-tools as a moon project and documents the profile in
docs/content/testing/profiles/mcp-profile.md per the harness sync rule.

https://claude.ai/code/session_01FTW7Ntp74EzrkSqSvzsxgB