### PR TITLE
feat: add api-first status MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,18 @@
 
 This file is the operating manual for coding agents working in this repo. Follow it first, then the codebase conventions.
 
+## Roadmap Alignment
+
+- Treat [ROADMAP.md](ROADMAP.md) as the target-state capability map, not as
+  proof that a capability already exists in the repo.
+- When work is described as "roadmap-driven", prefer the smallest end-to-end
+  slice that produces a real contract, runnable behavior, docs, and
+  verification in the current repository.
+- When updating docs or user-facing copy, explicitly separate implemented
+  behavior from planned capability direction so readers are not misled.
+- Defer plug-in, external-system, or governance expansion until the repo has a
+  concrete contract and runnable slice for that area.
+
 ## Important Long-Lived Decisions (ADR Guardrails)
 
 To avoid documentation bloat and context explosion, only record decisions in

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ Stemix is an Intelligent Development System (IDS) with an Intent-Driven Portal (
 
 **Documentation site**: [stemix.dev](https://stemix.dev)
 
+## Roadmap and Current Capability Status
+
+[ROADMAP.md](ROADMAP.md) is the target-state capability map for the platform.
+It describes where Stemix IDP is headed, not a guarantee that every capability
+already exists in the current repository.
+
+Today, the repo primarily provides:
+
+- contract-first health, readiness, UI, and MCP validation
+- reference Go and Node.js stacks
+- an API-first IDP status MVP for IDP-owned components
+- an external status publisher that emits static JSON and HTML from the same
+  live status contract
+
+Planned capabilities such as plug-in-based external system status, identity,
+policy, analytics, and broader governance remain roadmap items until they are
+implemented and documented as current behavior.
+
 ## What is IDP?
 
 The Intent-Driven Portal is an evolution of the Internal Developer Portal concept. It shares the IDP acronym intentionally, but goes beyond traditional developer portals by deeply integrating AI and web technologies to improve the entire development experience.
@@ -54,7 +72,7 @@ deploy/     Container definitions, Kubernetes manifests, Helm charts (planned)
 plugins/    Plug-in SDK and example plug-ins (planned)
 docs/       Docusaurus documentation site (docs/content/ is the source of truth)
 tests/      Contract test harness (TypeScript) and Layer 1 Gherkin intent specs
-tools/      Developer tooling, scripts, and MCP server definitions
+tools/      Developer tooling, MCP adapters, and the static status publisher
 ```
 
 **Key documentation:**
@@ -62,6 +80,8 @@ tools/      Developer tooling, scripts, and MCP server definitions
 - [docs/content/testing/contract-harness.md](docs/content/testing/contract-harness.md) --
   Contract test harness guide (newcomers, implementers, and contributors)
 - [docs/content/security.md](docs/content/security.md) -- Security and privacy scanning guide
+- [ROADMAP.md](ROADMAP.md) -- Target-state capability roadmap and sequencing input
+- [tools/status/README.md](tools/status/README.md) -- Static JSON and HTML status publisher for external hosting
 - [docs/content/architecture/decisions/](docs/content/architecture/decisions/) -- Architecture Decision Records (ADR index)
 - [docs/content/architecture/diagrams/](docs/content/architecture/diagrams/) -- C4 architecture diagrams (context, container, and component views)
 - [docs/content/containers/](docs/content/containers/) -- Container images: building, running, and publishing
@@ -285,6 +305,12 @@ Run contract tests against a running stack:
 
 ```bash
 make test
+```
+
+Publish static status artifacts from the live BFF status API:
+
+```bash
+tsx tools/status/publish-status.ts
 ```
 
 See [docs/content/testing/contract-harness.md](docs/content/testing/contract-harness.md) for a

--- a/docs/content/containers/mcp-server.md
+++ b/docs/content/containers/mcp-server.md
@@ -39,7 +39,7 @@ docker run --rm -p 8080:8080 \
 
 | Tool | Description |
 | --- | --- |
-| `get_portal_summary` | Returns portal status, service health metrics, active plugins, and queued intents |
+| `get_portal_summary` | Returns the shared IDP status summary contract for IDP-owned components |
 | `check_health` | Returns BFF `/health` and `/readiness` responses |
 
 ## Dockerfile

--- a/docs/content/testing/contract-harness.md
+++ b/docs/content/testing/contract-harness.md
@@ -79,18 +79,21 @@ tests/
 ├── features/          Layer 1 intent specifications (Gherkin .feature files)
 │   ├── core.feature
 │   ├── operational.feature
+│   ├── status-profile.feature
 │   └── ui-profile.feature
 └── src/
     ├── index.ts       Entry point and test runner
     ├── types.ts       Shared types (ProfileName, TestCase, StackMetadata, …)
     ├── http.ts        Zero-dependency Node.js HTTP client
     ├── assertions.ts  assert() and parseJsonOrThrow() helpers
+    ├── browser.ts     Headless Chromium helper for rendered UI checks
     ├── runtime.ts     URL resolution, stack.json loading, profile selection
     └── profiles/
         ├── index.ts          Routes a profile name to its test factory
         ├── core.ts           5 baseline tests
         ├── operational.ts    5 runtime/semantic tests
-        └── ui-profile.ts     3 UI capability tests
+        ├── status-profile.ts 3 API-first status tests
+        └── ui-profile.ts     5 UI capability tests
 ```
 
 **Key design choices:**
@@ -101,7 +104,8 @@ tests/
   parse in CI pipelines.
 - The harness never imports implementation code. Compliance is validated
   entirely through HTTP.
-- Node.js 18+ is the only runtime requirement (uses the built-in `http` module).
+- Node.js 18+ is required for the harness runtime. Rendered `ui-profile` checks
+  additionally require a local Chromium-family browser such as Chrome or Edge.
 
 ---
 
@@ -142,7 +146,7 @@ just the correct shape. All health-related assertions conform to
 | `operational:bff health checks sub-components use IETF format` | `checks` is an object; each key uses `componentName:measurementName` format; each entry has `status`, `componentType`, and `time` (ISO-8601) |
 | `operational:bff readiness contract semantics are stable` | `status` is `"pass"` or `"fail"`; `checks` is a non-empty object |
 
-### `ui-profile` — UI capability checks (3 tests)
+### `ui-profile` — UI capability checks (5 tests)
 
 Optional. Only runs when the stack declares `capabilities.ui.enabled: true` in
 `stack.json`. Validates externally observable UI behavior without asserting
@@ -152,7 +156,22 @@ framework internals (no React/Vue/Next-specific checks).
 | --- | --- |
 | `ui-profile:web root returns HTML document shell` | `GET /` returns `text/html` with `<html` in the body |
 | `ui-profile:web document shell includes a title` | `GET /` body contains a `<title` tag |
+| `ui-profile:web root renders live portal summary content` | rendered `GET /` includes the status summary cards and a live component label |
+| `ui-profile:status route renders detailed portal summary content` | rendered `GET /status` includes the detailed status view and publication guidance |
 | `ui-profile:web mode declaration is valid (<mode>)` | Declared `ui.mode` is one of `spa`, `ssr`, or `server-rendered` |
+
+### `status-profile` — API-first IDP status checks (3 tests)
+
+Optional. Only runs when the stack declares `capabilities.status.enabled: true`
+in `stack.json`. It validates the shared `GET /api/portal/summary` contract
+that feeds the portal home page, dedicated status route, MCP
+`get_portal_summary` tool, and static status publisher.
+
+| Test | What is checked |
+| --- | --- |
+| `status-profile:bff portal summary returns expected shape` | `GET /api/portal/summary` returns JSON with status, metrics, freshness, and component entries |
+| `status-profile:portal summary metrics are internally consistent` | aggregate counts and top-level status match the component list |
+| `status-profile:portal summary timestamps and freshness are valid` | timestamps are ISO-8601 and freshness metadata matches component observation ages |
 
 ---
 
@@ -174,6 +193,9 @@ harness generates zero tests for it unless `stack.json` declares
 `capabilities.ui.enabled: true`. This means the profile is safe to include in
 `contractProfiles` for a UI stack without breaking non-UI stacks.
 
+The `status-profile` profile behaves the same way: it generates zero tests
+unless `stack.json` declares `capabilities.status.enabled: true`.
+
 ---
 
 ## The `stack.json` capability declaration
@@ -190,6 +212,9 @@ Minimum required fields:
   "interface": "rest",
   "contractProfiles": ["core", "operational"],
   "capabilities": {
+    "status": {
+      "enabled": false
+    },
     "ui": {
       "enabled": false
     }
@@ -204,8 +229,11 @@ For a UI-capable stack:
   "language": "nodejs",
   "framework": "react-fastify",
   "interface": "rest",
-  "contractProfiles": ["core", "operational", "ui-profile"],
+  "contractProfiles": ["core", "operational", "status-profile", "ui-profile"],
   "capabilities": {
+    "status": {
+      "enabled": true
+    },
     "ui": {
       "enabled": true,
       "mode": "spa"
@@ -222,6 +250,7 @@ For a UI-capable stack:
 | `framework` | string | Server framework (e.g. `net-http`, `fastify`, `axum`) |
 | `interface` | string | Interface type (currently always `rest`) |
 | `contractProfiles` | `ProfileName[]` | Profiles this stack must pass |
+| `capabilities.status.enabled` | boolean | Whether this stack exposes the shared IDP status API |
 | `capabilities.ui.enabled` | boolean | Whether this stack serves a UI |
 | `capabilities.ui.mode` | `"spa" \| "ssr" \| "server-rendered"` | UI rendering mode when enabled |
 
@@ -238,6 +267,7 @@ For a UI-capable stack:
 | `IDP_STACK_PATH` | _(unset)_ | Relative path to the stack directory; loads `stack.json` |
 | `IDP_CONTRACT_PROFILES` | _(unset)_ | Comma-separated list of profiles to run |
 | `IDP_CONTRACT_PROFILE` | _(unset)_ | Single profile override |
+| `IDP_UI_BROWSER_PATH` | _(auto-detect)_ | Chrome or Edge executable path for rendered `ui-profile` checks |
 
 ### Controlling where a stack binds
 
@@ -280,7 +310,7 @@ IDP_WEB_URL="http://localhost:3001" \
 
 ```bash
 IDP_STACK_PATH="stacks/nodejs/react-fastify/rest" \
-  IDP_CONTRACT_PROFILES="core,operational,ui-profile" \
+  IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile" \
   npm run test:contract
 ```
 
@@ -344,7 +374,7 @@ declared profiles on every change.
 
 - **Language / framework**: Go 1.25, standard library `net/http` only
 - **Moon project ID**: `go-net-http-rest`
-- **Profiles**: `core`, `operational`
+- **Profiles**: `core`, `operational`, `status-profile`
 - **Components**: two compiled binaries in `.bin/`
   - `idp-go-web` — serves `GET /`, `GET /health`, binds `127.0.0.1:3000`
   - `idp-go-bff` — serves `GET /`, `GET /health`, `GET /readiness`,
@@ -366,7 +396,8 @@ make -C stacks/go/net-http/rest run-bff
 - **Language / framework**: TypeScript, Node.js 24, Fastify 5 (BFF), Vite +
   React 19 (web SPA)
 - **Moon project ID**: `nodejs-react-fastify-rest`
-- **Profiles**: `core`, `operational`, `ui-profile` (`ui.mode: spa`)
+- **Profiles**: `core`, `operational`, `status-profile`, `ui-profile`
+  (`ui.mode: spa`)
 - **Components**:
   - `web/server.ts` — Vite dev server serving the React SPA, binds
     `127.0.0.1:3000`

--- a/docs/content/testing/index.md
+++ b/docs/content/testing/index.md
@@ -30,9 +30,10 @@ area of expected behavior. A stack declares which profiles it must pass in its
 
 | Profile | Required by | Tests | Description |
 | --- | --- | --- | --- |
-| [`core`](./profiles/core) | All stacks | 4 | Baseline HTTP surface: reachability, content-type, and field presence |
-| [`operational`](./profiles/operational) | Tier 1 stacks | 3 | Runtime conventions and exact semantic values |
-| [`ui-profile`](./profiles/ui-profile) | UI stacks (opt-in) | 3 | Observable HTML output and declared rendering mode |
+| [`core`](./profiles/core) | All stacks | 5 | Baseline HTTP surface: reachability, content-type, and field presence |
+| [`operational`](./profiles/operational) | Tier 1 stacks | 5 | Runtime conventions and exact semantic values |
+| [`status-profile`](./profiles/status-profile) | Status-capable stacks (opt-in) | 3 | API-first IDP status checks for the shared portal summary contract |
+| [`ui-profile`](./profiles/ui-profile) | UI stacks (opt-in) | 5 | Observable HTML output plus rendered status UI behavior |
 | [`mcp-profile`](./profiles/mcp-profile) | MCP servers (opt-in) | 4 | MCP initialize, tool discovery, and tool invocation |
 
 ## Guides
@@ -42,4 +43,5 @@ area of expected behavior. A stack declares which profiles it must pass in its
 | [Contract Test Harness](./contract-harness) | Implementers, contributors | How the harness works, how to run it, and how to build a new compliant implementation |
 | [Core Profile](./profiles/core) | Implementers | Baseline scenarios every stack must pass |
 | [Operational Profile](./profiles/operational) | Implementers | Semantic correctness scenarios for Tier 1 stacks |
+| [Status Profile](./profiles/status-profile) | Implementers, operators | API-first status contract for IDP-owned components |
 | [UI Profile](./profiles/ui-profile) | Implementers | Opt-in UI behavior scenarios |

--- a/docs/content/testing/profiles/mcp-profile.md
+++ b/docs/content/testing/profiles/mcp-profile.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # MCP Profile
@@ -60,7 +60,7 @@ Source: [`tests/features/mcp-profile.feature`](https://github.com/ourchitecture/
 
 - `tools/call get_portal_summary` returns HTTP 2xx
 - `result.content[0].type` is `"text"`
-- `result.content[0].text` is valid JSON containing a `status` field
+- `result.content[0].text` is valid JSON matching the shared portal summary status contract
 
 ### tools/call check_health returns BFF health and readiness
 
@@ -79,7 +79,8 @@ Source: [`tests/src/profiles/mcp-profile.ts`](https://github.com/ourchitecture/i
 
 The harness sends raw JSON-RPC 2.0 POST requests to `IDP_MCP_URL/mcp` using the existing
 zero-dependency HTTP client. It handles both `application/json` and `text/event-stream` (SSE)
-response formats to remain transport-agnostic.
+response formats, sends the required `notifications/initialized` follow-up request, and reuses
+any `Mcp-Session-Id` header returned by the server during initialization.
 
 ## Stack declarations
 

--- a/docs/content/testing/profiles/status-profile.md
+++ b/docs/content/testing/profiles/status-profile.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 4
+---
+
+# Status Profile
+
+The `status-profile` proves that a stack exposes the shared API-first IDP
+status contract. It exists so the home page summary, dedicated status view, MCP
+adapter, and static status publisher can all depend on one validated source of
+truth instead of inventing separate status payloads.
+
+## Why it exists
+
+The status MVP is intentionally narrow: it reports the status of IDP-owned
+components only. Plug-in and third-party system status are postponed until the
+repo has a concrete plug-in architecture and adapter contract. This profile
+keeps the first slice honest and testable.
+
+## Layer 1 spec
+
+Source: [`tests/features/status-profile.feature`](https://github.com/ourchitecture/idp/blob/main/tests/features/status-profile.feature)
+
+## Scenarios (3 total)
+
+### BFF portal summary returns the expected shape
+
+**Precondition:** The BFF server is running and the stack declares
+`capabilities.status.enabled = true`.
+
+**Assertions:**
+
+- `GET /api/portal/summary` returns an HTTP status code in the 2xx range
+- `Content-Type` contains `application/json`
+- Response body contains `generatedAt`, `status`, `metrics`, `freshness`, and
+  a non-empty `components` array
+- Each component entry contains `id`, `label`, `kind`, `status`, `latencyMs`,
+  and `observedAt`
+
+### Portal summary metrics are internally consistent
+
+**Precondition:** The BFF server is running and the stack declares
+`capabilities.status.enabled = true`.
+
+**Assertions:**
+
+- `metrics.totalComponents` equals the number of components
+- `metrics.healthyComponents` equals the number of healthy components
+- `metrics.degradedComponents` equals the number of degraded components
+- Top-level `status` matches the aggregate component state
+
+### Portal summary timestamps and freshness are valid
+
+**Precondition:** The BFF server is running and the stack declares
+`capabilities.status.enabled = true`.
+
+**Assertions:**
+
+- `generatedAt` is within 60 seconds of the current time
+- Each component contains an ISO-8601 `observedAt`
+- `freshness.maxAgeSeconds` matches the oldest component observation age
+
+## Layer 2 harness
+
+Source: [`tests/src/profiles/status-profile.ts`](https://github.com/ourchitecture/idp/blob/main/tests/src/profiles/status-profile.ts)
+
+The TypeScript harness is derived from the `.feature` file above. When they
+disagree, the `.feature` file is authoritative.
+
+## Stack declarations
+
+Stacks that expose the shared status API must declare both the profile and the
+capability flag in `stack.json`:
+
+```jsonc
+{
+  "contractProfiles": ["core", "operational", "status-profile"],
+  "capabilities": {
+    "status": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Related
+
+- [Contract Test Harness](../contract-harness) — Full harness guide
+- [MCP Profile](./mcp-profile) — MCP tool checks that now validate the same summary contract
+- [ADR-0005](../../architecture/decisions/shared-capability-contract-and-conformance-profiles) — Capability contract and conformance profiles
+- [ADR-0009](../../architecture/decisions/intent-specification-format) — Gherkin as Layer 1 format

--- a/docs/content/testing/profiles/ui-profile.md
+++ b/docs/content/testing/profiles/ui-profile.md
@@ -6,22 +6,23 @@ sidebar_position: 3
 
 The `ui-profile` profile validates externally observable UI behavior. It is
 **opt-in**: the harness generates zero tests for this profile unless the stack
-declares `capabilities.ui.enabled: true` in its `stack.json`. No
-framework-specific internals (React components, Vite bundles, SSR output) are
-inspected.
+declares `capabilities.ui.enabled: true` in its `stack.json`. It checks both
+the document shell and the rendered UI without inspecting framework-specific
+internals.
 
 ## Why it exists
 
 Not all stacks serve a user interface — the Go BFF-only stack does not, and
 future API-only stacks will not. The UI profile ensures that stacks which do
-serve a UI produce a well-formed HTML document shell without prescribing any
-particular rendering strategy.
+serve a UI produce a well-formed HTML document shell and, for the status MVP,
+actually render live portal summary content on the home page and dedicated
+status route without prescribing any particular rendering strategy.
 
 ## Layer 1 spec
 
 Source: [`tests/features/ui-profile.feature`](https://github.com/ourchitecture/idp/blob/main/tests/features/ui-profile.feature)
 
-## Scenarios (3 total)
+## Scenarios (5 total)
 
 All three scenarios have an additional precondition beyond server availability:
 the stack must declare `capabilities.ui.enabled = true` in `stack.json`. If
@@ -46,6 +47,31 @@ that condition is not met, no tests run and the profile is silently skipped.
 - `GET /` returns an HTTP status code in the 2xx range
 - Response body contains the string `<title` (case-insensitive)
 
+### Web root renders live portal summary content
+
+**Preconditions:** The web server is running; the BFF is running;
+`capabilities.ui.enabled = true`.
+
+**Assertions:**
+
+- Rendering `GET /` in a headless Chromium browser includes the text
+  `System Status`
+- The rendered page includes the text `Observed Components`
+- The rendered page includes the text `IDP BFF`
+
+### Status route renders detailed portal summary content
+
+**Preconditions:** The web server is running; the BFF is running;
+`capabilities.ui.enabled = true`.
+
+**Assertions:**
+
+- Rendering `GET /status` in a headless Chromium browser includes the text
+  `Detailed IDP status`
+- The rendered page includes the text `Observed Components`
+- The rendered page includes the text `Publication Path`
+- The rendered page includes the text `IDP BFF`
+
 ### UI mode declaration is one of the accepted values
 
 **Precondition:** The stack's `stack.json` declares `capabilities.ui.mode`.
@@ -62,14 +88,21 @@ Source: [`tests/src/profiles/ui-profile.ts`](https://github.com/ourchitecture/id
 The TypeScript harness is derived from the `.feature` file above. When they
 disagree, the `.feature` file is authoritative.
 
+The rendered-page checks use a local Chromium-family browser in headless mode.
+Set `IDP_UI_BROWSER_PATH` when auto-detection cannot find Chrome or Edge on the
+current machine. `PUPPETEER_EXECUTABLE_PATH` is also honored as a fallback.
+
 ## Stack declarations
 
 A UI-capable stack declares the profile and enables the UI capability:
 
 ```jsonc
 {
-  "contractProfiles": ["core", "operational", "ui-profile"],
+  "contractProfiles": ["core", "operational", "status-profile", "ui-profile"],
   "capabilities": {
+    "status": {
+      "enabled": true
+    },
     "ui": {
       "enabled": true,
       "mode": "spa"

--- a/stacks/go/net-http/rest/Makefile
+++ b/stacks/go/net-http/rest/Makefile
@@ -73,7 +73,7 @@ check: check-lint check-test check-contract
 
 check-contract: build
 	@OUR_IDP_WEB_HOST="$(WEB_TEST_HOST)" OUR_IDP_PORT="$(WEB_TEST_PORT)" env -- "$(WEB_BIN)" >/dev/null 2>&1 & WEB_PID=$$!; \
-	OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" env -- "$(BFF_BIN)" >/dev/null 2>&1 & BFF_PID=$$!; \
+	OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" OUR_IDP_STATUS_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" env -- "$(BFF_BIN)" >/dev/null 2>&1 & BFF_PID=$$!; \
 	trap 'kill $$WEB_PID $$BFF_PID >/dev/null 2>&1 || true' EXIT; \
 	sleep 2; \
 	IDP_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" IDP_BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" IDP_STACK_PATH="$(STACK_PATH)" npm --prefix "$(ROOT_DIR)" run test:contract; \

--- a/stacks/go/net-http/rest/README.md
+++ b/stacks/go/net-http/rest/README.md
@@ -23,8 +23,10 @@ web server and the BFF server.
 
 - `core`
 - `operational`
+- `status-profile`
 
-This stack does not declare UI capability and does not run `ui-profile` tests.
+This stack declares status capability, but it does not declare UI capability
+and does not run `ui-profile` tests.
 
 ## Platform Note
 
@@ -102,6 +104,8 @@ Containers default to `0.0.0.0` host binding (overriding the native-dev
 - `OUR_IDP_WEB_HOST` / `OUR_IDP_API_HOST` — bind address (default `0.0.0.0`)
 - `OUR_IDP_PORT` — web port (default `3300`)
 - `OUR_IDP_API_PORT` — BFF port (default `8300`)
+- `OUR_IDP_STATUS_WEB_URL` — optional web base URL used by the BFF status API
+  to include live IDP web health in `/api/portal/summary`
 
 ### Published Images
 

--- a/stacks/go/net-http/rest/bff/main.go
+++ b/stacks/go/net-http/rest/bff/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -44,6 +45,37 @@ type readinessResponse struct {
 	Checks map[string][]checkEntry `json:"checks"`
 }
 
+type statusMetrics struct {
+	TotalComponents    int `json:"totalComponents"`
+	HealthyComponents  int `json:"healthyComponents"`
+	DegradedComponents int `json:"degradedComponents"`
+}
+
+type statusFreshness struct {
+	MaxAgeSeconds int `json:"maxAgeSeconds"`
+}
+
+type statusComponent struct {
+	ID         string `json:"id"`
+	Label      string `json:"label"`
+	Kind       string `json:"kind"`
+	Status     string `json:"status"`
+	LatencyMs  int64  `json:"latencyMs"`
+	ObservedAt string `json:"observedAt"`
+}
+
+type statusSummaryResponse struct {
+	GeneratedAt string            `json:"generatedAt"`
+	Status      string            `json:"status"`
+	Metrics     statusMetrics     `json:"metrics"`
+	Freshness   statusFreshness   `json:"freshness"`
+	Components  []statusComponent `json:"components"`
+}
+
+type healthEnvelope struct {
+	Status string `json:"status"`
+}
+
 func parsePort(value string) (int, bool) {
 	if value == "" {
 		return 0, false
@@ -72,6 +104,10 @@ func resolveHost() string {
 	}
 
 	return host
+}
+
+func resolveStatusWebURL() string {
+	return strings.TrimSpace(os.Getenv("OUR_IDP_STATUS_WEB_URL"))
 }
 
 func writeHealthJSON(w http.ResponseWriter, status int, payload any) {
@@ -141,6 +177,109 @@ func handleReadiness(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
+func createBFFStatusComponent(now time.Time) statusComponent {
+	return statusComponent{
+		ID:         "idp-bff",
+		Label:      "IDP BFF",
+		Kind:       "service",
+		Status:     "healthy",
+		LatencyMs:  0,
+		ObservedAt: now.UTC().Format(time.RFC3339),
+	}
+}
+
+func observeWebStatusComponent(base string) statusComponent {
+	startedAt := time.Now()
+	component := statusComponent{
+		ID:     "idp-web",
+		Label:  "IDP Web",
+		Kind:   "service",
+		Status: "degraded",
+	}
+
+	target, err := url.JoinPath(base, "/health")
+	if err != nil {
+		component.LatencyMs = time.Since(startedAt).Milliseconds()
+		component.ObservedAt = time.Now().UTC().Format(time.RFC3339)
+		return component
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(target)
+	if err == nil {
+		defer resp.Body.Close()
+
+		var payload healthEnvelope
+		if decodeErr := json.NewDecoder(resp.Body).Decode(&payload); decodeErr == nil &&
+			resp.StatusCode >= 200 && resp.StatusCode < 300 &&
+			payload.Status == "pass" {
+			component.Status = "healthy"
+		}
+	}
+
+	component.LatencyMs = time.Since(startedAt).Milliseconds()
+	component.ObservedAt = time.Now().UTC().Format(time.RFC3339)
+
+	return component
+}
+
+func buildStatusSummary() statusSummaryResponse {
+	components := make([]statusComponent, 0, 2)
+
+	if webURL := resolveStatusWebURL(); webURL != "" {
+		components = append(components, observeWebStatusComponent(webURL))
+	}
+
+	components = append(components, createBFFStatusComponent(time.Now()))
+
+	healthyComponents := 0
+	degradedComponents := 0
+	generatedAt := time.Now().UTC()
+	maxAgeSeconds := 0
+
+	for _, component := range components {
+		if component.Status == "healthy" {
+			healthyComponents++
+		} else {
+			degradedComponents++
+		}
+
+		observedAt, err := time.Parse(time.RFC3339, component.ObservedAt)
+		if err == nil {
+			ageSeconds := int(generatedAt.Sub(observedAt).Seconds())
+			if ageSeconds < 0 {
+				ageSeconds = 0
+			}
+			if ageSeconds > maxAgeSeconds {
+				maxAgeSeconds = ageSeconds
+			}
+		}
+	}
+
+	status := "ok"
+	if degradedComponents > 0 {
+		status = "degraded"
+	}
+
+	return statusSummaryResponse{
+		GeneratedAt: generatedAt.Format(time.RFC3339),
+		Status:      status,
+		Metrics: statusMetrics{
+			TotalComponents:    len(components),
+			HealthyComponents:  healthyComponents,
+			DegradedComponents: degradedComponents,
+		},
+		Freshness: statusFreshness{
+			MaxAgeSeconds: maxAgeSeconds,
+		},
+		Components: components,
+	}
+}
+
+func handlePortalSummary(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, buildStatusSummary())
+}
+
 func main() {
 	host := resolveHost()
 	port := resolvePort()
@@ -150,6 +289,7 @@ func main() {
 	mux.HandleFunc("/", handleRoot)
 	mux.HandleFunc("/health", handleHealth)
 	mux.HandleFunc("/readiness", handleReadiness)
+	mux.HandleFunc("/api/portal/summary", handlePortalSummary)
 
 	payload, err := json.Marshal(startupLog{
 		Level: "info",

--- a/stacks/go/net-http/rest/stack.json
+++ b/stacks/go/net-http/rest/stack.json
@@ -4,9 +4,13 @@
   "interface": "rest",
   "contractProfiles": [
     "core",
-    "operational"
+    "operational",
+    "status-profile"
   ],
   "capabilities": {
+    "status": {
+      "enabled": true
+    },
     "ui": {
       "enabled": false
     }

--- a/stacks/nodejs/react-fastify/rest/Makefile
+++ b/stacks/nodejs/react-fastify/rest/Makefile
@@ -57,10 +57,10 @@ check: check-lint check-test check-contract
 
 check-contract:
 	@OUR_IDP_WEB_HOST="$(WEB_TEST_HOST)" OUR_IDP_PORT="$(WEB_TEST_PORT)" npm --prefix "$(ROOT_DIR)" run start:web:react-fastify >/dev/null 2>&1 & WEB_PID=$$!; \
-	OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" npm --prefix "$(ROOT_DIR)" run start:bff:react-fastify >/dev/null 2>&1 & BFF_PID=$$!; \
+	OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" OUR_IDP_STATUS_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" npm --prefix "$(ROOT_DIR)" run start:bff:react-fastify >/dev/null 2>&1 & BFF_PID=$$!; \
 	trap 'kill $$WEB_PID $$BFF_PID >/dev/null 2>&1 || true' EXIT; \
 	sleep 3; \
-	IDP_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" IDP_BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" IDP_STACK_PATH="$(STACK_PATH)" IDP_CONTRACT_PROFILES="core,operational,ui-profile" npm --prefix "$(ROOT_DIR)" run test:contract; \
+	IDP_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" IDP_BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" IDP_STACK_PATH="$(STACK_PATH)" IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile" npm --prefix "$(ROOT_DIR)" run test:contract; \
 	STATUS=$$?; \
 	kill $$WEB_PID $$BFF_PID >/dev/null 2>&1 || true; \
 	wait $$WEB_PID $$BFF_PID 2>/dev/null || true; \
@@ -71,10 +71,10 @@ test-contract: check-contract
 e2e:
 	@STACK_PATH="$(STACK_PATH)" \
 	WEB_START_CMD='OUR_IDP_WEB_HOST="$(WEB_TEST_HOST)" OUR_IDP_PORT="$(WEB_TEST_PORT)" npm --prefix "$(ROOT_DIR)" run start:web:react-fastify' \
-	BFF_START_CMD='OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" npm --prefix "$(ROOT_DIR)" run start:bff:react-fastify' \
+	BFF_START_CMD='OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" OUR_IDP_STATUS_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" npm --prefix "$(ROOT_DIR)" run start:bff:react-fastify' \
 	WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" \
 	BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" \
-	CONTRACT_PROFILES="core,operational,ui-profile" \
+	CONTRACT_PROFILES="core,operational,status-profile,ui-profile" \
 	ROOT_DIR="$(ROOT_DIR)" \
 	bash "$(ROOT_DIR)/scripts/e2e/run-stack-e2e.sh"
 

--- a/stacks/nodejs/react-fastify/rest/README.md
+++ b/stacks/nodejs/react-fastify/rest/README.md
@@ -23,9 +23,13 @@ BFF.
 
 - `core`
 - `operational`
+- `status-profile`
 - `ui-profile`
 
-This stack declares UI capability mode `spa`.
+This stack declares status capability and UI capability mode `spa`.
+Rendered `ui-profile` checks use a local Chromium-family browser; set
+`IDP_UI_BROWSER_PATH` if Chrome or Edge cannot be auto-detected on the current
+machine.
 
 ## Commands
 
@@ -101,6 +105,8 @@ The web container uses nginx and proxies `/api/*` requests to the BFF via the
 
 - `OUR_IDP_API_HOST` -- bind address (default `0.0.0.0`)
 - `OUR_IDP_API_PORT` -- BFF port (default `8400`)
+- `OUR_IDP_STATUS_WEB_URL` -- optional web base URL used by
+  `/api/portal/summary` to include live IDP web health
 
 ### Published Images
 

--- a/stacks/nodejs/react-fastify/rest/bff/src/routes/portal-summary.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/routes/portal-summary.ts
@@ -1,63 +1,134 @@
 import { z } from "zod";
 import type { FastifyPluginAsync } from "fastify";
 
-const serviceSchema = z.object({
+const SUMMARY_TIMEOUT_MS = 2_000;
+
+const healthEnvelopeSchema = z.object({
+  status: z.enum(["pass", "fail", "warn"]),
+});
+
+const componentSchema = z.object({
   id: z.string(),
   label: z.string(),
+  kind: z.literal("service"),
   status: z.enum(["healthy", "degraded"]),
   latencyMs: z.number().nonnegative(),
+  observedAt: z.string(),
 });
 
 const summaryResponseSchema = z.object({
   generatedAt: z.string(),
   status: z.enum(["ok", "degraded"]),
   metrics: z.object({
-    servicesHealthy: z.number().int().nonnegative(),
-    activePlugins: z.number().int().nonnegative(),
-    queuedIntents: z.number().int().nonnegative(),
+    totalComponents: z.number().int().nonnegative(),
+    healthyComponents: z.number().int().nonnegative(),
+    degradedComponents: z.number().int().nonnegative(),
   }),
-  services: z.array(serviceSchema),
+  freshness: z.object({
+    maxAgeSeconds: z.number().int().nonnegative(),
+  }),
+  components: z.array(componentSchema).min(1),
 });
 
-type Service = z.infer<typeof serviceSchema>;
+type PortalComponent = z.infer<typeof componentSchema>;
 
-function getServiceSet(): Service[] {
-  return [
-    {
-      id: "catalog",
-      label: "Service Catalog",
-      status: "healthy",
-      latencyMs: 24,
+function resolveStatusWebUrl(): URL | null {
+  const raw = process.env.OUR_IDP_STATUS_WEB_URL?.trim();
+  if (raw === undefined || raw.length === 0) {
+    return null;
+  }
+
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function observeWebComponent(baseUrl: URL): Promise<PortalComponent> {
+  const startedAt = Date.now();
+  let status: PortalComponent["status"] = "degraded";
+
+  try {
+    const response = await fetch(new URL("/health", baseUrl), {
+      headers: {
+        Accept: "application/health+json, application/json",
+      },
+      signal: AbortSignal.timeout(SUMMARY_TIMEOUT_MS),
+    });
+
+    if (response.ok) {
+      const payload = healthEnvelopeSchema.parse(await response.json());
+      if (payload.status === "pass") {
+        status = "healthy";
+      }
+    }
+  } catch {
+    status = "degraded";
+  }
+
+  return {
+    id: "idp-web",
+    label: "IDP Web",
+    kind: "service",
+    status,
+    latencyMs: Date.now() - startedAt,
+    observedAt: new Date().toISOString(),
+  };
+}
+
+function createBffComponent(): PortalComponent {
+  return {
+    id: "idp-bff",
+    label: "IDP BFF",
+    kind: "service",
+    status: "healthy",
+    latencyMs: 0,
+    observedAt: new Date().toISOString(),
+  };
+}
+
+function buildSummary(components: PortalComponent[]) {
+  const generatedAt = new Date();
+  const healthyComponents = components.filter((component) => component.status === "healthy").length;
+  const degradedComponents = components.length - healthyComponents;
+
+  const maxAgeSeconds = components.reduce((maxAge, component) => {
+    const observedAt = Date.parse(component.observedAt);
+    if (!Number.isFinite(observedAt)) {
+      return maxAge;
+    }
+
+    const ageSeconds = Math.max(0, Math.floor((generatedAt.getTime() - observedAt) / 1000));
+    return Math.max(maxAge, ageSeconds);
+  }, 0);
+
+  return summaryResponseSchema.parse({
+    generatedAt: generatedAt.toISOString(),
+    status: degradedComponents > 0 ? "degraded" : "ok",
+    metrics: {
+      totalComponents: components.length,
+      healthyComponents,
+      degradedComponents,
     },
-    {
-      id: "policy",
-      label: "Policy Engine",
-      status: "healthy",
-      latencyMs: 36,
+    freshness: {
+      maxAgeSeconds,
     },
-    {
-      id: "plugin-runtime",
-      label: "Plugin Runtime",
-      status: "degraded",
-      latencyMs: 88,
-    },
-  ];
+    components,
+  });
 }
 
 export const portalSummaryRoutes: FastifyPluginAsync = async (app) => {
   app.get("/api/portal/summary", async () => {
-    const services = getServiceSet();
-    const servicesHealthy = services.filter((service) => service.status === "healthy").length;
+    const components: PortalComponent[] = [];
+    const webUrl = resolveStatusWebUrl();
 
-    return summaryResponseSchema.parse({
-      generatedAt: new Date().toISOString(),
-      status: servicesHealthy === services.length ? "ok" : "degraded",
-      metrics: {
-        servicesHealthy,
-        activePlugins: 7,
-        queuedIntents: 5,
-      },
-      services,
-    });
+    if (webUrl !== null) {
+      components.push(await observeWebComponent(webUrl));
+    }
+
+    components.push(createBffComponent());
+
+    return buildSummary(components);
   });
 };

--- a/stacks/nodejs/react-fastify/rest/stack.json
+++ b/stacks/nodejs/react-fastify/rest/stack.json
@@ -5,9 +5,13 @@
   "contractProfiles": [
     "core",
     "operational",
+    "status-profile",
     "ui-profile"
   ],
   "capabilities": {
+    "status": {
+      "enabled": true
+    },
     "ui": {
       "enabled": true,
       "mode": "spa"

--- a/stacks/nodejs/react-fastify/rest/web/server.ts
+++ b/stacks/nodejs/react-fastify/rest/web/server.ts
@@ -5,12 +5,6 @@ import { createServer } from "vite";
 const DEFAULT_PORT = 3000;
 const DEFAULT_HOST = "127.0.0.1";
 
-const HEALTH_RESPONSE = JSON.stringify({
-  status: "pass",
-  serviceId: "idp-web",
-  description: "IDP Web Server",
-});
-
 function parsePort(value: string | undefined): number | undefined {
   if (value === undefined || value === "") {
     return undefined;
@@ -62,14 +56,6 @@ async function start(): Promise<void> {
       port,
     },
   });
-
-  // Add /health middleware before Vite handles requests
-  server.middlewares.use("/health", (_req, res) => {
-    res.setHeader("Content-Type", "application/health+json; charset=utf-8");
-    res.writeHead(200);
-    res.end(HEALTH_RESPONSE);
-  });
-
   await server.listen();
 
   console.log(

--- a/stacks/nodejs/react-fastify/rest/web/src/components/portal-summary-overview.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/components/portal-summary-overview.tsx
@@ -1,0 +1,89 @@
+import { Link } from "react-router-dom";
+import type { PortalSummary } from "../lib/api-client";
+import { ServiceList } from "./service-list";
+import { StatusCard } from "./status-card";
+
+type PortalSummaryOverviewProps = {
+  summary: PortalSummary;
+  compact?: boolean;
+};
+
+function formatGeneratedAt(value: string): string {
+  return new Date(value).toLocaleString();
+}
+
+function describeFreshness(maxAgeSeconds: number): string {
+  if (maxAgeSeconds === 0) {
+    return "All observations are current.";
+  }
+
+  if (maxAgeSeconds === 1) {
+    return "Oldest observation is 1 second old.";
+  }
+
+  return `Oldest observation is ${maxAgeSeconds} seconds old.`;
+}
+
+export function PortalSummaryOverview({
+  summary,
+  compact = false,
+}: PortalSummaryOverviewProps) {
+  const visibleComponents = compact ? summary.components.slice(0, 2) : summary.components;
+
+  return (
+    <>
+      <section className="status-grid" aria-label="Live IDP status summary">
+        <StatusCard
+          title="System Status"
+          value={summary.status === "ok" ? "Healthy" : "Degraded"}
+          subtitle={`Snapshot generated ${formatGeneratedAt(summary.generatedAt)}`}
+          tone={summary.status === "ok" ? "healthy" : "degraded"}
+        />
+        <StatusCard
+          title="Healthy Components"
+          value={String(summary.metrics.healthyComponents)}
+          subtitle={`${summary.metrics.totalComponents} total components observed`}
+          tone="healthy"
+        />
+        <StatusCard
+          title="Degraded Components"
+          value={String(summary.metrics.degradedComponents)}
+          subtitle="Components needing investigation"
+          tone={summary.metrics.degradedComponents > 0 ? "degraded" : "healthy"}
+        />
+        <StatusCard
+          title="Freshness"
+          value={`${summary.freshness.maxAgeSeconds}s`}
+          subtitle={describeFreshness(summary.freshness.maxAgeSeconds)}
+        />
+      </section>
+
+      <section className="service-panel" aria-label="Observed IDP components">
+        <header>
+          <div>
+            <h2>Observed Components</h2>
+            <p>
+              This MVP reports IDP-owned components only. Plug-in and third-party
+              system status is intentionally deferred.
+            </p>
+          </div>
+          {compact ? (
+            <Link className="portal-action" to="/status">
+              Open detailed status
+            </Link>
+          ) : null}
+        </header>
+
+        <div className="service-list-wrap">
+          <ServiceList components={visibleComponents} />
+        </div>
+
+        {compact && summary.components.length > visibleComponents.length ? (
+          <p className="service-list-caption">
+            Showing {visibleComponents.length} of {summary.components.length} observed components.
+          </p>
+        ) : null}
+      </section>
+    </>
+  );
+}

--- a/stacks/nodejs/react-fastify/rest/web/src/components/service-list.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/components/service-list.tsx
@@ -1,21 +1,21 @@
 import type { PortalSummary } from "../lib/api-client";
 
 type ServiceListProps = {
-  services: PortalSummary["services"];
+  components: PortalSummary["components"];
 };
 
 function toTone(status: "healthy" | "degraded"): "healthy" | "degraded" {
   return status;
 }
 
-export function ServiceList({ services }: ServiceListProps) {
+export function ServiceList({ components }: ServiceListProps) {
   return (
     <div className="service-list">
-      {services.map((service) => (
+      {components.map((service) => (
         <article key={service.id} className="service-item">
           <div>
             <h3>{service.label}</h3>
-            <p>{service.id}</p>
+            <p>{service.id} - observed {new Date(service.observedAt).toLocaleTimeString()}</p>
           </div>
           <div className={`service-state service-state--${toTone(service.status)}`}>
             <span>{service.status}</span>

--- a/stacks/nodejs/react-fastify/rest/web/src/lib/api-client.ts
+++ b/stacks/nodejs/react-fastify/rest/web/src/lib/api-client.ts
@@ -6,15 +6,20 @@ export type PortalSummary = {
   generatedAt: string;
   status: PortalStatus;
   metrics: {
-    servicesHealthy: number;
-    activePlugins: number;
-    queuedIntents: number;
+    totalComponents: number;
+    healthyComponents: number;
+    degradedComponents: number;
   };
-  services: Array<{
+  freshness: {
+    maxAgeSeconds: number;
+  };
+  components: Array<{
     id: string;
     label: string;
+    kind: "service";
     status: ServiceStatus;
     latencyMs: number;
+    observedAt: string;
   }>;
 };
 

--- a/stacks/nodejs/react-fastify/rest/web/src/router.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/router.tsx
@@ -8,10 +8,23 @@ const HomePage = lazy(async () => {
   return { default: module.HomePage };
 });
 
+const StatusPage = lazy(async () => {
+  const module = await import("./routes/status-page");
+  return { default: module.StatusPage };
+});
+
 function HomeRoute() {
   return (
     <Suspense fallback={<RouteLoading />}>
       <HomePage />
+    </Suspense>
+  );
+}
+
+function StatusRoute() {
+  return (
+    <Suspense fallback={<RouteLoading />}>
+      <StatusPage />
     </Suspense>
   );
 }
@@ -24,6 +37,11 @@ export const router = createBrowserRouter([
   {
     path: "/",
     element: <HomeRoute />,
+    errorElement: <RootErrorBoundary />,
+  },
+  {
+    path: "/status",
+    element: <StatusRoute />,
     errorElement: <RootErrorBoundary />,
   },
 ]);

--- a/stacks/nodejs/react-fastify/rest/web/src/routes/home-page.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/routes/home-page.tsx
@@ -1,4 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { PortalSummaryOverview } from "../components/portal-summary-overview";
+import { fetchPortalSummary } from "../lib/api-client";
+
 export function HomePage() {
+  const portalSummaryQuery = useQuery({
+    queryKey: ["portal-summary"],
+    queryFn: fetchPortalSummary,
+  });
+
   return (
     <main className="portal-shell">
       <header className="portal-hero">
@@ -6,77 +16,57 @@ export function HomePage() {
           Stemix
           <span className="portal-badge">Early Alpha</span>
         </p>
-        <h1>The development experience<br />is being reimagined.</h1>
+        <h1>API-first status for the IDP itself.</h1>
         <p className="portal-subtitle">
-          Stemix is an AI-native Intelligent Development System — connecting product intent
-          to engineering reality through a secure, extensible, self-hosted platform. We're
-          still building. What you're looking at is a pre-release reference stack; much
-          more work lies ahead.
+          The first MVP capability is live status for IDP-owned components. The
+          same BFF contract drives this home page summary, the detailed portal
+          status view, the MCP status tool, and the static publisher for
+          externally hosted status artifacts.
         </p>
+        <div className="portal-actions">
+          <Link className="portal-action" to="/status">
+            View detailed status
+          </Link>
+        </div>
       </header>
 
-      <section className="status-grid" aria-label="Capabilities in development">
-        <article className="status-card">
-          <div className="feature-icon">🎯</div>
-          <h2 className="status-card__value">Intent-Driven Portal</h2>
-          <p className="status-card__subtitle">
-            Translate high-level product decisions into actionable engineering work.
-            Automatically surface gaps between intent and implementation.
-          </p>
-        </article>
-        <article className="status-card">
-          <div className="feature-icon">🤖</div>
-          <h2 className="status-card__value">AI &amp; MCP-First</h2>
-          <p className="status-card__subtitle">
-            Model Context Protocol as the standard AI integration layer. AI capabilities
-            built in from day one — not bolted on as an afterthought.
-          </p>
-        </article>
-        <article className="status-card">
-          <div className="feature-icon">🔒</div>
-          <h2 className="status-card__value">Secure by Default</h2>
-          <p className="status-card__subtitle">
-            Zero-trust architecture. Encrypted at rest and in transit. Least privilege
-            everywhere. Security is never optional.
-          </p>
-        </article>
-        <article className="status-card">
-          <div className="feature-icon">🏠</div>
-          <h2 className="status-card__value">Self-Service Hosting</h2>
-          <p className="status-card__subtitle">
-            Run the full platform privately, on your own infrastructure, with minimal
-            operational overhead and no vendor lock-in.
-          </p>
-        </article>
-        <article className="status-card">
-          <div className="feature-icon">🔌</div>
-          <h2 className="status-card__value">Extensible Plug-ins</h2>
-          <p className="status-card__subtitle">
-            Clear contracts, sandboxed execution, and a plug-in SDK to extend the platform
-            without touching core systems.
-          </p>
-        </article>
-        <article className="status-card">
-          <div className="feature-icon">🏢</div>
-          <h2 className="status-card__value">Multi-Tenant Ready</h2>
-          <p className="status-card__subtitle">
-            Strong tenant isolation with options for dedicated physical infrastructure and
-            flexible multi-tenant SaaS deployment modes.
-          </p>
-        </article>
-      </section>
+      {portalSummaryQuery.isLoading ? (
+        <section className="service-panel" aria-live="polite">
+          <p className="empty-state">Loading the current IDP status summary...</p>
+        </section>
+      ) : null}
 
-      <footer className="service-panel" role="note">
+      {portalSummaryQuery.isError ? (
+        <section className="service-panel" aria-live="assertive">
+          <p className="empty-state empty-state--error">
+            Unable to load the live status summary. The dedicated status route
+            and static publisher both depend on `/api/portal/summary`, so this
+            is a useful signal that the current runtime needs attention.
+          </p>
+        </section>
+      ) : null}
+
+      {portalSummaryQuery.data !== undefined ? (
+        <PortalSummaryOverview compact summary={portalSummaryQuery.data} />
+      ) : null}
+
+      <section className="service-panel" role="note">
+        <header>
+          <div>
+            <h2>Roadmap Context</h2>
+            <p>
+              This repo now has a concrete status slice. Plug-in and external
+              system status remain roadmap items until the plug-in architecture
+              and adapter contracts exist.
+            </p>
+          </div>
+        </header>
         <p className="empty-state">
-          This is a pre-release alpha reference stack. Contracts, APIs, and UI are actively
-          evolving — expect breaking changes between releases. Not production-ready. Follow
-          progress and explore the architecture at{" "}
-          <a href="https://stemix.dev" rel="noopener noreferrer" className="portal-link">
-            stemix.dev
-          </a>
-          .
+          See <a href="https://stemix.dev" rel="noopener noreferrer" className="portal-link">stemix.dev</a> for
+          architecture context and use <Link to="/status" className="portal-link">the detailed status view</Link> to
+          inspect the current portal runtime.
         </p>
-      </footer>
+      </section>
     </main>
   );
 }

--- a/stacks/nodejs/react-fastify/rest/web/src/routes/status-page.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/routes/status-page.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { PortalSummaryOverview } from "../components/portal-summary-overview";
+import { fetchPortalSummary } from "../lib/api-client";
+
+export function StatusPage() {
+  const portalSummaryQuery = useQuery({
+    queryKey: ["portal-summary"],
+    queryFn: fetchPortalSummary,
+  });
+
+  return (
+    <main className="portal-shell">
+      <header className="portal-hero">
+        <p className="portal-kicker">
+          Stemix
+          <span className="portal-badge">Status</span>
+        </p>
+        <h1>Detailed IDP status</h1>
+        <p className="portal-subtitle">
+          This route is the in-product operational view for the MVP. It reads
+          the same summary contract that the MCP adapter and static status
+          publisher consume.
+        </p>
+        <div className="portal-actions">
+          <Link className="portal-action portal-action--secondary" to="/">
+            Back to home
+          </Link>
+        </div>
+      </header>
+
+      {portalSummaryQuery.isLoading ? (
+        <section className="service-panel" aria-live="polite">
+          <p className="empty-state">Loading the detailed status view...</p>
+        </section>
+      ) : null}
+
+      {portalSummaryQuery.isError ? (
+        <section className="service-panel" aria-live="assertive">
+          <p className="empty-state empty-state--error">
+            The portal could not retrieve `/api/portal/summary`. Validate the
+            BFF runtime and regenerate any external static status artifacts once
+            the live contract is healthy again.
+          </p>
+        </section>
+      ) : null}
+
+      {portalSummaryQuery.data !== undefined ? (
+        <PortalSummaryOverview summary={portalSummaryQuery.data} />
+      ) : null}
+
+      <section className="service-panel">
+        <header>
+          <div>
+            <h2>Publication Path</h2>
+            <p>
+              External status artifacts are generated from the same live summary
+              contract and should be hosted independently from the interactive
+              portal runtime.
+            </p>
+          </div>
+        </header>
+        <p className="empty-state">
+          Run <code>tsx tools/status/publish-status.ts</code> from the repo root
+          to emit static JSON and HTML snapshots from the current BFF status
+          response.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/stacks/nodejs/react-fastify/rest/web/src/styles.css
+++ b/stacks/nodejs/react-fastify/rest/web/src/styles.css
@@ -85,6 +85,39 @@ body {
   max-width: 66ch;
 }
 
+.portal-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.portal-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(17, 100, 102, 0.18);
+  padding: 0.55rem 0.95rem;
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.portal-action:hover {
+  background: #0d5657;
+}
+
+.portal-action--secondary {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.portal-action--secondary:hover {
+  background: #f7f0e6;
+}
+
 .status-grid {
   display: grid;
   gap: 0.9rem;
@@ -214,6 +247,12 @@ body {
   font-size: 0.78rem;
   color: var(--muted);
   font-weight: 500;
+}
+
+.service-list-caption {
+  margin-top: 0.85rem;
+  color: var(--muted);
+  font-size: 0.85rem;
 }
 
 .service-state--healthy {

--- a/stacks/nodejs/react-fastify/rest/web/vite.config.ts
+++ b/stacks/nodejs/react-fastify/rest/web/vite.config.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const bffPort = Number.parseInt(process.env.OUR_IDP_API_PORT ?? "8000", 10);
 const bffTargetPort = Number.isNaN(bffPort) ? 8000 : bffPort;
@@ -11,9 +11,28 @@ const defaultHost = process.env.OUR_IDP_WEB_HOST?.trim() || "127.0.0.1";
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
 
+const HEALTH_RESPONSE = JSON.stringify({
+  status: "pass",
+  serviceId: "idp-web",
+  description: "IDP Web Server",
+});
+
+function healthEndpointPlugin(): Plugin {
+  return {
+    name: "idp-health-endpoint",
+    configureServer(server) {
+      server.middlewares.use("/health", (_req, res) => {
+        res.setHeader("Content-Type", "application/health+json; charset=utf-8");
+        res.writeHead(200);
+        res.end(HEALTH_RESPONSE);
+      });
+    },
+  };
+}
+
 export default defineConfig({
   root: currentDir,
-  plugins: [react()],
+  plugins: [healthEndpointPlugin(), react()],
   build: {
     sourcemap: true,
     rollupOptions: {

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,7 @@ the required HTTP endpoints.
 ## Requirements
 
 - Node.js 18+ (for stable runtime behavior)
+- Chrome or Edge when running the rendered `ui-profile` checks
 
 ## Configuration
 
@@ -16,21 +17,28 @@ the required HTTP endpoints.
   capability declarations, example: `stacks/nodejs/react-fastify/rest`)
 - `IDP_CONTRACT_PROFILE` (optional single profile override)
 - `IDP_CONTRACT_PROFILES` (optional comma-separated profile list override)
+- `IDP_UI_BROWSER_PATH` (optional; path to Chrome or Edge for browser-backed
+  `ui-profile` rendering checks)
 
 ## Conformance Profiles
 
 - `core`: required baseline behavior
 - `operational`: runtime and operational behavior checks
+- `status-profile`: API-first IDP status checks for stacks that declare status support
 - `ui-profile`: UI-capability contract checks for stacks that declare UI support
+  and can be rendered in a local Chromium-family browser
 
-By default, the harness runs `core` + `operational`, and only runs
-`ui-profile` when both:
+By default, the harness runs `core` + `operational`, and only runs opt-in
+profiles such as `status-profile` and `ui-profile` when both:
 
 - requested by environment profile selection, and
 - declared in stack metadata (`stack.json`)
 
 When `IDP_STACK_PATH` is provided and no profile override env vars are set,
 profiles are selected from `stack.json` (`contractProfiles`).
+
+The status MVP is intentionally scoped to IDP-owned components. Plug-in and
+third-party system status remain out of scope for `status-profile`.
 
 ## Run
 
@@ -56,7 +64,7 @@ IDP_WEB_URL="http://localhost:3001" IDP_BFF_URL="http://localhost:8001" npm run 
 Example for a specific stack and explicit profile set:
 
 ```bash
-IDP_STACK_PATH="stacks/nodejs/react-fastify/rest" IDP_CONTRACT_PROFILES="core,operational,ui-profile" npm run test:contract
+IDP_STACK_PATH="stacks/nodejs/react-fastify/rest" IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile" npm run test:contract
 ```
 
 ## Container Image

--- a/tests/features/mcp-profile.feature
+++ b/tests/features/mcp-profile.feature
@@ -9,6 +9,8 @@ Feature: MCP profile — Model Context Protocol interface contract
 
   Background:
     Given the MCP server is running at the URL defined by IDP_MCP_URL
+    And the client follows the MCP initialize and initialized handshake
+    And the client reuses any "Mcp-Session-Id" header returned by the server
 
   Scenario: MCP server responds to initialize with server info and capabilities
     When the client sends an MCP initialize request to the MCP server
@@ -32,7 +34,7 @@ Feature: MCP profile — Model Context Protocol interface contract
     And the JSON-RPC response contains a result field
     And the result content is a non-empty array of content items
     And content item 0 has type "text" and a non-empty text field
-    And the text is valid JSON containing a "status" field
+    And the text is valid JSON matching the portal summary status contract
 
   Scenario: tools/call check_health returns BFF health and readiness
     When the client calls the MCP tool "check_health" with no arguments

--- a/tests/features/status-profile.feature
+++ b/tests/features/status-profile.feature
@@ -1,0 +1,36 @@
+Feature: Status profile contract — API-first IDP status
+  This profile is opt-in. It runs only when the stack declares
+  capabilities.status.enabled = true in its stack.json. It validates the live
+  IDP status API exposed by the BFF. The MVP is intentionally scoped to
+  IDP-owned components only; plug-in and third-party system status are out of
+  scope for this profile.
+
+  Background:
+    Given the BFF server is running at the URL defined by IDP_BFF_URL
+    And the stack declares capabilities.status.enabled = true in stack.json
+
+  Scenario: BFF portal summary returns the expected shape
+    When the client sends GET /api/portal/summary to the BFF server
+    Then the response status code is in the 2xx range
+    And the response Content-Type header contains "application/json"
+    And the response body is valid JSON containing:
+      | field                     | expectation                                 |
+      | generatedAt               | ISO-8601 timestamp                           |
+      | status                    | "ok" or "degraded"                          |
+      | metrics.totalComponents   | non-negative integer                         |
+      | metrics.healthyComponents | non-negative integer                         |
+      | metrics.degradedComponents| non-negative integer                         |
+      | freshness.maxAgeSeconds   | non-negative integer                         |
+      | components                | non-empty array of IDP-owned status entries |
+
+  Scenario: Portal summary metrics are internally consistent
+    When the client sends GET /api/portal/summary to the BFF server
+    Then the metrics total equals the number of components
+    And the healthy and degraded component counts match the component statuses
+    And the top-level status matches the aggregate component state
+
+  Scenario: Portal summary timestamps and freshness are valid
+    When the client sends GET /api/portal/summary to the BFF server
+    Then generatedAt is within 60 seconds of the current time
+    And each component entry contains an ISO-8601 observedAt timestamp
+    And freshness.maxAgeSeconds matches the oldest component observation age

--- a/tests/features/ui-profile.feature
+++ b/tests/features/ui-profile.feature
@@ -1,8 +1,8 @@
 Feature: UI profile contract — externally observable UI behavior
   This profile is opt-in. It runs only when the stack declares
   capabilities.ui.enabled = true in its stack.json. It validates observable
-  HTML output and the declared rendering mode without asserting any
-  framework-specific internals.
+  HTML output, rendered status summary behavior, and the declared rendering
+  mode without asserting framework-specific internals.
 
   Background:
     Given the web server is running at the URL defined by IDP_WEB_URL
@@ -18,6 +18,21 @@ Feature: UI profile contract — externally observable UI behavior
     When the client sends GET / to the web server
     Then the response status code is in the 2xx range
     And the response body contains the string "<title" (case-insensitive)
+
+  Scenario: Web root renders live portal summary content
+    Given the BFF server is running at the URL defined by IDP_BFF_URL
+    When the client renders GET / in a headless browser
+    Then the rendered page includes the text "System Status"
+    And the rendered page includes the text "Observed Components"
+    And the rendered page includes the text "IDP BFF"
+
+  Scenario: Status route renders detailed portal summary content
+    Given the BFF server is running at the URL defined by IDP_BFF_URL
+    When the client renders GET /status in a headless browser
+    Then the rendered page includes the text "Detailed IDP status"
+    And the rendered page includes the text "Observed Components"
+    And the rendered page includes the text "Publication Path"
+    And the rendered page includes the text "IDP BFF"
 
   Scenario: UI mode declaration is one of the accepted values
     Given the stack's stack.json declares capabilities.ui.mode

--- a/tests/src/browser.ts
+++ b/tests/src/browser.ts
@@ -1,0 +1,125 @@
+import { spawn } from "node:child_process";
+
+const BROWSER_RENDER_TIMEOUT_MS = 15_000;
+
+const WINDOWS_BROWSER_PATHS = [
+  "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+  "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+  "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+  "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+];
+
+const MACOS_BROWSER_PATHS = [
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+];
+
+const LINUX_BROWSER_PATHS = [
+  "google-chrome",
+  "google-chrome-stable",
+  "chromium",
+  "chromium-browser",
+  "microsoft-edge",
+  "msedge",
+];
+
+function getBrowserCandidates(): string[] {
+  const envCandidates = [
+    process.env.IDP_UI_BROWSER_PATH?.trim(),
+    process.env.PUPPETEER_EXECUTABLE_PATH?.trim(),
+  ].filter((value): value is string => value !== undefined && value.length > 0);
+
+  const platformCandidates =
+    process.platform === "win32"
+      ? WINDOWS_BROWSER_PATHS
+      : process.platform === "darwin"
+        ? MACOS_BROWSER_PATHS
+        : LINUX_BROWSER_PATHS;
+
+  return [...envCandidates, ...platformCandidates];
+}
+
+function runDumpDom(browserPath: string, url: URL): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      browserPath,
+      [
+        "--headless",
+        "--disable-gpu",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--virtual-time-budget=10000",
+        "--dump-dom",
+        url.toString(),
+      ],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+
+    const timeoutId = setTimeout(() => {
+      child.kill();
+      reject(new Error(`Browser render timed out after ${BROWSER_RENDER_TIMEOUT_MS}ms`));
+    }, BROWSER_RENDER_TIMEOUT_MS);
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+
+    child.stdout.on("data", (chunk) => {
+      stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+    });
+
+    child.once("error", (error) => {
+      clearTimeout(timeoutId);
+      reject(error);
+    });
+
+    child.once("close", (code) => {
+      clearTimeout(timeoutId);
+
+      if (code !== 0) {
+        const stderr = Buffer.concat(stderrChunks).toString("utf-8").trim();
+        reject(new Error(stderr.length > 0 ? stderr : `Browser exited with code ${code ?? -1}`));
+        return;
+      }
+
+      resolve(Buffer.concat(stdoutChunks).toString("utf-8"));
+    });
+  });
+}
+
+export async function renderDomOrThrow(url: URL): Promise<string> {
+  const candidates = getBrowserCandidates();
+  let lastError: Error | null = null;
+
+  for (const candidate of candidates) {
+    try {
+      return await runDumpDom(candidate, url);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        ((error as NodeJS.ErrnoException).code === "ENOENT" ||
+          (error as NodeJS.ErrnoException).code === "EINVAL")
+      ) {
+        lastError = error;
+        continue;
+      }
+
+      lastError = error instanceof Error ? error : new Error(String(error));
+      continue;
+    }
+  }
+
+  const detail =
+    lastError instanceof Error ? ` Last error: ${lastError.message}` : "";
+
+  throw new Error(
+    "Unable to render the UI in a headless Chromium browser. " +
+      "Set IDP_UI_BROWSER_PATH to a local Chrome or Edge executable if auto-detection fails." +
+      detail
+  );
+}

--- a/tests/src/http.ts
+++ b/tests/src/http.ts
@@ -47,7 +47,11 @@ export function request(url: URL): Promise<ResponsePayload> {
   });
 }
 
-export function post(url: URL, body: unknown): Promise<ResponsePayload> {
+export function post(
+  url: URL,
+  body: unknown,
+  extraHeaders?: Record<string, string>
+): Promise<ResponsePayload> {
   const client = url.protocol === "https:" ? https : http;
   const payload = JSON.stringify(body);
 
@@ -60,6 +64,7 @@ export function post(url: URL, body: unknown): Promise<ResponsePayload> {
           "Content-Type": "application/json",
           "Accept": "application/json, text/event-stream",
           "Content-Length": Buffer.byteLength(payload),
+          ...extraHeaders,
         },
       },
       (res) => {

--- a/tests/src/index.ts
+++ b/tests/src/index.ts
@@ -36,7 +36,13 @@ async function main(): Promise<void> {
 
   const stackMetadata = await loadStackMetadata();
   const requestedProfiles = resolveRequestedProfiles();
-  const orderedProfiles: ProfileName[] = ["core", "operational", "ui-profile", "mcp-profile"];
+  const orderedProfiles: ProfileName[] = [
+    "core",
+    "operational",
+    "status-profile",
+    "ui-profile",
+    "mcp-profile",
+  ];
 
   const context: ContractContext = {
     webBaseUrl,

--- a/tests/src/profiles/index.ts
+++ b/tests/src/profiles/index.ts
@@ -1,6 +1,7 @@
 import { createCoreTests } from "./core";
 import { createMcpProfileTests } from "./mcp-profile";
 import { createOperationalTests } from "./operational";
+import { createStatusProfileTests } from "./status-profile";
 import { createUiProfileTests } from "./ui-profile";
 import type { ContractContext, ProfileName, TestCase } from "../types";
 
@@ -11,6 +12,10 @@ export function buildTestsForProfile(profile: ProfileName, context: ContractCont
 
   if (profile === "operational") {
     return createOperationalTests(context);
+  }
+
+  if (profile === "status-profile") {
+    return createStatusProfileTests(context);
   }
 
   if (profile === "mcp-profile") {

--- a/tests/src/profiles/mcp-profile.ts
+++ b/tests/src/profiles/mcp-profile.ts
@@ -1,18 +1,30 @@
 import { assert, parseJsonOrThrow } from "../assertions";
 import { post } from "../http";
+import { parsePortalSummaryOrThrow } from "../status";
 import type { ContractContext, TestCase } from "../types";
 
 const MCP_PROTOCOL_VERSION = "2024-11-05";
 
 type JsonRpcRequest = {
   jsonrpc: "2.0";
-  id: number;
+  id?: number;
   method: string;
   params?: Record<string, unknown>;
 };
 
-function mcpRequest(mcpBaseUrl: URL, payload: JsonRpcRequest): ReturnType<typeof post> {
-  return post(new URL("/mcp", mcpBaseUrl), payload);
+function mcpRequest(
+  mcpBaseUrl: URL,
+  payload: JsonRpcRequest,
+  sessionId?: string
+): ReturnType<typeof post> {
+  const headers =
+    sessionId === undefined
+      ? undefined
+      : {
+          "Mcp-Session-Id": sessionId,
+        };
+
+  return post(new URL("/mcp", mcpBaseUrl), payload, headers);
 }
 
 /**
@@ -63,39 +75,68 @@ export function createMcpProfileTests(context: ContractContext): TestCase[] {
 
   const { mcpBaseUrl } = context;
   let requestId = 1;
+  let sessionId: string | undefined;
+  let initializeResult: Record<string, unknown> | null = null;
 
   function nextId(): number {
     return requestId++;
+  }
+
+  async function ensureInitialized(): Promise<Record<string, unknown>> {
+    if (initializeResult !== null) {
+      return initializeResult;
+    }
+
+    const initializeResponse = await mcpRequest(mcpBaseUrl, {
+      jsonrpc: "2.0",
+      id: nextId(),
+      method: "initialize",
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "idp-contract-test", version: "0.1.0" },
+      },
+    });
+
+    assert(
+      initializeResponse.status >= 200 && initializeResponse.status < 300,
+      `Expected 2xx from MCP initialize, got ${initializeResponse.status}`
+    );
+
+    const envelope = parseJsonRpcResponse(initializeResponse.body);
+    assert("result" in envelope, "MCP initialize response must contain a result field");
+
+    const result = envelope.result as Record<string, unknown>;
+    assert(
+      typeof result === "object" && result !== null,
+      "MCP initialize result must be an object"
+    );
+
+    sessionId = initializeResponse.headers["mcp-session-id"];
+    initializeResult = result;
+
+    const initializedResponse = await mcpRequest(
+      mcpBaseUrl,
+      {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      },
+      sessionId
+    );
+
+    assert(
+      initializedResponse.status >= 200 && initializedResponse.status < 300,
+      `Expected 2xx from MCP notifications/initialized, got ${initializedResponse.status}`
+    );
+
+    return result;
   }
 
   return [
     {
       name: "mcp-profile:initialize returns server info and capabilities",
       run: async () => {
-        const response = await mcpRequest(mcpBaseUrl, {
-          jsonrpc: "2.0",
-          id: nextId(),
-          method: "initialize",
-          params: {
-            protocolVersion: MCP_PROTOCOL_VERSION,
-            capabilities: {},
-            clientInfo: { name: "idp-contract-test", version: "0.1.0" },
-          },
-        });
-
-        assert(
-          response.status >= 200 && response.status < 300,
-          `Expected 2xx from MCP initialize, got ${response.status}`
-        );
-
-        const envelope = parseJsonRpcResponse(response.body);
-        assert("result" in envelope, "MCP initialize response must contain a result field");
-
-        const result = envelope.result as Record<string, unknown>;
-        assert(
-          typeof result === "object" && result !== null,
-          "MCP initialize result must be an object"
-        );
+        const result = await ensureInitialized();
         assert(
           "serverInfo" in result,
           "MCP initialize result must contain serverInfo"
@@ -119,11 +160,13 @@ export function createMcpProfileTests(context: ContractContext): TestCase[] {
     {
       name: "mcp-profile:tools/list returns expected tools with required fields",
       run: async () => {
+        await ensureInitialized();
+
         const response = await mcpRequest(mcpBaseUrl, {
           jsonrpc: "2.0",
           id: nextId(),
           method: "tools/list",
-        });
+        }, sessionId);
 
         assert(
           response.status >= 200 && response.status < 300,
@@ -161,6 +204,8 @@ export function createMcpProfileTests(context: ContractContext): TestCase[] {
     {
       name: "mcp-profile:tools/call get_portal_summary returns portal status",
       run: async () => {
+        await ensureInitialized();
+
         const response = await mcpRequest(mcpBaseUrl, {
           jsonrpc: "2.0",
           id: nextId(),
@@ -169,7 +214,7 @@ export function createMcpProfileTests(context: ContractContext): TestCase[] {
             name: "get_portal_summary",
             arguments: {},
           },
-        });
+        }, sessionId);
 
         assert(
           response.status >= 200 && response.status < 300,
@@ -192,14 +237,14 @@ export function createMcpProfileTests(context: ContractContext): TestCase[] {
           "MCP tool result content[0].text must be a non-empty string"
         );
 
-        const summary = parseJsonOrThrow(firstItem.text as string) as Record<string, unknown>;
-        assert(typeof summary === "object" && summary !== null, "get_portal_summary text must be valid JSON");
-        assert("status" in summary, "get_portal_summary result must include a status field");
+        parsePortalSummaryOrThrow(parseJsonOrThrow(firstItem.text as string));
       },
     },
     {
       name: "mcp-profile:tools/call check_health returns BFF health envelope",
       run: async () => {
+        await ensureInitialized();
+
         const response = await mcpRequest(mcpBaseUrl, {
           jsonrpc: "2.0",
           id: nextId(),
@@ -208,7 +253,7 @@ export function createMcpProfileTests(context: ContractContext): TestCase[] {
             name: "check_health",
             arguments: {},
           },
-        });
+        }, sessionId);
 
         assert(
           response.status >= 200 && response.status < 300,

--- a/tests/src/profiles/status-profile.ts
+++ b/tests/src/profiles/status-profile.ts
@@ -1,0 +1,95 @@
+import { parseJsonOrThrow } from "../assertions";
+import { request } from "../http";
+import { ensureServiceAvailable } from "../runtime";
+import { parsePortalSummaryOrThrow } from "../status";
+import type { ContractContext, TestCase } from "../types";
+
+function isStatusEnabled(context: ContractContext): boolean {
+  return context.stackMetadata?.capabilities?.status?.enabled === true;
+}
+
+export function createStatusProfileTests(context: ContractContext): TestCase[] {
+  if (!isStatusEnabled(context)) {
+    return [];
+  }
+
+  const { bffBaseUrl } = context;
+
+  return [
+    {
+      name: "status-profile:bff portal summary returns expected shape",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(new URL("/api/portal/summary", bffBaseUrl));
+
+        if (response.status < 200 || response.status >= 300) {
+          throw new Error(`Expected 2xx, got ${response.status}`);
+        }
+
+        const contentType = response.headers["content-type"] ?? "";
+        if (!contentType.includes("application/json")) {
+          throw new Error("Portal summary must return application/json content type");
+        }
+
+        parsePortalSummaryOrThrow(parseJsonOrThrow(response.body));
+      },
+    },
+    {
+      name: "status-profile:portal summary metrics are internally consistent",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(new URL("/api/portal/summary", bffBaseUrl));
+        const summary = parsePortalSummaryOrThrow(parseJsonOrThrow(response.body));
+
+        const healthyCount = summary.components.filter((component) => component.status === "healthy").length;
+        const degradedCount = summary.components.filter((component) => component.status === "degraded").length;
+
+        if (summary.metrics.totalComponents !== summary.components.length) {
+          throw new Error("metrics.totalComponents must equal the number of components");
+        }
+        if (summary.metrics.healthyComponents !== healthyCount) {
+          throw new Error("metrics.healthyComponents must equal the number of healthy components");
+        }
+        if (summary.metrics.degradedComponents !== degradedCount) {
+          throw new Error("metrics.degradedComponents must equal the number of degraded components");
+        }
+
+        const expectedStatus = degradedCount > 0 ? "degraded" : "ok";
+        if (summary.status !== expectedStatus) {
+          throw new Error(`summary.status must be '${expectedStatus}' when metrics indicate that state`);
+        }
+      },
+    },
+    {
+      name: "status-profile:portal summary timestamps and freshness are valid",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(new URL("/api/portal/summary", bffBaseUrl));
+        const summary = parsePortalSummaryOrThrow(parseJsonOrThrow(response.body));
+
+        const generatedAt = Date.parse(summary.generatedAt);
+        const now = Date.now();
+        if (Math.abs(now - generatedAt) > 60_000) {
+          throw new Error("generatedAt must be within 60 seconds of the current time");
+        }
+
+        let maxAgeSeconds = 0;
+        for (const component of summary.components) {
+          const observedAt = Date.parse(component.observedAt);
+          if (observedAt > generatedAt + 5_000) {
+            throw new Error("component observedAt timestamps must not be meaningfully in the future");
+          }
+
+          const ageSeconds = Math.max(0, Math.floor((generatedAt - observedAt) / 1000));
+          if (ageSeconds > maxAgeSeconds) {
+            maxAgeSeconds = ageSeconds;
+          }
+        }
+
+        if (summary.freshness.maxAgeSeconds !== maxAgeSeconds) {
+          throw new Error("freshness.maxAgeSeconds must equal the oldest component observation age");
+        }
+      },
+    },
+  ];
+}

--- a/tests/src/profiles/ui-profile.ts
+++ b/tests/src/profiles/ui-profile.ts
@@ -1,4 +1,5 @@
 import { assert } from "../assertions";
+import { renderDomOrThrow } from "../browser";
 import { request } from "../http";
 import { ensureServiceAvailable } from "../runtime";
 import type { ContractContext, TestCase } from "../types";
@@ -21,7 +22,7 @@ export function createUiProfileTests(context: ContractContext): TestCase[] {
     return [];
   }
 
-  const { webBaseUrl } = context;
+  const { webBaseUrl, bffBaseUrl } = context;
 
   return [
     {
@@ -48,6 +49,54 @@ export function createUiProfileTests(context: ContractContext): TestCase[] {
 
         const bodyLower = response.body.toLowerCase();
         assert(bodyLower.includes("<title"), "Web response must include a <title> tag");
+      },
+    },
+    {
+      name: "ui-profile:web root renders live portal summary content",
+      run: async () => {
+        await ensureServiceAvailable("web server", webBaseUrl);
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+
+        const renderedDom = await renderDomOrThrow(new URL("/", webBaseUrl));
+
+        assert(
+          renderedDom.includes("System Status"),
+          "Rendered home page must include the live portal summary status card"
+        );
+        assert(
+          renderedDom.includes("Observed Components"),
+          "Rendered home page must include the observed components section"
+        );
+        assert(
+          renderedDom.includes("IDP BFF"),
+          "Rendered home page must include a component label from the live portal summary"
+        );
+      },
+    },
+    {
+      name: "ui-profile:status route renders detailed portal summary content",
+      run: async () => {
+        await ensureServiceAvailable("web server", webBaseUrl);
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+
+        const renderedDom = await renderDomOrThrow(new URL("/status", webBaseUrl));
+
+        assert(
+          renderedDom.includes("Detailed IDP status"),
+          "Rendered status route must include the detailed status heading"
+        );
+        assert(
+          renderedDom.includes("Observed Components"),
+          "Rendered status route must include the observed components section"
+        );
+        assert(
+          renderedDom.includes("Publication Path"),
+          "Rendered status route must include the static publication guidance section"
+        );
+        assert(
+          renderedDom.includes("IDP BFF"),
+          "Rendered status route must include a component label from the live portal summary"
+        );
       },
     },
     {

--- a/tests/src/runtime.ts
+++ b/tests/src/runtime.ts
@@ -19,7 +19,13 @@ function parseProfiles(raw: string | undefined): string[] {
 }
 
 function isProfileName(value: string): value is ProfileName {
-  return value === "core" || value === "operational" || value === "ui-profile" || value === "mcp-profile";
+  return (
+    value === "core" ||
+    value === "operational" ||
+    value === "status-profile" ||
+    value === "ui-profile" ||
+    value === "mcp-profile"
+  );
 }
 
 export function resolveBaseUrl(envName: string, fallback: string): URL {
@@ -168,7 +174,11 @@ export function shouldRunProfile(
     return stackMetadata.contractProfiles.includes(profile);
   }
 
-  if (profile === "ui-profile" || profile === "mcp-profile") {
+  if (
+    (profile === "status-profile" && stackMetadata?.capabilities?.status?.enabled !== true) ||
+    (profile === "ui-profile" && stackMetadata?.capabilities?.ui?.enabled !== true) ||
+    (profile === "mcp-profile" && stackMetadata?.capabilities?.mcp?.enabled !== true)
+  ) {
     return false;
   }
 

--- a/tests/src/status.ts
+++ b/tests/src/status.ts
@@ -1,0 +1,76 @@
+import { assert } from "./assertions";
+
+export type PortalSummary = {
+  generatedAt: string;
+  status: "ok" | "degraded";
+  metrics: {
+    totalComponents: number;
+    healthyComponents: number;
+    degradedComponents: number;
+  };
+  freshness: {
+    maxAgeSeconds: number;
+  };
+  components: Array<{
+    id: string;
+    label: string;
+    kind: "service";
+    status: "healthy" | "degraded";
+    latencyMs: number;
+    observedAt: string;
+  }>;
+};
+
+function isIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed);
+}
+
+function assertNonNegativeInteger(value: unknown, message: string): asserts value is number {
+  assert(typeof value === "number" && Number.isInteger(value) && value >= 0, message);
+}
+
+function assertNonNegativeNumber(value: unknown, message: string): asserts value is number {
+  assert(typeof value === "number" && Number.isFinite(value) && value >= 0, message);
+}
+
+export function parsePortalSummaryOrThrow(value: unknown): PortalSummary {
+  assert(typeof value === "object" && value !== null, "Portal summary must be a JSON object");
+
+  const candidate = value as Record<string, unknown>;
+  assert(candidate.status === "ok" || candidate.status === "degraded", "Portal summary status must be 'ok' or 'degraded'");
+  assert(isIsoTimestamp(candidate.generatedAt), "Portal summary generatedAt must be an ISO-8601 timestamp");
+
+  const metrics = candidate.metrics as Record<string, unknown>;
+  assert(typeof metrics === "object" && metrics !== null, "Portal summary metrics must be an object");
+  assertNonNegativeInteger(metrics.totalComponents, "metrics.totalComponents must be a non-negative integer");
+  assertNonNegativeInteger(metrics.healthyComponents, "metrics.healthyComponents must be a non-negative integer");
+  assertNonNegativeInteger(metrics.degradedComponents, "metrics.degradedComponents must be a non-negative integer");
+
+  const freshness = candidate.freshness as Record<string, unknown>;
+  assert(typeof freshness === "object" && freshness !== null, "Portal summary freshness must be an object");
+  assertNonNegativeInteger(freshness.maxAgeSeconds, "freshness.maxAgeSeconds must be a non-negative integer");
+
+  const components = candidate.components;
+  assert(Array.isArray(components), "Portal summary components must be an array");
+
+  for (const component of components) {
+    assert(typeof component === "object" && component !== null, "Each portal summary component must be an object");
+    const entry = component as Record<string, unknown>;
+    assert(typeof entry.id === "string" && entry.id.length > 0, "Each component must have a non-empty id");
+    assert(typeof entry.label === "string" && entry.label.length > 0, "Each component must have a non-empty label");
+    assert(entry.kind === "service", "Each component kind must be 'service'");
+    assert(
+      entry.status === "healthy" || entry.status === "degraded",
+      "Each component status must be 'healthy' or 'degraded'"
+    );
+    assertNonNegativeNumber(entry.latencyMs, "Each component latencyMs must be a non-negative number");
+    assert(isIsoTimestamp(entry.observedAt), "Each component observedAt must be an ISO-8601 timestamp");
+  }
+
+  return candidate as unknown as PortalSummary;
+}

--- a/tests/src/types.ts
+++ b/tests/src/types.ts
@@ -1,4 +1,9 @@
-export type ProfileName = "core" | "operational" | "ui-profile" | "mcp-profile";
+export type ProfileName =
+  | "core"
+  | "operational"
+  | "status-profile"
+  | "ui-profile"
+  | "mcp-profile";
 
 export type UiMode = "spa" | "ssr" | "server-rendered";
 
@@ -8,6 +13,9 @@ export type StackMetadata = {
   interface?: string;
   contractProfiles?: ProfileName[];
   capabilities?: {
+    status?: {
+      enabled?: boolean;
+    };
     ui?: {
       enabled?: boolean;
       mode?: UiMode;

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -87,7 +87,7 @@ docker run --rm -p 8080:8080 \
 
 | Tool                 | Description                                                                       |
 |----------------------|-----------------------------------------------------------------------------------|
-| `get_portal_summary` | Returns portal status, service health metrics, active plugins, and queued intents |
+| `get_portal_summary` | Returns the shared IDP status summary contract for IDP-owned components |
 | `check_health`       | Returns BFF `/health` and `/readiness` responses                                  |
 
 ## Platform notes

--- a/tools/mcp/src/server.ts
+++ b/tools/mcp/src/server.ts
@@ -2,12 +2,29 @@ import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { registerCheckHealth } from "./tools/check-health.js";
-import { registerGetPortalSummary } from "./tools/get-portal-summary.js";
+import {
+  CHECK_HEALTH_TOOL_DESCRIPTION,
+  CHECK_HEALTH_TOOL_NAME,
+  registerCheckHealth,
+  runCheckHealthTool,
+} from "./tools/check-health.js";
+import {
+  GET_PORTAL_SUMMARY_TOOL_DESCRIPTION,
+  GET_PORTAL_SUMMARY_TOOL_NAME,
+  registerGetPortalSummary,
+  runGetPortalSummaryTool,
+} from "./tools/get-portal-summary.js";
 
 const SERVER_NAME = "stemix-idp";
 const SERVER_VERSION = "0.1.0";
+const MCP_PROTOCOL_VERSION = "2024-11-05";
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+};
 
 function buildMcpServer(): McpServer {
   const server = new McpServer({
@@ -21,7 +38,35 @@ function buildMcpServer(): McpServer {
   return server;
 }
 
+function writeJson(
+  res: import("node:http").ServerResponse,
+  statusCode: number,
+  payload: unknown,
+  headers?: Record<string, string>
+): void {
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json",
+    ...headers,
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function readRequestBody(req: import("node:http").IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    req.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf-8"));
+    });
+    req.on("error", reject);
+  });
+}
+
 async function startHttpMode(port: number): Promise<void> {
+  const sessions = new Map<string, boolean>();
+
   const httpServer = createServer(async (req, res) => {
     if (req.url !== "/mcp") {
       res.writeHead(404, { "Content-Type": "application/json" });
@@ -29,33 +74,146 @@ async function startHttpMode(port: number): Promise<void> {
       return;
     }
 
-    // Each request gets its own stateless server + transport pair (no session state).
-    const server = buildMcpServer();
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (sessionId) => {
+    try {
+      if (req.method !== "POST") {
+        writeJson(res, 405, { error: "Only POST /mcp is supported." });
+        return;
+      }
+
+      const body = await readRequestBody(req);
+      const payload = JSON.parse(body) as JsonRpcRequest;
+      const method = payload.method;
+
+      if (payload.jsonrpc !== "2.0" || typeof method !== "string") {
+        writeJson(res, 400, {
+          jsonrpc: "2.0",
+          error: { code: -32600, message: "Invalid Request" },
+          id: payload.id ?? null,
+        });
+        return;
+      }
+
+      if (method === "initialize") {
+        const sessionId = randomUUID();
+        sessions.set(sessionId, false);
         process.stderr.write(
           JSON.stringify({ level: "info", msg: "MCP session initialized", sessionId }) + "\n"
         );
-      },
-    });
+        writeJson(
+          res,
+          200,
+          {
+            jsonrpc: "2.0",
+            id: payload.id ?? null,
+            result: {
+              protocolVersion: MCP_PROTOCOL_VERSION,
+              capabilities: {
+                tools: {
+                  listChanged: true,
+                },
+              },
+              serverInfo: {
+                name: SERVER_NAME,
+                version: SERVER_VERSION,
+              },
+            },
+          },
+          {
+            "Mcp-Session-Id": sessionId,
+          }
+        );
+        return;
+      }
 
-    transport.onclose = () => {
-      void server.close();
-    };
+      const rawSessionId = req.headers["mcp-session-id"];
+      const sessionId = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
+      if (sessionId === undefined || !sessions.has(sessionId)) {
+        writeJson(res, 400, {
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Bad Request: Mcp-Session-Id header is required" },
+          id: payload.id ?? null,
+        });
+        return;
+      }
 
-    await server.connect(transport);
+      if (method === "notifications/initialized") {
+        sessions.set(sessionId, true);
+        res.writeHead(202);
+        res.end();
+        return;
+      }
 
-    try {
-      await transport.handleRequest(req, res);
+      if (sessions.get(sessionId) !== true) {
+        writeJson(res, 400, {
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Bad Request: Server not initialized" },
+          id: payload.id ?? null,
+        });
+        return;
+      }
+
+      if (method === "tools/list") {
+        writeJson(res, 200, {
+          jsonrpc: "2.0",
+          id: payload.id ?? null,
+          result: {
+            tools: [
+              {
+                name: GET_PORTAL_SUMMARY_TOOL_NAME,
+                description: GET_PORTAL_SUMMARY_TOOL_DESCRIPTION,
+                inputSchema: { type: "object", properties: {}, additionalProperties: false },
+              },
+              {
+                name: CHECK_HEALTH_TOOL_NAME,
+                description: CHECK_HEALTH_TOOL_DESCRIPTION,
+                inputSchema: { type: "object", properties: {}, additionalProperties: false },
+              },
+            ],
+          },
+        });
+        return;
+      }
+
+      if (method === "tools/call") {
+        const toolName = payload.params?.name;
+        if (toolName === GET_PORTAL_SUMMARY_TOOL_NAME) {
+          writeJson(res, 200, {
+            jsonrpc: "2.0",
+            id: payload.id ?? null,
+            result: await runGetPortalSummaryTool(),
+          });
+          return;
+        }
+
+        if (toolName === CHECK_HEALTH_TOOL_NAME) {
+          writeJson(res, 200, {
+            jsonrpc: "2.0",
+            id: payload.id ?? null,
+            result: await runCheckHealthTool(),
+          });
+          return;
+        }
+
+        writeJson(res, 404, {
+          jsonrpc: "2.0",
+          error: { code: -32601, message: `Tool not found: ${String(toolName)}` },
+          id: payload.id ?? null,
+        });
+        return;
+      }
+
+      writeJson(res, 404, {
+        jsonrpc: "2.0",
+        error: { code: -32601, message: `Method not found: ${method}` },
+        id: payload.id ?? null,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       process.stderr.write(
         JSON.stringify({ level: "error", msg: "MCP request failed", error: message }) + "\n"
       );
       if (!res.headersSent) {
-        res.writeHead(500, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Internal server error" }));
+        writeJson(res, 500, { error: "Internal server error" });
       }
     }
   });

--- a/tools/mcp/src/tools/check-health.ts
+++ b/tools/mcp/src/tools/check-health.ts
@@ -2,6 +2,10 @@ import http from "node:http";
 import https from "node:https";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+export const CHECK_HEALTH_TOOL_NAME = "check_health";
+export const CHECK_HEALTH_TOOL_DESCRIPTION =
+  "Check the health and readiness status of the IDP BFF service. Returns both the IETF health check response and the readiness check response.";
+
 function resolveBffUrl(): URL {
   const raw = process.env.IDP_BFF_URL ?? "http://localhost:8000";
   return new URL(raw);
@@ -24,27 +28,31 @@ function fetchText(url: URL): Promise<string> {
   });
 }
 
+export async function runCheckHealthTool(): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  const bffUrl = resolveBffUrl();
+
+  const [healthBody, readinessBody] = await Promise.all([
+    fetchText(new URL("/health", bffUrl)),
+    fetchText(new URL("/readiness", bffUrl)),
+  ]);
+
+  const result = {
+    health: JSON.parse(healthBody) as unknown,
+    readiness: JSON.parse(readinessBody) as unknown,
+  };
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(result) }],
+  };
+}
+
 export function registerCheckHealth(server: McpServer): void {
   server.tool(
-    "check_health",
-    "Check the health and readiness status of the IDP BFF service. Returns both the IETF health check response and the readiness check response.",
+    CHECK_HEALTH_TOOL_NAME,
+    CHECK_HEALTH_TOOL_DESCRIPTION,
     {},
-    async () => {
-      const bffUrl = resolveBffUrl();
-
-      const [healthBody, readinessBody] = await Promise.all([
-        fetchText(new URL("/health", bffUrl)),
-        fetchText(new URL("/readiness", bffUrl)),
-      ]);
-
-      const result = {
-        health: JSON.parse(healthBody) as unknown,
-        readiness: JSON.parse(readinessBody) as unknown,
-      };
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(result) }],
-      };
-    }
+    async () => runCheckHealthTool()
   );
 }

--- a/tools/mcp/src/tools/get-portal-summary.ts
+++ b/tools/mcp/src/tools/get-portal-summary.ts
@@ -1,6 +1,32 @@
 import http from "node:http";
 import https from "node:https";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+export const GET_PORTAL_SUMMARY_TOOL_NAME = "get_portal_summary";
+export const GET_PORTAL_SUMMARY_TOOL_DESCRIPTION =
+  "Get the shared IDP status summary for IDP-owned components from the BFF portal summary contract.";
+
+const portalSummarySchema = z.object({
+  generatedAt: z.string(),
+  status: z.enum(["ok", "degraded"]),
+  metrics: z.object({
+    totalComponents: z.number().int().nonnegative(),
+    healthyComponents: z.number().int().nonnegative(),
+    degradedComponents: z.number().int().nonnegative(),
+  }),
+  freshness: z.object({
+    maxAgeSeconds: z.number().int().nonnegative(),
+  }),
+  components: z.array(z.object({
+    id: z.string(),
+    label: z.string(),
+    kind: z.literal("service"),
+    status: z.enum(["healthy", "degraded"]),
+    latencyMs: z.number().nonnegative(),
+    observedAt: z.string(),
+  })).min(1),
+});
 
 function resolveBffUrl(): URL {
   const raw = process.env.IDP_BFF_URL ?? "http://localhost:8000";
@@ -24,17 +50,23 @@ function fetchText(url: URL): Promise<string> {
   });
 }
 
+export async function runGetPortalSummaryTool(): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  const bffUrl = resolveBffUrl();
+  const body = await fetchText(new URL("/api/portal/summary", bffUrl));
+  const summary = portalSummarySchema.parse(JSON.parse(body) as unknown);
+
+  return {
+    content: [{ type: "text", text: JSON.stringify(summary) }],
+  };
+}
+
 export function registerGetPortalSummary(server: McpServer): void {
   server.tool(
-    "get_portal_summary",
-    "Get the current status of the IDP portal, including service health metrics, active plugins, and queued intents.",
+    GET_PORTAL_SUMMARY_TOOL_NAME,
+    GET_PORTAL_SUMMARY_TOOL_DESCRIPTION,
     {},
-    async () => {
-      const bffUrl = resolveBffUrl();
-      const body = await fetchText(new URL("/api/portal/summary", bffUrl));
-      return {
-        content: [{ type: "text" as const, text: body }],
-      };
-    }
+    async () => runGetPortalSummaryTool()
   );
 }

--- a/tools/mcp/tsconfig.json
+++ b/tools/mcp/tsconfig.json
@@ -1,8 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "baseUrl": ".",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "paths": {
+      "@modelcontextprotocol/sdk/server/*.js": [
+        "node_modules/@modelcontextprotocol/sdk/dist/esm/server/*.d.ts"
+      ]
+    },
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,

--- a/tools/status/README.md
+++ b/tools/status/README.md
@@ -1,0 +1,26 @@
+# Status Publisher
+
+This tool exists so the same live IDP status contract can be published outside
+the interactive portal runtime. It fetches `GET /api/portal/summary` from a
+running BFF and writes static JSON and HTML artifacts that can be hosted
+independently.
+
+## Run
+
+From the repository root:
+
+```bash
+tsx tools/status/publish-status.ts
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `IDP_BFF_URL` | `http://127.0.0.1:8000` | Base URL for the BFF that serves `/api/portal/summary` |
+| `STATUS_PUBLISH_DIR` | `.tmp/status-site` | Output directory for the generated artifacts |
+
+## Output
+
+- `status.json` — machine-readable snapshot matching the live status contract
+- `index.html` — simple static status page rendered from the same snapshot

--- a/tools/status/publish-status.ts
+++ b/tools/status/publish-status.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+type PortalStatus = "ok" | "degraded";
+type ComponentStatus = "healthy" | "degraded";
+
+type PortalSummary = {
+  generatedAt: string;
+  status: PortalStatus;
+  metrics: {
+    totalComponents: number;
+    healthyComponents: number;
+    degradedComponents: number;
+  };
+  freshness: {
+    maxAgeSeconds: number;
+  };
+  components: Array<{
+    id: string;
+    label: string;
+    kind: "service";
+    status: ComponentStatus;
+    latencyMs: number;
+    observedAt: string;
+  }>;
+};
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function parsePortalSummary(value: unknown): PortalSummary {
+  assert(typeof value === "object" && value !== null, "Portal summary must be an object");
+  const candidate = value as Record<string, unknown>;
+
+  assert(candidate.status === "ok" || candidate.status === "degraded", "Portal summary status must be 'ok' or 'degraded'");
+  assert(isIsoTimestamp(candidate.generatedAt), "Portal summary generatedAt must be an ISO-8601 timestamp");
+
+  const metrics = candidate.metrics as Record<string, unknown>;
+  assert(typeof metrics === "object" && metrics !== null, "Portal summary metrics must be an object");
+  assert(typeof metrics.totalComponents === "number", "metrics.totalComponents must be a number");
+  assert(typeof metrics.healthyComponents === "number", "metrics.healthyComponents must be a number");
+  assert(typeof metrics.degradedComponents === "number", "metrics.degradedComponents must be a number");
+
+  const freshness = candidate.freshness as Record<string, unknown>;
+  assert(typeof freshness === "object" && freshness !== null, "Portal summary freshness must be an object");
+  assert(typeof freshness.maxAgeSeconds === "number", "freshness.maxAgeSeconds must be a number");
+
+  const components = candidate.components;
+  assert(Array.isArray(components) && components.length > 0, "Portal summary components must be a non-empty array");
+
+  for (const component of components) {
+    assert(typeof component === "object" && component !== null, "Each component must be an object");
+    const entry = component as Record<string, unknown>;
+    assert(typeof entry.id === "string" && entry.id.length > 0, "Each component must have a non-empty id");
+    assert(typeof entry.label === "string" && entry.label.length > 0, "Each component must have a non-empty label");
+    assert(entry.kind === "service", "Each component kind must be 'service'");
+    assert(entry.status === "healthy" || entry.status === "degraded", "Each component status must be 'healthy' or 'degraded'");
+    assert(typeof entry.latencyMs === "number" && entry.latencyMs >= 0, "Each component latencyMs must be a non-negative number");
+    assert(isIsoTimestamp(entry.observedAt), "Each component observedAt must be an ISO-8601 timestamp");
+  }
+
+  return candidate as unknown as PortalSummary;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderHtml(summary: PortalSummary): string {
+  const rows = summary.components
+    .map((component) => {
+      const statusClass = component.status === "healthy" ? "ok" : "warn";
+      return `
+        <tr>
+          <td>${escapeHtml(component.label)}</td>
+          <td>${escapeHtml(component.id)}</td>
+          <td><span class="pill ${statusClass}">${escapeHtml(component.status)}</span></td>
+          <td>${component.latencyMs} ms</td>
+          <td>${escapeHtml(new Date(component.observedAt).toLocaleString())}</td>
+        </tr>`;
+    })
+    .join("");
+
+  const title = summary.status === "ok" ? "IDP status: healthy" : "IDP status: degraded";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)}</title>
+    <style>
+      body { font-family: "Segoe UI", sans-serif; margin: 0; background: #f5f2eb; color: #1f2a37; }
+      main { max-width: 960px; margin: 0 auto; padding: 2rem 1rem 3rem; display: grid; gap: 1rem; }
+      .panel { background: #fffdf8; border: 1px solid rgba(31,42,55,0.08); border-radius: 20px; padding: 1rem 1.25rem; }
+      .hero h1 { margin: 0.5rem 0 0.35rem; font-size: 2rem; }
+      .hero p, .panel p { color: #4f5d75; }
+      .cards { display: grid; gap: 0.85rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+      .card { background: #fffdf8; border: 1px solid rgba(31,42,55,0.08); border-radius: 18px; padding: 1rem; }
+      .card h2 { margin: 0; font-size: 0.95rem; color: #4f5d75; font-weight: 500; }
+      .card strong { display: block; margin-top: 0.6rem; font-size: 1.55rem; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 0.7rem 0.4rem; border-bottom: 1px solid rgba(31,42,55,0.08); }
+      th { color: #4f5d75; font-weight: 600; }
+      .pill { display: inline-block; border-radius: 999px; padding: 0.18rem 0.55rem; font-size: 0.85rem; font-weight: 700; text-transform: capitalize; }
+      .pill.ok { background: rgba(10,123,97,0.12); color: #0a7b61; }
+      .pill.warn { background: rgba(185,87,45,0.12); color: #b9572d; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="panel hero">
+        <p>Stemix external status snapshot</p>
+        <h1>${escapeHtml(title)}</h1>
+        <p>This static page was generated from the live <code>/api/portal/summary</code> contract so it can be hosted independently from the interactive portal runtime.</p>
+      </section>
+      <section class="cards">
+        <article class="card">
+          <h2>Generated</h2>
+          <strong>${escapeHtml(new Date(summary.generatedAt).toLocaleString())}</strong>
+        </article>
+        <article class="card">
+          <h2>Healthy Components</h2>
+          <strong>${summary.metrics.healthyComponents}</strong>
+        </article>
+        <article class="card">
+          <h2>Degraded Components</h2>
+          <strong>${summary.metrics.degradedComponents}</strong>
+        </article>
+        <article class="card">
+          <h2>Freshness</h2>
+          <strong>${summary.freshness.maxAgeSeconds}s</strong>
+        </article>
+      </section>
+      <section class="panel">
+        <h2>Observed components</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>ID</th>
+              <th>Status</th>
+              <th>Latency</th>
+              <th>Observed</th>
+            </tr>
+          </thead>
+          <tbody>${rows}
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>`;
+}
+
+async function main(): Promise<void> {
+  const baseUrl = process.env.IDP_BFF_URL ?? "http://127.0.0.1:8000";
+  const outputDir = path.resolve(process.cwd(), process.env.STATUS_PUBLISH_DIR ?? ".tmp/status-site");
+
+  const response = await fetch(new URL("/api/portal/summary", baseUrl), {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch portal summary: HTTP ${response.status}`);
+  }
+
+  const summary = parsePortalSummary(await response.json());
+  const html = renderHtml(summary);
+  const json = JSON.stringify(summary, null, 2) + "\n";
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(path.join(outputDir, "status.json"), json, "utf8");
+  await fs.writeFile(path.join(outputDir, "index.html"), html, "utf8");
+
+  const [writtenJson, writtenHtml] = await Promise.all([
+    fs.readFile(path.join(outputDir, "status.json"), "utf8"),
+    fs.readFile(path.join(outputDir, "index.html"), "utf8"),
+  ]);
+
+  parsePortalSummary(JSON.parse(writtenJson) as unknown);
+  assert(writtenHtml.includes("<table>"), "Generated HTML must include a component table");
+  assert(writtenHtml.includes(summary.components[0].label), "Generated HTML must include component content");
+
+  process.stdout.write(
+    JSON.stringify({
+      level: "info",
+      msg: "status artifacts generated",
+      outputDir,
+      files: ["status.json", "index.html"],
+    }) + "\n"
+  );
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(
+    JSON.stringify({
+      level: "error",
+      msg: "status artifact generation failed",
+      error: message,
+    }) + "\n"
+  );
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add the API-first IDP status MVP as a shared `/api/portal/summary` contract across the Go BFF, React/Fastify BFF, MCP adapter, portal UI, and static publisher
- add the new `status-profile` contract harness coverage and strengthen `ui-profile` and `mcp-profile` to validate the new status experience end to end
- update roadmap-aware docs in `README.md`, `AGENTS.md`, stack docs, and testing docs so implemented behavior is clearly separated from planned roadmap work

## Validation
- `moon run repo:check-lint-md`
- `npm run typecheck:stack:react-fastify`
- `node_modules\\.bin\\tsc --project tests\\tsconfig.json --noEmit`
- Node stack contract run with `core,operational,status-profile,ui-profile`
- Go stack contract run with `core,operational,status-profile`
- `npm --prefix tools/mcp ci`
- `npm --prefix tools/mcp run typecheck`
- `npm --prefix tools/mcp run build`
- MCP contract run with `mcp-profile`
- `tsx tools/status/publish-status.ts` against a live Go BFF
