### PR TITLE
docs(maintainers): add social engagement guidance and links

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -23,6 +23,17 @@ Maintainers responsible for code review, merging, and release management.
 - Monitor CI/CD pipelines and container image publishing.
 - Ensure documentation stays current with code changes.
 
+## Community and Social Guidance
+
+Maintain public communication with the same quality bar used for code and docs.
+
+- Use [`SOCIAL.md`](../SOCIAL.md) as the shared guide for channel roles,
+  content flow, and engagement rules.
+- Keep GitHub as the canonical destination for meaningful discussions,
+  decisions, and RFCs.
+- Prefer linking to existing discussions or docs over duplicating content across
+  platforms.
+
 ## Release Process
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ tools/      Developer tooling, scripts, and MCP server definitions
 - [docs/content/architecture/decisions/](docs/content/architecture/decisions/) -- Architecture Decision Records (ADR index)
 - [docs/content/architecture/diagrams/](docs/content/architecture/diagrams/) -- C4 architecture diagrams (context, container, and component views)
 - [docs/content/containers/](docs/content/containers/) -- Container images: building, running, and publishing
+- [SOCIAL.md](SOCIAL.md) -- Social media guidance and content flow
 
 ## Getting Started
 

--- a/SOCIAL.md
+++ b/SOCIAL.md
@@ -1,0 +1,264 @@
+# IDP Social Media and Community Engagement Guide
+
+## Purpose
+
+This guide explains how IDP communicates in public so community interaction stays clear,
+focused, and reusable.
+
+The goal is not to be everywhere. The goal is to:
+
+- Create clarity
+- Focus attention
+- Turn conversations into reusable knowledge
+
+Every piece of content should answer this question:
+
+> What should someone do differently because of this?
+
+## Core Principles
+
+### One source of truth
+
+GitHub is where durable conversations happen:
+
+- Decisions
+- Questions
+- Feedback
+- RFCs
+- Roadmap discussions
+
+All meaningful engagement should point back to GitHub.
+
+### Content flows and is not duplicated
+
+We do not create separate long-form content for each platform.
+
+We:
+
+- Start ideas in one place
+- Refine them
+- Distribute them
+- Curate them
+
+### Signal over noise
+
+Not everything needs to be posted everywhere.
+
+We prioritize:
+
+- What matters now
+- What helps others act
+- What can be reused later
+
+### Direction over presence
+
+We are not trying to respond everywhere.
+
+We are guiding people toward:
+
+- Better understanding
+- Better decisions
+- The right place to engage
+
+## Platform Roles
+
+### GitHub (source of truth)
+
+- Purpose: thinking, discussion, decisions, contribution
+- Used for: Q&A, RFCs, roadmap discussions, canonical announcements, issues, execution
+
+### Blog ([stemix.dev/blog](https://stemix.dev/blog))
+
+- Purpose: refined thinking, evergreen resources
+- Used for: deep explanations, mental models, architecture patterns, lessons learned
+
+### Newsletter (Ghost)
+
+- Purpose: curation, direction
+- Used for: periodic summaries, important updates, external signal with commentary
+
+### LinkedIn
+
+- Purpose: reach, professional context
+- Used for: blog summaries, opinionated insights, key announcements
+
+### Bluesky
+
+- Purpose: exploration, conversation
+- Used for: early ideas, questions, observations
+
+### X (Twitter)
+
+- Purpose: signals, lightweight updates
+- Used for: quick announcements, links, short updates
+
+## Content Flow
+
+Default flow:
+
+1. Idea or question -> GitHub Discussion
+2. Refined thinking -> Blog
+3. Distribution -> LinkedIn
+4. Aggregation -> Newsletter
+5. Lightweight signals -> X
+6. Optional exploration -> Bluesky
+
+## Content Types and Destinations
+
+### Major releases
+
+- Examples: v1 launch, significant feature milestones
+- GitHub: full announcement (canonical)
+- Blog: deep explanation of why it matters
+- LinkedIn: summary and positioning
+- Newsletter: highlight
+- X: announcement and link
+
+### Minor releases
+
+- Examples: small features, improvements, fixes
+- GitHub: release notes
+- LinkedIn: optional summary if meaningful
+- Newsletter: include in periodic summary
+- X: short update
+
+### Roadmap updates
+
+- Examples: direction shifts, new priorities
+- GitHub: roadmap discussion
+- Blog: optional when strategic context is needed
+- LinkedIn: high-level summary
+- Newsletter: highlight
+
+### Open thoughts and early questions
+
+- Examples: new concepts, early thinking
+- GitHub: preferred location for discussion
+- Bluesky: optional early signal
+- LinkedIn: only when the insight is clear and actionable
+
+### Professional inquiries and feedback
+
+- Examples: "How are teams solving this?", "What would you do?"
+- GitHub: preferred discussion venue
+- LinkedIn: broader audience input
+
+### Technical inquiries and RFCs
+
+- Examples: architecture decisions, API design, system behavior
+- GitHub: required location for RFC or Discussion
+- Other platforms: point back to GitHub
+
+### News and announcements
+
+- Examples: partnerships, direction changes, major updates
+- GitHub: canonical announcement
+- LinkedIn: summary
+- Newsletter: highlight
+- X: short signal
+
+### Requests for help
+
+- Examples: contribution requests, open problems
+- GitHub: issue or discussion
+- LinkedIn: broader reach
+- X: signal boost
+
+### Calls to action
+
+- Examples: try the project, give feedback, join a discussion
+- Primary destination: GitHub
+- All platforms: point to one clear action
+
+### Fun and engagement
+
+- Examples: milestones, small wins, behind-the-scenes updates
+- LinkedIn: human connection
+- Bluesky: casual interaction
+- X: lightweight signal
+
+Do not overuse this content category.
+
+## Decision Tree
+
+When creating content, ask:
+
+1. Is this still forming -> GitHub or Bluesky
+2. Is this structured and reusable -> Blog
+3. Does this need reach -> LinkedIn
+4. Is this a quick signal -> X
+5. Is this a summary of multiple updates -> Newsletter
+
+## Engagement Rules
+
+### Route important conversations
+
+If a conversation matters, move it to GitHub.
+
+Example response:
+
+"This is a great question. Let's continue here so others can benefit."
+
+### Avoid duplication
+
+Do not rewrite the same content for every platform.
+
+Adapt instead:
+
+- Summarize
+- Expand
+- Link
+
+### Convert conversations into assets
+
+Every meaningful interaction should become one of the following:
+
+- A GitHub Discussion
+- A blog post
+- Documentation
+- Roadmap input
+
+### Limit active surfaces
+
+Primary focus:
+
+- GitHub
+- LinkedIn
+
+Everything else is optional or lightweight.
+
+## Weekly Rhythm
+
+Recommended baseline cadence:
+
+- GitHub: continuous engagement
+- LinkedIn: 2-4 posts
+- Blog: 0-1 posts
+- Newsletter: one issue, weekly or biweekly
+- Bluesky: 1-3 optional posts
+- X: lightweight updates
+
+## What Success Looks Like
+
+Not success:
+
+- More posts
+- More replies
+- More platforms
+
+Success:
+
+- Fewer repeated questions
+- More community contributions
+- Clear direction
+- Reusable knowledge
+
+## Final Reminder
+
+This system exists to:
+
+- Reduce noise
+- Increase clarity
+- Scale contribution
+
+If a post does not help someone make a better decision faster, do not post it.


### PR DESCRIPTION
## Summary
- Add a lint-clean social engagement guide in SOCIAL.md.
- Add maintainer-facing guidance that links to SOCIAL.md and reinforces GitHub as canonical.
- Add README discoverability link for the social guidance document.

## Validation
- moon run repo:check-lint-md