### PR TITLE
docs(auth): revise cross-stack oauth architecture wording

### DIFF
--- a/docs/content/architecture/decisions/0013-oauth-plugin-architecture.md
+++ b/docs/content/architecture/decisions/0013-oauth-plugin-architecture.md
@@ -64,18 +64,20 @@ surface). The intake threshold is met.
 ## Considered Options
 
 - Bundle a single fixed OAuth provider in the BFF (no plug-in model)
-- Use an external OAuth library (e.g., `golang.org/x/oauth2`) for the
-  reference implementation
 - Implement auth as an optional plug-in selected by environment variable,
-  using only Go standard library HTTP primitives
+  with each stack free to choose its own OAuth client implementation
+- Implement auth as an optional plug-in selected by environment variable,
+  using only Go standard library HTTP primitives in every reference stack
 
 ## Decision Outcome
 
 Chosen option: "Implement auth as an optional plug-in selected by environment
-variable, using only Go standard library HTTP primitives", because it keeps the
-default BFF free of auth dependencies, avoids external library version drift,
-and enables automated contract testing through a dedicated mock OAuth service
-without requiring a browser.
+variable, with each stack free to choose its own OAuth client implementation",
+because the durable decision is the shared auth contract, not a single library
+choice. This keeps the default BFF free of mandatory auth configuration,
+preserves a single provider-selection model across stacks, and still enables
+automated contract testing through the dedicated mock OAuth service without
+requiring a browser.
 
 ### Provider Selection
 
@@ -111,12 +113,19 @@ behavior is preserved exactly when `OUR_IDP_OAUTH_PROVIDER` is absent.
 | Secure | Controlled by `OUR_IDP_OAUTH_SECURE_COOKIE=true`; defaults to `false` for local HTTP |
 | Path | `/` |
 
-### Go Reference Implementation
+### Reference Stack Implementations
 
-The Go reference stack (`stacks/go/net-http/rest`) resolves provider
-endpoints from environment variables rather than importing an external OAuth
-library. This keeps the dependency graph minimal and makes endpoint URLs
-fully overridable for testing.
+The auth contract is shared across reference stacks, but the OAuth client
+implementation remains a stack-level detail. A stack may use standard-library
+HTTP primitives, a maintained ecosystem OAuth client, or a framework-native
+integration as long as it preserves the published contract defined in this ADR
+and passes `auth-profile`.
+
+The current Go reference stack (`stacks/go/net-http/rest`) resolves provider
+endpoints from environment variables and presently implements the flow with
+repo-local logic. A follow-on refactor may adopt `golang.org/x/oauth2`
+without requiring another contract change, because the library choice is not
+itself part of the durable architecture.
 
 Provider endpoint variables used by the `mock` provider:
 
@@ -131,9 +140,10 @@ The `github` provider uses fixed GitHub API URLs and requires
 `OUR_IDP_OAUTH_CLIENT_ID`, `OUR_IDP_OAUTH_CLIENT_SECRET`, and
 `OUR_IDP_OAUTH_REDIRECT_URL`.
 
-This is an implementation detail of the Go reference stack. Other stack
-implementations are free to use their ecosystem's OAuth libraries as long as
-they satisfy the auth-profile contract.
+Other stacks are expected to follow the same contract while selecting the
+implementation approach that best matches their ecosystem. The Node.js React +
+Fastify reference stack, for example, may use maintained Fastify-compatible
+OAuth and session libraries when its auth capability is implemented.
 
 ### Mock OAuth Service for Automated Testing
 
@@ -191,8 +201,9 @@ in CI.
   variables, making the test harness portable across CI and local environments
 - Good, because the opt-in `auth-profile` model means non-auth stacks never
   fail auth contract checks
-- Good, because the Go reference stack avoids external OAuth library
-  dependency drift by using only standard library HTTP primitives
+- Good, because the architecture stays focused on stable behavior while
+  allowing each stack to adopt the OAuth client approach that best fits its
+  ecosystem
 - Bad, because each new provider requires an explicit implementation in the BFF
   — there is no generic OIDC auto-discovery in this MVP
 - Bad, because the mock OAuth service requires Java 21, which is not managed
@@ -223,16 +234,7 @@ in CI.
 - Bad, because switching providers requires code changes
 - Bad, because contract tests cannot run without a specific provider
 
-### Use an external OAuth library
-
-- Good, because reduces boilerplate for token exchange and PKCE
-- Good, because library handles edge cases (token refresh, error formats)
-- Bad, because adds an external dependency that must be versioned and audited
-- Bad, because library abstractions may not expose all endpoint URLs needed
-  for test overrides
-- Bad, because PKCE and advanced flows are out of scope for this MVP
-
-### Optional plug-in selected by environment variable (chosen)
+### Optional plug-in selected by environment variable with stack-specific implementation choice (chosen)
 
 - Good, because default deployment is auth-free with no code or env changes
 - Good, because a single `OUR_IDP_OAUTH_PROVIDER` variable controls the
@@ -242,14 +244,32 @@ in CI.
   browser or live external service
 - Good, because endpoint URL overrides allow the same BFF binary to target
   different environments without recompilation
+- Good, because the durable contract stays stable even if one stack later
+  migrates from repo-local HTTP handling to a maintained OAuth library
+- Good, because stack implementations can adopt ecosystem libraries for
+  protocol handling, session integration, or framework ergonomics
 - Bad, because each new provider must be explicitly implemented in BFF code
+- Bad, because ecosystem-library choices still add dependency review and
+  version-maintenance overhead inside each stack that adopts them
+
+### Optional plug-in selected by environment variable using only Go standard library HTTP primitives in every stack
+
+- Good, because avoids external OAuth dependency drift entirely
+- Good, because makes the implementation model uniform across stacks
+- Bad, because pushes protocol and error-handling edge cases into each stack's
+  custom code
+- Bad, because it constrains non-Go stacks to implementation rules that do not
+  naturally match their ecosystem
+- Bad, because the library choice is reversible implementation detail, not the
+  durable decision this ADR needs to record
 
 ## More Information
 
 ### Future Extension Path
 
-This ADR covers the current MVP scope: `mock` and `github` providers, with
-session-cookie-based state. Future work may include:
+This ADR covers the current auth contract scope: `mock` and `github`
+providers, with session-cookie-based state and opt-in `auth-profile`
+conformance. Future work may include:
 
 - General OIDC federation (Okta, Azure AD, Google) — requires provider
   auto-discovery from the OIDC well-known configuration endpoint

--- a/docs/content/testing/contract-harness.md
+++ b/docs/content/testing/contract-harness.md
@@ -182,6 +182,9 @@ in `stack.json`. It validates the observable contract of the BFF auth surface
 when an OAuth provider is active (`OUR_IDP_OAUTH_PROVIDER != "none"`).
 `provider=none` behavior is out of scope.
 
+The profile is stack-agnostic. Today the Go reference stack declares it, and
+future stacks may declare it once they expose the same auth contract.
+
 | Test | What is checked |
 | --- | --- |
 | `auth-profile:me endpoint returns 401 when unauthenticated` | `GET /auth/me` without a session cookie returns HTTP 401 |
@@ -435,6 +438,8 @@ make -C stacks/go/net-http/rest run-bff
 - **Moon project ID**: `nodejs-react-fastify-rest`
 - **Profiles**: `core`, `operational`, `status-profile`, `ui-profile`
   (`ui.mode: spa`)
+- **Auth status**: does not yet declare `auth-profile`; when auth is added it
+  must follow the same shared contract used by the Go reference stack
 - **Components**:
   - `web/server.ts` — Vite dev server serving the React SPA, binds
     `127.0.0.1:3000`

--- a/docs/content/testing/profiles/auth-profile.md
+++ b/docs/content/testing/profiles/auth-profile.md
@@ -16,10 +16,15 @@ observable contract of the BFF auth surface — redirect behavior, unauthenticat
 responses, session cookie creation, authenticated responses, and session cookie
 cleanup — using the stateful mock OAuth round-trip.
 
-## MVP scope
+## Current provider scope
 
-This MVP covers **GitHub OAuth login only**. General OIDC federation (Okta,
-Azure AD, Google, etc.) is out of scope for this iteration.
+The current contract covers two provider modes:
+
+- `mock` for automated testing against the local mock OAuth service
+- `github` for real GitHub OAuth App flows
+
+General OIDC federation (Okta, Azure AD, Google, etc.) remains out of scope
+for this iteration.
 
 The BFF `OUR_IDP_OAUTH_PROVIDER` environment variable currently accepts two
 values:
@@ -30,8 +35,8 @@ values:
 | `github` | Real GitHub OAuth App flow (requires a live GitHub App and a browser) |
 
 Future providers would each require a separate provider implementation in the
-BFF. No provider auto-discovery or general OIDC federation is included in this
-release.
+BFF or an approved follow-on architecture change. No provider auto-discovery or
+general OIDC federation is included in the current contract.
 
 ## Who must pass it
 
@@ -148,11 +153,13 @@ capability flag in `stack.json`:
 
 The following tools must be installed before running the auth profile locally.
 Only the items marked **not managed by proto** require separate installation.
+The current runnable example commands below use the Go reference stack, which
+is the auth-capable stack implemented today.
 
 | Tool | Version | Managed by proto? | Notes |
 | --- | --- | --- | --- |
 | Java (JDK) | 21 | **No** | Required to build and run the mock OAuth service. Install via [SDKMAN](https://sdkman.io/), a system package manager, or a direct [Temurin JDK download](https://adoptium.net/). |
-| Go | Current (see `.prototools`) | Yes | Required to run the BFF server. |
+| Go | Current (see `.prototools`) | Yes | Required for the current auth-capable reference-stack examples in this guide. |
 | Node.js | Current (see `.prototools`) | Yes | Required to run the contract test harness. |
 
 > **Java 21 is not managed by `proto` for this MVP.** The `.prototools` file
@@ -195,7 +202,7 @@ Requires Java 21 (see [Prerequisites](#prerequisites) above).
 # Terminal 1 – start the mock OAuth service (requires Java 21)
 cd tools/mock-oauth && ./mvnw spring-boot:run -q
 
-# Terminal 2 – start the BFF with mock provider
+# Terminal 2 – start the current Go BFF example with mock provider
 OUR_IDP_OAUTH_PROVIDER=mock make -C stacks/go/net-http/rest run-bff
 
 # Terminal 3 – run only the auth-profile contract tests
@@ -208,6 +215,10 @@ npm run test:contract
 
 The contract test harness performs the full OAuth round-trip programmatically —
 no browser interaction is required.
+
+The contract itself is stack-agnostic. Any future stack that declares
+`"auth-profile"` in `contractProfiles` and `capabilities.auth.enabled = true`
+must satisfy the same observable behavior.
 
 ### Real GitHub OAuth (manual — GitHub App required)
 

--- a/stacks/go/net-http/rest/README.md
+++ b/stacks/go/net-http/rest/README.md
@@ -36,6 +36,10 @@ The BFF supports an optional OAuth plug-in selected by the
 set to `none`, no auth routes are registered and the default server behavior is
 fully preserved.
 
+This auth surface follows the shared contract described by ADR-0013 and
+`auth-profile`; other auth-capable stacks may implement the same behavior with
+different stack-native libraries.
+
 ### Providers
 
 | Value | Description |

--- a/stacks/nodejs/react-fastify/rest/README.md
+++ b/stacks/nodejs/react-fastify/rest/README.md
@@ -31,6 +31,16 @@ Rendered `ui-profile` checks use a local Chromium-family browser; set
 `IDP_UI_BROWSER_PATH` if Chrome or Edge cannot be auto-detected on the current
 machine.
 
+## Auth Capability Status
+
+This stack does not yet implement the optional OAuth auth surface and does not
+currently declare `auth-profile`.
+
+When auth support lands, it should follow the shared ADR-0013 / `auth-profile`
+contract used by auth-capable stacks: `OUR_IDP_OAUTH_PROVIDER`,
+`/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/me`, and the
+`idp_session` cookie contract.
+
 ## Commands
 
 Moon (maintainer/CI canonical):

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,9 @@ the required HTTP endpoints.
 - `auth-profile`: OAuth 2.0 auth endpoint checks for stacks that declare auth
   capability and run with a configured provider
 
+`auth-profile` is a shared cross-stack contract even though the current
+automated example path uses the Go reference stack.
+
 By default, the harness runs `core` + `operational`, and only runs opt-in
 profiles such as `status-profile`, `ui-profile`, and `auth-profile` when both:
 
@@ -75,7 +78,8 @@ Example for a specific stack and explicit profile set:
 IDP_STACK_PATH="stacks/nodejs/react-fastify/rest" IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile" npm run test:contract
 ```
 
-Example for the auth profile against the Go stack with the mock provider:
+Example for the auth profile against the current Go auth-capable stack with the
+mock provider:
 
 ```bash
 OUR_IDP_OAUTH_PROVIDER=mock IDP_STACK_PATH="stacks/go/net-http/rest" IDP_CONTRACT_PROFILE="auth-profile" npm run test:contract


### PR DESCRIPTION
Update ADR-0013 to treat the auth contract as the durable decision while leaving OAuth client choice to each reference stack.

Align the shared auth guides and stack READMEs so they no longer imply a permanent Go-only or stdlib-only implementation model.

Closes #97