### PR TITLE
feat(go-net-http-rest): add local auth contract validation targets

### DIFF
--- a/scripts/ci/run-contract-check.py
+++ b/scripts/ci/run-contract-check.py
@@ -24,9 +24,16 @@ Required environment variables:
     ROOT_DIR          Repo root directory (used for npm --prefix)
 
 Optional environment variables:
-    CONTRACT_PROFILES Comma-separated contract profile names
-    READY_TIMEOUT     Seconds to wait for readiness (default: 120)
-    READY_INTERVAL    Polling interval in seconds (default: 1)
+    MOCK_OAUTH_START_CMD  Shell command to start a mock OAuth server.
+                          When set, MOCK_OAUTH_URL is also required.
+                          The mock OAuth server is started before the
+                          BFF and torn down with the other servers.
+    MOCK_OAUTH_URL        Base URL for the mock OAuth server
+                          (e.g. http://127.0.0.1:9000). Used for the
+                          readiness check at MOCK_OAUTH_URL/health.
+    CONTRACT_PROFILES     Comma-separated contract profile names
+    READY_TIMEOUT         Seconds to wait for readiness (default: 120)
+    READY_INTERVAL        Polling interval in seconds (default: 1)
 """
 
 import atexit
@@ -34,9 +41,11 @@ import os
 import re
 import shlex
 import signal
+import socket
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 import urllib.error
 
@@ -50,6 +59,8 @@ BFF_START_CMD = os.environ.get("BFF_START_CMD")
 WEB_URL = os.environ.get("WEB_URL")
 BFF_URL = os.environ.get("BFF_URL")
 ROOT_DIR = os.environ.get("ROOT_DIR")
+MOCK_OAUTH_START_CMD = os.environ.get("MOCK_OAUTH_START_CMD", "")
+MOCK_OAUTH_URL = os.environ.get("MOCK_OAUTH_URL", "")
 CONTRACT_PROFILES = os.environ.get("CONTRACT_PROFILES", "")
 READY_TIMEOUT = int(os.environ.get("READY_TIMEOUT", "120"))
 READY_INTERVAL = int(os.environ.get("READY_INTERVAL", "1"))
@@ -60,6 +71,14 @@ for var in ("STACK_PATH", "WEB_START_CMD", "BFF_START_CMD",
         print(f"[contract:{STACK_PATH or '?'}] ERROR: {var} is required",
               file=sys.stderr)
         sys.exit(1)
+
+if MOCK_OAUTH_START_CMD and not MOCK_OAUTH_URL:
+    print(
+        f"[contract:{STACK_PATH}] ERROR: MOCK_OAUTH_URL is required when "
+        "MOCK_OAUTH_START_CMD is set",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 READINESS_PATH = "/readiness"
 BFF_READY_URL = BFF_URL.rstrip("/") + READINESS_PATH
@@ -117,6 +136,34 @@ signal.signal(signal.SIGINT, _signal_handler)
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _url_hostport(url: str) -> tuple[str, int]:
+    """Return (host, port) parsed from a URL string."""
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return host, port
+
+
+def check_port_free(host: str, port: int, label: str) -> bool:
+    """Return True when the TCP port is free; print an error and return False if in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1)
+        result = s.connect_ex((host, port))
+    if result == 0:
+        print(
+            f"[contract:{STACK_PATH}] ERROR: {label} port {port} is already "
+            f"in use on {host}.",
+            file=sys.stderr,
+        )
+        print(
+            f"[contract:{STACK_PATH}]   Stop the process using port {port} "
+            "before running this target.",
+            file=sys.stderr,
+        )
+        return False
+    return True
 
 
 def log(msg: str) -> None:
@@ -234,12 +281,40 @@ def main() -> int:
     log_section(f"Starting contract check: {STACK_PATH}")
     log(f"Web URL:  {WEB_URL}")
     log(f"BFF URL:  {BFF_URL}")
+    if MOCK_OAUTH_URL:
+        log(f"Mock OAuth URL: {MOCK_OAUTH_URL}")
     if CONTRACT_PROFILES:
         log(f"Profiles: {CONTRACT_PROFILES}")
+
+    # --- Pre-flight port checks -----------------------------------------------
+
+    log_section("Pre-flight port check")
+    port_checks = [
+        ("Web server",  *_url_hostport(WEB_URL)),
+        ("BFF server",  *_url_hostport(BFF_URL)),
+    ]
+    if MOCK_OAUTH_URL:
+        port_checks.append(("Mock OAuth server", *_url_hostport(MOCK_OAUTH_URL)))
+    for label, host, port in port_checks:
+        if not check_port_free(host, port, label):
+            return 1
+    log("All required ports are free")
 
     # --- Start servers -------------------------------------------------------
 
     log_section("Starting servers")
+    if MOCK_OAUTH_START_CMD:
+        mock_proc = start_server(MOCK_OAUTH_START_CMD, "Mock OAuth server")
+        mock_ready_url = MOCK_OAUTH_URL.rstrip("/") + "/health"
+        log_section("Waiting for Mock OAuth readiness")
+        if not wait_for_ready("Mock OAuth readiness", mock_ready_url,
+                              READY_TIMEOUT, READY_INTERVAL, mock_proc):
+            print(
+                f"[contract:{STACK_PATH}] FAIL: Mock OAuth did not become ready"
+                " -- aborting test run",
+                file=sys.stderr,
+            )
+            return 1
     bff_proc = start_server(BFF_START_CMD, "BFF server")
     start_server(WEB_START_CMD, "Web server")
 

--- a/stacks/go/net-http/rest/Makefile
+++ b/stacks/go/net-http/rest/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all install build clean lint check-lint check-test check-contract check-ci check test test-contract run-web run-bff setup-debug-tools build-web build-bff build-debug-web build-debug-bff build-container-web build-container-bff build-containers
+.PHONY: help all install build clean lint check-lint check-test check-contract check-ci check test test-contract run-web run-bff setup-debug-tools build-web build-bff build-debug-web build-debug-bff build-container-web build-container-bff build-containers check-java build-mock-oauth check-contract-auth
 
 ROOT_DIR := ../../../..
 BIN_DIR := .bin
@@ -7,6 +7,9 @@ WEB_TEST_HOST := 127.0.0.1
 BFF_TEST_HOST := 127.0.0.1
 WEB_TEST_PORT := 3300
 BFF_TEST_PORT := 8300
+MOCK_OAUTH_DIR := $(ROOT_DIR)/tools/mock-oauth
+MOCK_OAUTH_JAR := $(MOCK_OAUTH_DIR)/target/mock-oauth.jar
+MOCK_OAUTH_PORT ?= 9000
 CONTAINER_LOCAL_PREFIX := localhost
 CONTAINER_IMAGE_BASE := stemix-go-net-http-rest
 PROTO_HOME ?= $(HOME)/.proto
@@ -46,6 +49,9 @@ help:
 	@printf "  build-container-web Build web container image (requires docker)\n"
 	@printf "  build-container-bff Build BFF container image (requires docker)\n"
 	@printf "  build-containers  Build all container images (requires docker)\n"
+	@printf "  check-java        Verify java is in PATH (fail fast with install hint)\n"
+	@printf "  build-mock-oauth  Build the mock OAuth JAR (requires java)\n"
+	@printf "  check-contract-auth Run auth-profile end-to-end contract validation\n"
 
 all:
 	@if [ -x "$(MOON_BIN)" ]; then \
@@ -205,3 +211,30 @@ build-container-bff:
 		.
 
 build-containers: build-container-web build-container-bff
+
+check-java:
+	@if ! command -v java >/dev/null 2>&1; then \
+		echo "ERROR: java is required but not found in PATH." >&2; \
+		echo "  Install Java 21 or later: https://adoptium.net/" >&2; \
+		exit 1; \
+	fi
+
+build-mock-oauth: check-java
+	@"$(MAKE)" -C "$(MOCK_OAUTH_DIR)" build
+
+check-contract-auth:
+	@if [ -x "$(MOON_BIN)" ]; then \
+		"$(MOON_BIN)" run go-net-http-rest:check-contract-auth; \
+	else \
+		"$(MAKE)" build-web build-bff build-mock-oauth; \
+		STACK_PATH="$(STACK_PATH)" \
+		WEB_START_CMD='OUR_IDP_WEB_HOST="$(WEB_TEST_HOST)" OUR_IDP_PORT="$(WEB_TEST_PORT)" env -- "$(abspath $(WEB_BIN))"' \
+		BFF_START_CMD='OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" OUR_IDP_STATUS_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" OUR_IDP_OAUTH_PROVIDER=mock MOCK_OAUTH_PORT="$(MOCK_OAUTH_PORT)" OUR_IDP_OAUTH_REDIRECT_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)/auth/callback" env -- "$(abspath $(BFF_BIN))"' \
+		MOCK_OAUTH_START_CMD='java -jar "$(abspath $(MOCK_OAUTH_JAR))"' \
+		MOCK_OAUTH_URL="http://127.0.0.1:$(MOCK_OAUTH_PORT)" \
+		WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" \
+		BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" \
+		CONTRACT_PROFILES=auth-profile \
+		ROOT_DIR="$(ROOT_DIR)" \
+		python3 "$(ROOT_DIR)/scripts/ci/run-contract-check.py"; \
+	fi

--- a/stacks/go/net-http/rest/moon.yml
+++ b/stacks/go/net-http/rest/moon.yml
@@ -80,3 +80,38 @@ tasks:
     deps: ["build-container-web", "build-container-bff"]
     options:
       runInCI: false
+  check-java:
+    command:
+      - "bash"
+      - "-c"
+      - >-
+        command -v java >/dev/null 2>&1 ||
+        { echo 'ERROR: java is required but not found in PATH.
+        Install Java 21+: https://adoptium.net/' >&2; exit 1; }
+  build-mock-oauth:
+    command: ["bash", "-c", "true"]
+    deps:
+      - "check-java"
+      - "mock-oauth:build"
+  check-contract-auth:
+    command: ["python3", "../../../../scripts/ci/run-contract-check.py"]
+    deps: ["build", "build-mock-oauth"]
+    env:
+      STACK_PATH: "stacks/go/net-http/rest"
+      WEB_START_CMD: "OUR_IDP_WEB_HOST=127.0.0.1 OUR_IDP_PORT=3300 env -- .bin/idp-go-web"
+      BFF_START_CMD: >-
+        OUR_IDP_API_HOST=127.0.0.1
+        OUR_IDP_API_PORT=8300
+        OUR_IDP_STATUS_WEB_URL=http://127.0.0.1:3300
+        OUR_IDP_OAUTH_PROVIDER=mock
+        MOCK_OAUTH_PORT=9000
+        OUR_IDP_OAUTH_REDIRECT_URL=http://127.0.0.1:8300/auth/callback
+        env -- .bin/idp-go-bff
+      MOCK_OAUTH_START_CMD: "java -jar ../../../../tools/mock-oauth/target/mock-oauth.jar"
+      MOCK_OAUTH_URL: "http://127.0.0.1:9000"
+      WEB_URL: "http://127.0.0.1:3300"
+      BFF_URL: "http://127.0.0.1:8300"
+      CONTRACT_PROFILES: "auth-profile"
+      ROOT_DIR: "../../../.."
+    options:
+      runInCI: false


### PR DESCRIPTION
Add check-java, build-mock-oauth, and check-contract-auth Make/moon
targets to the Go stack. check-contract-auth builds the stack and the
mock OAuth JAR, starts all three processes (web, mock-oauth, BFF) with
OUR_IDP_OAUTH_PROVIDER=mock and OUR_IDP_OAUTH_REDIRECT_URL set for
the local callback path, runs the auth-profile contract suite via
IDP_CONTRACT_PROFILES=auth-profile, and tears down all processes
reliably on success or failure. The target is deliberately excluded
from check, all, and check-ci so it never runs in automated CI.

Extend run-contract-check.py with optional MOCK_OAUTH_START_CMD /
MOCK_OAUTH_URL support and add pre-flight port-in-use checks for all
server ports (web, BFF, mock-oauth) so conflicts surface immediately
with a clear error message before any process is started.

Refs #58