### PR TITLE
fix: resolve Dependabot lodash vulnerability alerts

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17785,15 +17785,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -52,7 +52,8 @@
     "node": ">=20.0.0"
   },
   "overrides": {
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
     "serialize-javascript": "7.0.5",
     "magic-string": "^0.30.0"
   }


### PR DESCRIPTION
## Summary

- Updates `lodash` override from `4.17.21` → `4.18.1` in `docs/package.json`
- Adds `lodash-es` override at `4.18.1` in `docs/package.json`
- Resolves all 5 open Dependabot alerts: CVE-2025-13465, CVE-2026-2950 (×2), CVE-2026-4800 (×2)

Closes #149

## Test plan

- [x] `npm install` succeeds without deprecation warnings
- [x] `npm audit` shows no lodash-related vulnerabilities
- [x] All lodash/lodash-es instances resolve to 4.18.1 (`npm ls lodash`)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>