### PR TITLE
docs: add GitHub ruleset enforcement context to agent skills

### DIFF
--- a/.claude/skills/audit-work-integrity/SKILL.md
+++ b/.claude/skills/audit-work-integrity/SKILL.md
@@ -199,7 +199,9 @@ Evaluate findings with deterministic rules.
      close/ref verbs.
 2. **Closed-context mismatch** (only when `include_closed=true`)
    - Condition: branch still exists after merged PR where branch deletion
-     policy appears inconsistent.
+     policy appears inconsistent. GitHub rulesets prevent deletion of
+     the `main` branch itself; feature branch auto-deletion after merge
+     is configured separately in repository settings.
 
 ## Step 5: Score and Status
 

--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-changes
-version: 1.3.1
+version: 1.3.2
 description: >
   End-to-end workflow that reviews working tree changes, creates a
   feature branch, commits with strict Conventional Commits format,
@@ -360,6 +360,12 @@ gh pr edit <pr_number> --add-assignee "@me" \
 
 ## Step 13: Wait for Status Checks and Merge
 
+The `main` branch is protected by GitHub rulesets that enforce required status
+checks, at least one approving CODEOWNERS review, resolved conversations, and
+squash-only merges. GitHub will reject any merge attempt that does not satisfy
+these constraints. The checks below serve as pre-flight verification to surface
+failures early.
+
 Before merging, wait for all required PR status checks to pass.
 This is a hard gate: do not merge while any check is failing, cancelled,
 timed out, pending, queued, or in progress.
@@ -389,7 +395,8 @@ gh pr checks <pr_number> --watch --interval 15
 
 This command blocks until all checks complete. If any required check
 fails, stop and report the failing check names and URLs to the user —
-do not merge.
+do not merge. Even if this skill attempted a non-squash merge or merge
+with failing checks, GitHub rulesets would block the operation.
 
 Once all checks pass, use the GitHub MCP `merge_pull_request`
 tool to merge:
@@ -397,7 +404,8 @@ tool to merge:
 - **owner**: repository owner
 - **repo**: repository name
 - **pullNumber**: the PR number from Step 12
-- **merge_method**: `squash`
+- **merge_method**: `squash` (the only permitted method; the repository
+  ruleset enforces linear history via squash merges)
 
 **Fallback**: If the MCP tool is unavailable, use the `gh` CLI:
 

--- a/.claude/skills/triage-community-work/SKILL.md
+++ b/.claude/skills/triage-community-work/SKILL.md
@@ -154,7 +154,8 @@ item can match multiple rules; record every applicable reason.
 4. **Community PR with failing status checks**
    - Condition: PR has one or more failed required status checks.
    - Why: the contributor may not know how to fix CI failures or may
-     not have access to reproduce them.
+     not have access to reproduce them. GitHub rulesets block merge
+     until all required checks pass.
    - Next step: review the failures, comment with guidance on how to
      fix, or push fixes directly if the contributor has granted
      maintainer push access to their fork.
@@ -170,7 +171,8 @@ item can match multiple rules; record every applicable reason.
 6. **Community PR targets wrong base branch**
    - Condition: PR targets a branch other than `main`.
    - Why: community contributors may not know the correct base
-     branch.
+     branch. The `main` branch ruleset only applies to PRs targeting
+     `main`; PRs targeting other branches may bypass protections.
    - Next step: comment explaining the correct base branch and help
      retarget the PR.
 

--- a/.claude/skills/triage-managed-work/SKILL.md
+++ b/.claude/skills/triage-managed-work/SKILL.md
@@ -209,7 +209,8 @@ can match multiple rules; record every applicable reason.
 3. **PR has failing status checks**
    - Condition: PR has one or more failed required status checks.
    - Why: failing checks block merge and may indicate broken code or
-     configuration issues.
+     configuration issues. GitHub rulesets enforce this — the merge
+     button is blocked until all required checks pass.
    - Next step: investigate the failing checks, push fixes, or
      re-run if the failure is transient.
 
@@ -231,7 +232,8 @@ can match multiple rules; record every applicable reason.
 6. **PR has merge conflicts**
    - Condition: PR is not mergeable due to conflicts with the base
      branch.
-   - Why: conflicts block merge and grow worse over time.
+   - Why: conflicts block merge and grow worse over time. The repository
+     ruleset requires linear history, so conflicted PRs cannot be merged.
    - Next step: rebase or merge `base_branch` into the feature branch
      to resolve conflicts.
 


### PR DESCRIPTION
## Summary

- Add GitHub ruleset enforcement context to 4 agent skills:
  **ship-changes**, **triage-managed-work**, **triage-community-work**,
  and **audit-work-integrity**
- Clarifies that merge constraints (required status checks, approving
  reviews, squash-only, conversation resolution) are enforced at the
  GitHub level via rulesets
- Bumps ship-changes skill version to 1.3.2

## Test plan

- [x] `moon run repo:check-lint-md` passes (0 errors across 70 files)
- [x] Verify PR validation checks pass
- [x] Confirm skill instructions are consistent with AGENTS.md
  `### Branch Protection (GitHub Rulesets)` subsection