### PR TITLE
feat(auth-profile): implement mock OAuth round-trip contract tests

### DIFF
--- a/docs/content/testing/contract-harness.md
+++ b/docs/content/testing/contract-harness.md
@@ -92,7 +92,7 @@ tests/
     └── profiles/
         ├── index.ts          Routes a profile name to its test factory
         ├── core.ts           5 baseline tests
-        ├── auth-profile.ts   3 OAuth auth tests
+        ├── auth-profile.ts   5 OAuth auth tests
         ├── operational.ts    5 runtime/semantic tests
         ├── status-profile.ts 3 API-first status tests
         └── ui-profile.ts     5 UI capability tests
@@ -175,7 +175,7 @@ that feeds the portal home page, dedicated status route, MCP
 | `status-profile:portal summary metrics are internally consistent` | aggregate counts and top-level status match the component list |
 | `status-profile:portal summary timestamps and freshness are valid` | timestamps are ISO-8601 and freshness metadata matches component observation ages |
 
-### `auth-profile` — OAuth 2.0 authentication contract (3 tests)
+### `auth-profile` — OAuth 2.0 authentication contract (5 tests)
 
 Optional. Only runs when the stack declares `capabilities.auth.enabled: true`
 in `stack.json`. It validates the observable contract of the BFF auth surface
@@ -184,8 +184,10 @@ when an OAuth provider is active (`OUR_IDP_OAUTH_PROVIDER != "none"`).
 
 | Test | What is checked |
 | --- | --- |
-| `auth-profile:login endpoint initiates the OAuth flow` | `GET /auth/login` returns a 3xx redirect whose `Location` header points at the configured provider authorization URL |
 | `auth-profile:me endpoint returns 401 when unauthenticated` | `GET /auth/me` without a session cookie returns HTTP 401 |
+| `auth-profile:login endpoint initiates the OAuth flow` | `GET /auth/login` returns a 3xx redirect whose `Location` header points at the configured provider authorization URL and includes a `state` parameter |
+| `auth-profile:callback endpoint completes the OAuth flow` | `GET /auth/callback?code=<code>&state=<captured-state>` returns a 3xx redirect and sets the `idp_session` cookie |
+| `auth-profile:me endpoint returns 200 with user JSON when authenticated` | `GET /auth/me` with the `idp_session` cookie returns HTTP 200 with JSON containing a `login` field |
 | `auth-profile:logout endpoint returns 204 and clears session cookie` | `POST /auth/logout` returns HTTP 204; if `Set-Cookie` is present it expires `idp_session` |
 
 ---
@@ -409,7 +411,7 @@ declared profiles on every change.
 
 - **Language / framework**: Go 1.25, standard library `net/http` only
 - **Moon project ID**: `go-net-http-rest`
-- **Profiles**: `core`, `operational`, `status-profile`
+- **Profiles**: `core`, `operational`, `status-profile`, `auth-profile`
 - **Components**: two compiled binaries in `.bin/`
   - `idp-go-web` — serves `GET /`, `GET /health`, binds `127.0.0.1:3000`
   - `idp-go-bff` — serves `GET /`, `GET /health`, `GET /readiness`,

--- a/docs/content/testing/index.md
+++ b/docs/content/testing/index.md
@@ -35,7 +35,7 @@ area of expected behavior. A stack declares which profiles it must pass in its
 | [`status-profile`](./profiles/status-profile) | Status-capable stacks (opt-in) | 3 | API-first IDP status checks for the shared portal summary contract |
 | [`ui-profile`](./profiles/ui-profile) | UI stacks (opt-in) | 5 | Observable HTML output plus rendered status UI behavior |
 | [`mcp-profile`](./profiles/mcp-profile) | MCP servers (opt-in) | 4 | MCP initialize, tool discovery, and tool invocation |
-| [`auth-profile`](./profiles/auth-profile) | Auth-capable stacks (opt-in) | 3 | OAuth 2.0 auth endpoint contract: login redirect, 401 unauthenticated, logout |
+| [`auth-profile`](./profiles/auth-profile) | Auth-capable stacks (opt-in) | 5 | OAuth 2.0 auth endpoint contract: 401 unauthenticated, login redirect, callback round-trip, 200 authenticated, logout |
 
 ## Guides
 

--- a/docs/content/testing/profiles/auth-profile.md
+++ b/docs/content/testing/profiles/auth-profile.md
@@ -13,7 +13,8 @@ provider-dependent and not always enabled in every deployment.
 Auth is a first-class IDP capability, but it requires an active OAuth provider
 (`OUR_IDP_OAUTH_PROVIDER != "none"`) to be meaningful. This profile enforces the
 observable contract of the BFF auth surface — redirect behavior, unauthenticated
-responses, and session cookie cleanup — without requiring a live OAuth round-trip.
+responses, session cookie creation, authenticated responses, and session cookie
+cleanup — using the stateful mock OAuth round-trip.
 
 ## Who must pass it
 
@@ -30,17 +31,7 @@ configured OAuth provider.
 
 Source: [`tests/features/auth-profile.feature`](https://github.com/ourchitecture/idp/blob/main/tests/features/auth-profile.feature)
 
-## Scenarios (3 total)
-
-### Login endpoint initiates the OAuth flow
-
-**Precondition:** The BFF server is running with an OAuth provider configured.
-
-**Assertions:**
-
-- `GET /auth/login` returns an HTTP status code in the 3xx range
-- The `Location` header is present and non-empty
-- The `Location` header points to the configured OAuth provider authorization URL
+## Scenarios (5 total)
 
 ### Me endpoint returns 401 when unauthenticated
 
@@ -49,6 +40,35 @@ Source: [`tests/features/auth-profile.feature`](https://github.com/ourchitecture
 **Assertions:**
 
 - `GET /auth/me` without a session cookie returns HTTP 401
+
+### Login endpoint initiates the OAuth flow
+
+**Precondition:** The BFF server is running with an OAuth provider configured.
+
+**Assertions:**
+
+- `GET /auth/login` returns HTTP 302
+- The `Location` header is present and non-empty
+- The `Location` header points to the configured OAuth provider authorization URL
+- The `Location` URL includes a `state` parameter (captured for the callback test)
+
+### Callback endpoint completes the OAuth flow
+
+**Precondition:** State was captured from the login redirect.
+
+**Assertions:**
+
+- `GET /auth/callback?code=<code>&state=<captured-state>` returns a status code in the 3xx range
+- The response sets the `idp_session` cookie
+
+### Me endpoint returns 200 with user JSON when authenticated
+
+**Precondition:** Session cookie was captured from the callback response.
+
+**Assertions:**
+
+- `GET /auth/me` with the `idp_session` cookie returns HTTP 200
+- The response body is JSON containing a `login` field
 
 ### Logout endpoint accepts requests and clears the session cookie
 
@@ -67,11 +87,20 @@ Source: [`tests/src/profiles/auth-profile.ts`](https://github.com/ourchitecture/
 The TypeScript harness is derived from the `.feature` file above. When they
 disagree, the `.feature` file is authoritative.
 
-The harness uses the zero-dependency HTTP client already present in the contract
-test runner. Because Node.js `http.request` does not follow redirects
-automatically, the 3xx response from `/auth/login` is received and asserted
-directly, including validation that the redirect target matches the configured
-provider authorization URL.
+The harness runs the full mock OAuth round-trip in order:
+
+1. `GET /auth/me` without a cookie — asserts 401.
+2. `GET /auth/login` — asserts a 3xx redirect to the provider, captures the
+   `state` parameter from the `Location` header.
+3. `GET /auth/callback?code=mock-code&state=<captured>` — asserts a 3xx
+   redirect, captures the `idp_session` cookie from `Set-Cookie`.
+4. `GET /auth/me` with the session cookie — asserts 200 and JSON with a `login`
+   field.
+5. `POST /auth/logout` — asserts 204 and that the `idp_session` cookie is
+   expired.
+
+Because Node.js `http.request` does not follow redirects automatically, all 3xx
+responses are received and asserted directly.
 
 ## Stack declarations
 
@@ -101,10 +130,17 @@ capability flag in `stack.json`:
 ## Running the profile
 
 ```sh
-# Start the BFF with a mock OAuth provider, then run contract tests:
+# Terminal 1 – start the mock OAuth service
+cd tools/mock-oauth && ./mvnw spring-boot:run -q
+
+# Terminal 2 – start the BFF with mock provider
+OUR_IDP_OAUTH_PROVIDER=mock make -C stacks/go/net-http/rest run-bff
+
+# Terminal 3 – run only the auth-profile contract tests
 OUR_IDP_OAUTH_PROVIDER=mock \
 IDP_BFF_URL=http://localhost:8000 \
 IDP_STACK_PATH=stacks/go/net-http/rest \
+IDP_CONTRACT_PROFILE=auth-profile \
 npm run test:contract
 ```
 

--- a/stacks/go/net-http/rest/README.md
+++ b/stacks/go/net-http/rest/README.md
@@ -24,9 +24,10 @@ web server and the BFF server.
 - `core`
 - `operational`
 - `status-profile`
+- `auth-profile`
 
-This stack declares status capability, but it does not declare UI capability
-and does not run `ui-profile` tests.
+This stack declares status and auth capabilities, but it does not declare UI
+capability and does not run `ui-profile` tests.
 
 ## Auth Capability (BFF)
 
@@ -48,7 +49,7 @@ fully preserved.
 | Method | Path | Description |
 | --- | --- | --- |
 | `GET` | `/auth/login` | Redirects to the provider authorization URL with a CSRF state value. |
-| `GET` | `/auth/callback` | Exchanges the authorization code, sets an `idp_session` cookie, and returns user JSON. |
+| `GET` | `/auth/callback` | Exchanges the authorization code, sets an `idp_session` cookie, and redirects to `/`. |
 | `POST` | `/auth/logout` | Clears the session and expires the cookie. Returns 204. |
 | `GET` | `/auth/me` | Returns the user profile for the active session, or 401. |
 
@@ -75,7 +76,7 @@ cd tools/mock-oauth && ./mvnw spring-boot:run -q
 # Terminal 2 – start the BFF with mock provider
 OUR_IDP_OAUTH_PROVIDER=mock make -C stacks/go/net-http/rest run-bff
 
-# Initiate login (follow the redirect to /oauth/authorize, then back to /auth/callback)
+# Initiate login (follow redirects: /auth/login → mock /oauth/authorize → /auth/callback → /)
 # Use a cookie jar so the session cookie is saved automatically.
 curl -v -L -c /tmp/idp-cookies.txt http://127.0.0.1:8000/auth/login
 

--- a/stacks/go/net-http/rest/bff/auth.go
+++ b/stacks/go/net-http/rest/bff/auth.go
@@ -357,7 +357,7 @@ func makeCallbackHandler(cfg *oauthConfig) http.HandlerFunc {
 			Secure:   resolveSecureCookie(),
 		})
 
-		writeJSON(w, user)
+		http.Redirect(w, r, "/", http.StatusFound)
 	}
 }
 

--- a/stacks/go/net-http/rest/bff/auth_test.go
+++ b/stacks/go/net-http/rest/bff/auth_test.go
@@ -286,8 +286,14 @@ func TestCallbackHandlerValidFlow(t *testing.T) {
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusFound {
+		t.Errorf("expected 302, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the callback redirects to /.
+	loc := w.Header().Get("Location")
+	if loc != "/" {
+		t.Errorf("expected redirect to /, got %s", loc)
 	}
 
 	// Verify idp_session cookie is set.
@@ -342,8 +348,8 @@ func TestCallbackHandlerStateIsOneTimeUse(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/auth/callback?code=c1&state="+state, nil)
 	w1 := httptest.NewRecorder()
 	handler.ServeHTTP(w1, req1)
-	if w1.Code != http.StatusOK {
-		t.Fatalf("first callback should succeed, got %d", w1.Code)
+	if w1.Code != http.StatusFound {
+		t.Fatalf("first callback should succeed with 302, got %d", w1.Code)
 	}
 
 	// Replay with the same state must be rejected.

--- a/stacks/go/net-http/rest/stack.json
+++ b/stacks/go/net-http/rest/stack.json
@@ -5,7 +5,8 @@
   "contractProfiles": [
     "core",
     "operational",
-    "status-profile"
+    "status-profile",
+    "auth-profile"
   ],
   "capabilities": {
     "status": {

--- a/tests/features/auth-profile.feature
+++ b/tests/features/auth-profile.feature
@@ -12,15 +12,27 @@ Feature: Auth profile — OAuth 2.0 authentication contract
     And the stack declares capabilities.auth.enabled = true in stack.json
     And the BFF is configured with an OAuth provider (OUR_IDP_OAUTH_PROVIDER != "none")
 
-  Scenario: Login endpoint initiates the OAuth flow
-    When the client sends GET /auth/login to the BFF server
-    Then the response status code is in the 3xx range
-    And the response Location header is present and non-empty
-    And the Location header points to the configured OAuth provider authorization URL
-
   Scenario: Me endpoint returns 401 when the request is unauthenticated
     When the client sends GET /auth/me to the BFF server without a session cookie
     Then the response status code is 401
+
+  Scenario: Login endpoint initiates the OAuth flow
+    When the client sends GET /auth/login to the BFF server
+    Then the response status code is 302
+    And the response Location header is present and non-empty
+    And the Location header points to the configured OAuth provider authorization URL
+
+  Scenario: Callback endpoint completes the OAuth flow
+    Given the client has performed GET /auth/login and captured the state parameter from the Location header
+    When the client sends GET /auth/callback with a valid code and the captured state to the BFF server
+    Then the response status code is in the 3xx range
+    And the response sets the idp_session cookie
+
+  Scenario: Me endpoint returns 200 with user JSON when authenticated
+    Given the client has completed the OAuth callback and holds an idp_session cookie
+    When the client sends GET /auth/me to the BFF server with the session cookie
+    Then the response status code is 200
+    And the response body is JSON containing a login field
 
   Scenario: Logout endpoint accepts requests and clears the session cookie
     When the client sends POST /auth/logout to the BFF server

--- a/tests/src/http.ts
+++ b/tests/src/http.ts
@@ -34,13 +34,23 @@ function collectResponse(res: http.IncomingMessage): Promise<ResponsePayload> {
   });
 }
 
-export function request(url: URL): Promise<ResponsePayload> {
+export function request(
+  url: URL,
+  extraHeaders?: Record<string, string>
+): Promise<ResponsePayload> {
   const client = url.protocol === "https:" ? https : http;
 
   return new Promise((resolve, reject) => {
-    const req = client.request(url, { method: "GET" }, (res) => {
-      collectResponse(res).then(resolve).catch(reject);
-    });
+    const req = client.request(
+      url,
+      {
+        method: "GET",
+        headers: { ...extraHeaders },
+      },
+      (res) => {
+        collectResponse(res).then(resolve).catch(reject);
+      }
+    );
 
     req.on("error", reject);
     req.end();

--- a/tests/src/profiles/auth-profile.ts
+++ b/tests/src/profiles/auth-profile.ts
@@ -35,7 +35,24 @@ export function createAuthProfileTests(context: ContractContext): TestCase[] {
   const { bffBaseUrl } = context;
   const expectedAuthorizationUrl = resolveExpectedAuthorizationUrl();
 
+  // Shared state captured across sequential tests.
+  let capturedState = "";
+  let capturedSessionCookie = "";
+
   return [
+    {
+      name: "auth-profile:me endpoint returns 401 when unauthenticated",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(new URL("/auth/me", bffBaseUrl));
+
+        if (response.status !== 401) {
+          throw new Error(
+            `Expected 401 from /auth/me without a session cookie, got ${response.status}`
+          );
+        }
+      },
+    },
     {
       name: "auth-profile:login endpoint initiates the OAuth flow",
       run: async () => {
@@ -74,17 +91,81 @@ export function createAuthProfileTests(context: ContractContext): TestCase[] {
             `Expected /auth/login redirect to point to ${expectedAuthorizationUrl.toString()}, got ${redirectUrl.toString()}`
           );
         }
+
+        const state = redirectUrl.searchParams.get("state");
+        if (!state) {
+          throw new Error(
+            "Expected a state parameter in the /auth/login redirect URL"
+          );
+        }
+        capturedState = state;
       },
     },
     {
-      name: "auth-profile:me endpoint returns 401 when unauthenticated",
+      name: "auth-profile:callback endpoint completes the OAuth flow",
       run: async () => {
-        await ensureServiceAvailable("BFF server", bffBaseUrl);
-        const response = await request(new URL("/auth/me", bffBaseUrl));
-
-        if (response.status !== 401) {
+        if (!capturedState) {
           throw new Error(
-            `Expected 401 from /auth/me without a session cookie, got ${response.status}`
+            "auth-profile:callback requires state captured from the login test"
+          );
+        }
+
+        const callbackUrl = new URL("/auth/callback", bffBaseUrl);
+        callbackUrl.searchParams.set("code", "mock-code");
+        callbackUrl.searchParams.set("state", capturedState);
+
+        const response = await request(callbackUrl);
+
+        if (response.status < 300 || response.status >= 400) {
+          throw new Error(
+            `Expected 3xx redirect from /auth/callback, got ${response.status}`
+          );
+        }
+
+        const setCookie = response.headers["set-cookie"] ?? "";
+        const match = /idp_session=([^;,\s]+)/i.exec(setCookie);
+        if (!match) {
+          throw new Error(
+            "Expected idp_session cookie to be set by /auth/callback"
+          );
+        }
+        capturedSessionCookie = `idp_session=${match[1]}`;
+      },
+    },
+    {
+      name: "auth-profile:me endpoint returns 200 with user JSON when authenticated",
+      run: async () => {
+        if (!capturedSessionCookie) {
+          throw new Error(
+            "auth-profile:me authenticated requires session cookie captured from the callback test"
+          );
+        }
+
+        const response = await request(new URL("/auth/me", bffBaseUrl), {
+          Cookie: capturedSessionCookie,
+        });
+
+        if (response.status !== 200) {
+          throw new Error(
+            `Expected 200 from /auth/me with a session cookie, got ${response.status}`
+          );
+        }
+
+        let body: unknown;
+        try {
+          body = JSON.parse(response.body);
+        } catch {
+          throw new Error("Expected JSON body from /auth/me with session");
+        }
+
+        if (
+          typeof body !== "object" ||
+          body === null ||
+          !("login" in body) ||
+          typeof (body as Record<string, unknown>).login !== "string"
+        ) {
+          throw new Error(
+            "Expected /auth/me response body to be JSON containing a login field"
           );
         }
       },


### PR DESCRIPTION
Add the full Layer 1 spec, Layer 2 harness, and Go BFF changes required
by issue #57 to verify the stateful mock OAuth flow end-to-end.

Layer 1 (tests/features/auth-profile.feature):
- Reorder scenarios to reflect the natural OAuth flow
- Add: callback endpoint completes the OAuth flow (3xx + idp_session cookie)
- Add: me endpoint returns 200 with user JSON when authenticated

Layer 2 (tests/src/profiles/auth-profile.ts):
- Run tests in order: unauthenticated me → login (capture state) →
  callback (capture session cookie) → authenticated me → logout
- Share captured state and session cookie across sequential tests via closures

tests/src/http.ts:
- Add optional extraHeaders param to request() to support Cookie injection

Go BFF (stacks/go/net-http/rest/bff/auth.go):
- Change callback success path from writeJSON(user) to http.Redirect(/, 302)

Go BFF tests (stacks/go/net-http/rest/bff/auth_test.go):
- Update TestCallbackHandlerValidFlow and TestCallbackHandlerStateIsOneTimeUse
  to expect 302 and assert the redirect Location header

stack.json: add auth-profile to contractProfiles
README.md: update callback route description and profile list
Docs: update auth-profile.md (5 scenarios), contract-harness.md, index.md

Closes #57

https://claude.ai/code/session_013btmX7iXRDmMeKGBWxpUp9