### PR TITLE
docs(flow): define provider adapter contract for MVP flow inputs

### DIFF
--- a/docs/content/flow/adapter-contract.md
+++ b/docs/content/flow/adapter-contract.md
@@ -1,0 +1,331 @@
+---
+sidebar_position: 6
+---
+
+# Provider Adapter Contract
+
+The provider adapter contract defines the normalized output that every source
+control and CI provider adapter must produce. The signal inference engine
+consumes these normalized types and never interacts with raw provider shapes.
+
+This contract is not the semantic core, not the API contract, and not the
+storage schema. It is the boundary that keeps adapters thin and the core
+provider-neutral.
+
+## Position in the architecture
+
+```text
+Provider API (GitHub / GitLab)
+        │
+        ▼
+   Provider Adapter
+   (normalizes to this contract)
+        │
+        ▼
+   Normalized Input Types  ← defined here
+        │
+        ▼
+   Signal Inference Engine
+        │
+        ▼
+   HTTP API / MCP Tools
+```
+
+Every type in this contract maps to one or more concepts from the
+[canonical flow model](./model). No type introduces a concept not needed by at
+least one of the six MVP signals in the [signal catalog](./signals).
+
+## Normalized input types
+
+### NormalizedRepository
+
+Maps to: work item scope, ownership context.
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `provider` | yes | enum: `github`, `gitlab` | Identifies the provider system |
+| `provider_id` | yes | string | Provider-scoped stable identifier |
+| `full_name` | yes | string | e.g. `org/repo` |
+| `default_branch` | yes | string | Trunk branch name |
+| `visibility` | no | enum: `public`, `private`, `internal` | |
+| `archived` | no | boolean | |
+| `fetched_at` | yes | ISO 8601 timestamp | When data was retrieved from the provider API |
+
+### NormalizedChange
+
+Maps to: Change (the reviewable modification under proposal).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `provider` | yes | enum | |
+| `provider_id` | yes | string | |
+| `repository_id` | yes | string | Matches `NormalizedRepository.provider_id` for the same provider |
+| `source_branch` | yes | string | |
+| `target_branch` | yes | string | |
+| `state` | yes | enum: `open`, `closed`, `merged`, `locked` | |
+| `author_actor_id` | yes | string | Matches `NormalizedActor.provider_id` |
+| `created_at` | yes | ISO 8601 timestamp | |
+| `updated_at` | yes | ISO 8601 timestamp | |
+| `title` | no | string | |
+| `is_draft` | no | boolean | GitHub draft PR or GitLab draft MR |
+| `work_item_refs` | no | `NormalizedWorkItemRef[]` | Empty array when none detected; never `null` |
+| `merged_at` | no | ISO 8601 timestamp | Present only when `state` is `merged` |
+| `closed_at` | no | ISO 8601 timestamp | Present only when `state` is `closed` |
+| `fetched_at` | yes | ISO 8601 timestamp | |
+
+### NormalizedActor
+
+Maps to: Actor (a person or automation accountable in the flow).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `provider` | yes | enum | |
+| `provider_id` | yes | string | |
+| `display_name` | yes | string | Best-effort human-readable name |
+| `provider_login` | no | string | Username as shown in the provider UI |
+| `team_memberships` | no | string[] | Team or group slugs |
+
+### NormalizedReviewState
+
+Maps to: Review state (human review status for a change).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `change_id` | yes | string | Matches `NormalizedChange.provider_id` |
+| `state` | yes | enum: `awaiting_review`, `under_review`, `changes_requested`, `approved`, `not_required` | |
+| `as_of` | yes | ISO 8601 timestamp | When this state was last computed |
+| `reviewer_actor_ids` | no | string[] | Actors assigned or who have responded |
+| `last_activity_at` | no | ISO 8601 timestamp | Most recent review action |
+| `approval_count` | no | integer | |
+| `required_approval_count` | no | integer | |
+
+### NormalizedValidationRun
+
+Maps to: Validation state (automated checks or manual gates).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `change_id` | yes | string | |
+| `scope` | yes | enum: `branch`, `trunk` | `branch` = pre-merge; `trunk` = post-merge integration |
+| `state` | yes | enum: `pending`, `running`, `passed`, `failed`, `flaky`, `skipped` | |
+| `run_at` | yes | ISO 8601 timestamp | When the run was recorded or last updated |
+| `name` | no | string | Check name or pipeline name |
+| `url` | no | string | Link to run details |
+| `duration_seconds` | no | integer | |
+| `failure_summary` | no | string | Brief failure description; no stack traces |
+
+### NormalizedMergeEvent
+
+Maps to: Change stage transition (implementation complete; feeds aging and trunk
+validation signals).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `change_id` | yes | string | |
+| `merged_at` | yes | ISO 8601 timestamp | |
+| `target_branch` | yes | string | |
+| `merged_by_actor_id` | no | string | Absent when the provider does not expose the merge actor |
+| `merge_commit_sha` | no | string | |
+
+### NormalizedOwnershipHint
+
+Maps to: Ownership state (clarity of accountability for a scope).
+
+At least one of `owner_actor_ids` or `owner_team_names` must be present when
+the hint represents a known owner. An empty-owner hint with `confidence:
+inferred` signals that ownership data could not be found.
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `repository_id` | yes | string | |
+| `owner_actor_ids` | no | string[] | |
+| `owner_team_names` | no | string[] | Team or group slugs |
+| `path_pattern` | no | string | Glob pattern from CODEOWNERS; absent means repository-level hint |
+| `source` | no | enum: `codeowners`, `group_membership`, `branch_protection`, `manual` | How the hint was derived |
+| `confidence` | no | enum: `declared`, `inferred` | `declared` when from an explicit file or rule |
+
+### NormalizedWorkItemRef
+
+Maps to: Work item (reference only; not a full work item record).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `external_id` | yes | string | As seen in the provider (issue number, ticket key) |
+| `title` | no | string | Best-effort from PR/MR body or linked issue |
+| `provider` | no | string | Source system if known |
+| `url` | no | string | |
+| `state` | no | string | Coarse state if fetchable: `open` or `closed` |
+
+## Normalization rules
+
+### Review state
+
+| Provider signal | Normalized state |
+| --- | --- |
+| GitHub: no reviewer assigned | `awaiting_review` |
+| GitHub: reviewer assigned, no response yet | `awaiting_review` |
+| GitHub: reviewer has commented but not approved or requested changes | `under_review` |
+| GitHub: `CHANGES_REQUESTED` from any reviewer | `changes_requested` |
+| GitHub: required approvals met | `approved` |
+| GitHub: review bypass rule active or review not required | `not_required` |
+| GitLab: approvals required > 0, not met | `awaiting_review` |
+| GitLab: at least one reviewer has responded without approving | `under_review` |
+| GitLab: blocking note without approval | `changes_requested` |
+| GitLab: required approvals met | `approved` |
+| GitLab: approval rules disabled or MR locked | `not_required` |
+
+### Validation state
+
+Scope assignment: a validation run is `branch` scope if it ran before merge
+(triggered on the PR or MR). It is `trunk` scope if it ran after merge on the
+default branch or trunk integration line.
+
+| Provider signal | Normalized state |
+| --- | --- |
+| GitHub Checks API: `success` | `passed` |
+| GitHub Checks API: `failure` or `error` | `failed` |
+| GitHub Checks API: `in_progress` | `running` |
+| GitHub Checks API: `queued` or `waiting` | `pending` |
+| GitHub Checks API: `neutral` or `skipped` | `skipped` |
+| GitHub legacy commit status: `success` | `passed` |
+| GitHub legacy commit status: `failure` or `error` | `failed` |
+| GitHub legacy commit status: `pending` | `running` |
+| GitLab Pipeline: `success` | `passed` |
+| GitLab Pipeline: `failed` | `failed` |
+| GitLab Pipeline: `running` | `running` |
+| GitLab Pipeline: `pending` or `created` | `pending` |
+| GitLab Pipeline: `canceled`, `skipped`, or `manual` | `skipped` |
+| Same scope alternates `passed`/`failed` across recent runs | `flaky` |
+
+### Ownership hints
+
+| Provider signal | `source` | `confidence` |
+| --- | --- | --- |
+| GitHub CODEOWNERS file entry | `codeowners` | `declared` |
+| GitLab Code Owners file entry | `codeowners` | `declared` |
+| GitLab group owner membership | `group_membership` | `declared` |
+| GitHub branch protection required reviewers | `branch_protection` | `declared` |
+| Derived from past PR/MR author history | omit | `inferred` |
+| No ownership data found | emit hint with empty owner lists | `inferred` |
+
+### Work item references
+
+Adapters must extract work item references from PR/MR title and description
+using provider-standard patterns, for example `closes #123` or `fixes #123`
+for GitHub and `Closes #123` or `Related to #456` for GitLab. If no references
+are detected, `work_item_refs` must be an empty array. Adapters must not infer
+work items from branch name patterns alone.
+
+## Provenance
+
+Every normalized type carries `provider` and `fetched_at`. These fields:
+
+- Identify which provider system the data came from.
+- Enable staleness detection in the inference engine.
+- Support audit and debugging without requiring full raw event storage.
+
+Adapters must record `fetched_at` as the time data was retrieved from the
+provider API, not the time of the underlying provider event.
+
+The optional `is_partial` flag (boolean) must be set to `true` on any type
+where the adapter could not retrieve all required fields due to a provider API
+gap or authorization constraint. Signal inference must treat partial inputs as
+reduced-confidence.
+
+## Provider capability notes
+
+| Capability | GitHub SaaS | GitLab SaaS | GitLab self-managed |
+| --- | --- | --- | --- |
+| CODEOWNERS file | yes | yes | yes |
+| Checks API (check suites and runs) | yes | no — use Pipelines | no — use Pipelines |
+| Legacy commit statuses | yes (deprecated path) | yes | yes |
+| Pipeline per MR | no — PR checks only | yes | yes |
+| Merge actor identity | yes | yes | yes (≥ 14.x) |
+| Approval rule count | via branch protection | via approval rules | via approval rules |
+| Work item cross-references | via linked issues | via related issues | via related issues |
+| Group-level ownership | no | yes | yes |
+| Draft or WIP state | yes — draft PR | yes — draft MR | yes |
+
+Adapters for providers with gaps must map to the closest normalized concept and
+set `is_partial: true` when the gap affects a required field.
+
+## Missing-data and partial-data rules
+
+| Absent or ambiguous field | Required behavior |
+| --- | --- |
+| `reviewer_actor_ids` absent on an open change | Set `state` to `awaiting_review` |
+| `work_item_refs` is empty | Do not infer work item context; signals that depend on work item scope must degrade gracefully |
+| No `NormalizedOwnershipHint` for the repository | Downstream ownership state resolves to `missing`; signals must handle `missing` explicitly |
+| `validation_runs` absent for an open change | Treat as `pending`; do not treat as `passed` |
+| `merged_by_actor_id` absent on a merge event | Record the merge event without the actor; do not block inference |
+| Any timestamp absent | Signals relying on elapsed time must reduce confidence or skip time-based inference |
+| `is_partial: true` on any type | Downstream inference reduces confidence for signals that depend on that partial type |
+| Provider API error retrieving an optional field | Set `is_partial: true`; do not fail the entire normalized output |
+| `approval_count` absent when `required_approval_count` is present | Treat approval count as zero |
+| `required_approval_count` absent | Do not infer an approval threshold; use `not_required` only when the provider explicitly signals no review is needed |
+| No pipeline or check data after a merge event | Emit a `trunk`-scoped `NormalizedValidationRun` with `state: pending` |
+| Conflicting ownership hints for the same path | Emit all hints and set `confidence: inferred` on each; the inference engine resolves conflicts |
+
+## Fixture shape
+
+Fixtures used in scenario tests follow this canonical YAML shape. Each fixture
+file provides all normalized types needed by the targeted flow insight signals.
+Fixtures must be self-contained and must not reference external resources or
+depend on a live provider API.
+
+```yaml
+fixture_id: "string — unique identifier"
+scenario: "string — flow insight signal this fixture targets"
+provider: "github | gitlab"
+description: "string — what this fixture represents"
+
+repository:
+  provider: "github | gitlab"
+  provider_id: "string"
+  full_name: "string"
+  default_branch: "string"
+  fetched_at: "ISO 8601"
+
+changes:
+  - provider: "github | gitlab"
+    provider_id: "string"
+    repository_id: "string"
+    source_branch: "string"
+    target_branch: "string"
+    state: "open | closed | merged | locked"
+    author_actor_id: "string"
+    created_at: "ISO 8601"
+    updated_at: "ISO 8601"
+    work_item_refs: []
+    fetched_at: "ISO 8601"
+
+actors:
+  - provider: "github | gitlab"
+    provider_id: "string"
+    display_name: "string"
+
+review_states:
+  - change_id: "string"
+    state: "awaiting_review | under_review | changes_requested | approved | not_required"
+    as_of: "ISO 8601"
+
+validation_runs:
+  - change_id: "string"
+    scope: "branch | trunk"
+    state: "pending | running | passed | failed | flaky | skipped"
+    run_at: "ISO 8601"
+
+merge_events:
+  - change_id: "string"
+    merged_at: "ISO 8601"
+    target_branch: "string"
+
+ownership_hints:
+  - repository_id: "string"
+    owner_team_names: []
+    source: "codeowners | group_membership | branch_protection | manual"
+    confidence: "declared | inferred"
+```
+
+See `schema/fixtures/provider-adapter-input/blocked-on-review-github.yaml` for
+a worked example aligned with the "blocked on review" signal scenario.

--- a/docs/content/flow/index.md
+++ b/docs/content/flow/index.md
@@ -17,6 +17,7 @@ Flow insights define the smallest shared language for understanding how work mov
 
 - Read the [canonical model](./model) to understand the shared vocabulary.
 - Review the [signal catalog](./signals) to see how the model is applied.
+- Read the [adapter contract](./adapter-contract) to understand the normalized types that provider adapters must produce.
 - Use the [scope guardrails](./scope) to keep provider-specific or workflow-shaped concerns out of the core.
 - Explore the [intent scenarios](./intent-scenarios) to see the Gherkin statements that anchor the MVP.
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -14,6 +14,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "flow/model",
         "flow/signals",
+        "flow/adapter-contract",
         "flow/scope",
         "flow/intent-scenarios",
       ],

--- a/schema/fixtures/provider-adapter-input/blocked-on-review-github.yaml
+++ b/schema/fixtures/provider-adapter-input/blocked-on-review-github.yaml
@@ -1,0 +1,92 @@
+# Fixture: blocked-on-review-github
+#
+# Worked example aligned with the "blocked on review" signal scenario from
+# tests/features/flow-insights.feature.
+#
+# A change titled "Add payment webhook" has been open for 36 hours beyond the
+# expected 24-hour review window. Two reviewers are assigned but neither has
+# responded. Branch validation passed. Ownership is declared via CODEOWNERS.
+#
+# This fixture is self-contained. It does not reference external resources or
+# depend on a live provider API.
+
+fixture_id: "blocked-on-review-github"
+scenario: "blocked_on_review"
+provider: "github"
+description: >
+  A change waiting 36 hours past the expected review window with two assigned
+  reviewers who have not responded. Branch validation passed. Ownership is
+  declared.
+
+repository:
+  provider: "github"
+  provider_id: "repo-payments-001"
+  full_name: "example-org/payments-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-01T10:00:00Z"
+
+changes:
+  - provider: "github"
+    provider_id: "pr-789"
+    repository_id: "repo-payments-001"
+    source_branch: "feature/add-payment-webhook"
+    target_branch: "main"
+    state: "open"
+    is_draft: false
+    author_actor_id: "actor-alice"
+    created_at: "2026-03-30T08:00:00Z"
+    updated_at: "2026-04-01T09:00:00Z"
+    title: "Add payment webhook"
+    work_item_refs:
+      - external_id: "42"
+        title: "Add payment webhook handler"
+        state: "open"
+    fetched_at: "2026-04-01T10:00:00Z"
+
+actors:
+  - provider: "github"
+    provider_id: "actor-alice"
+    display_name: "Alice"
+    provider_login: "alice"
+    team_memberships: ["payments-team"]
+  - provider: "github"
+    provider_id: "actor-bob"
+    display_name: "Bob"
+    provider_login: "bob"
+    team_memberships: ["payments-team"]
+  - provider: "github"
+    provider_id: "actor-carol"
+    display_name: "Carol"
+    provider_login: "carol"
+    team_memberships: ["payments-team"]
+
+review_states:
+  - change_id: "pr-789"
+    # Two reviewers assigned; neither has responded.
+    # Elapsed time (36 h) exceeds the expected review window (24 h).
+    state: "awaiting_review"
+    as_of: "2026-04-01T09:00:00Z"
+    reviewer_actor_ids:
+      - "actor-bob"
+      - "actor-carol"
+    last_activity_at: "2026-03-30T08:30:00Z"
+    required_approval_count: 1
+    approval_count: 0
+
+validation_runs:
+  - change_id: "pr-789"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-03-30T09:00:00Z"
+    name: "ci / test"
+    duration_seconds: 142
+
+merge_events: []
+
+ownership_hints:
+  - repository_id: "repo-payments-001"
+    owner_team_names: ["payments-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"

--- a/schema/provider-adapter-input.yaml
+++ b/schema/provider-adapter-input.yaml
@@ -1,0 +1,348 @@
+# Provider Adapter Input — JSON Schema (YAML format)
+#
+# This schema defines the normalized types that source control and CI provider
+# adapters must emit. It makes the contract in
+# docs/content/flow/adapter-contract.md unambiguous for tooling and
+# implementers.
+#
+# JSON Schema draft 2020-12.
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "schema/provider-adapter-input.yaml"
+title: "Provider Adapter Input"
+description: >
+  Normalized types produced by provider adapters and consumed by the signal
+  inference engine. No type in this schema introduces a concept not needed by
+  at least one of the six MVP flow insight signals.
+
+$defs:
+
+  ProviderEnum:
+    type: string
+    enum: [github, gitlab]
+    description: The source control or CI provider system.
+
+  ISOTimestamp:
+    type: string
+    format: date-time
+    description: An ISO 8601 date-time string (e.g. 2026-04-01T10:00:00Z).
+
+  NormalizedRepository:
+    type: object
+    description: >
+      Repository metadata. Maps to work item scope and ownership context in the
+      canonical flow model.
+    required: [provider, provider_id, full_name, default_branch, fetched_at]
+    additionalProperties: false
+    properties:
+      provider:
+        $ref: "#/$defs/ProviderEnum"
+      provider_id:
+        type: string
+        description: Provider-scoped stable identifier.
+      full_name:
+        type: string
+        description: Repository full name, e.g. org/repo.
+      default_branch:
+        type: string
+        description: Trunk branch name.
+      visibility:
+        type: string
+        enum: [public, private, internal]
+      archived:
+        type: boolean
+      fetched_at:
+        $ref: "#/$defs/ISOTimestamp"
+        description: When data was retrieved from the provider API.
+      is_partial:
+        type: boolean
+        description: >
+          True when the adapter could not retrieve all required fields due to a
+          provider API gap or authorization constraint.
+
+  NormalizedWorkItemRef:
+    type: object
+    description: >
+      A reference to a work item. This is a pointer only — not a full work item
+      record. Maps to the Work item concept in the canonical flow model.
+    required: [external_id]
+    additionalProperties: false
+    properties:
+      external_id:
+        type: string
+        description: >
+          The identifier as seen in the provider (issue number, ticket key).
+      title:
+        type: string
+        description: Best-effort title from the PR/MR body or linked issue.
+      provider:
+        type: string
+        description: Source system if known.
+      url:
+        type: string
+        format: uri
+      state:
+        type: string
+        description: "Coarse state if fetchable: open or closed."
+
+  NormalizedChange:
+    type: object
+    description: >
+      A reviewable modification to code, config, or content proposed against a
+      target branch. Maps to the Change concept in the canonical flow model.
+    required:
+      - provider
+      - provider_id
+      - repository_id
+      - source_branch
+      - target_branch
+      - state
+      - author_actor_id
+      - created_at
+      - updated_at
+      - fetched_at
+    additionalProperties: false
+    properties:
+      provider:
+        $ref: "#/$defs/ProviderEnum"
+      provider_id:
+        type: string
+      repository_id:
+        type: string
+        description: >
+          Matches NormalizedRepository.provider_id for the same provider.
+      source_branch:
+        type: string
+      target_branch:
+        type: string
+      state:
+        type: string
+        enum: [open, closed, merged, locked]
+      author_actor_id:
+        type: string
+        description: Matches NormalizedActor.provider_id.
+      created_at:
+        $ref: "#/$defs/ISOTimestamp"
+      updated_at:
+        $ref: "#/$defs/ISOTimestamp"
+      title:
+        type: string
+      is_draft:
+        type: boolean
+        description: True for GitHub draft PRs or GitLab draft MRs.
+      work_item_refs:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedWorkItemRef"
+        description: >
+          Empty array when none detected. Never null. Adapters must not infer
+          work items from branch name patterns alone.
+      merged_at:
+        $ref: "#/$defs/ISOTimestamp"
+        description: Present only when state is merged.
+      closed_at:
+        $ref: "#/$defs/ISOTimestamp"
+        description: Present only when state is closed.
+      fetched_at:
+        $ref: "#/$defs/ISOTimestamp"
+      is_partial:
+        type: boolean
+
+  NormalizedActor:
+    type: object
+    description: >
+      A person or automation that initiates, reviews, validates, or owns a
+      change. Maps to the Actor concept in the canonical flow model.
+    required: [provider, provider_id, display_name]
+    additionalProperties: false
+    properties:
+      provider:
+        $ref: "#/$defs/ProviderEnum"
+      provider_id:
+        type: string
+      display_name:
+        type: string
+        description: Best-effort human-readable name.
+      provider_login:
+        type: string
+        description: Username as shown in the provider UI.
+      team_memberships:
+        type: array
+        items:
+          type: string
+        description: Team or group slugs.
+
+  NormalizedReviewState:
+    type: object
+    description: >
+      The state of human review for a change. Maps to the Review state concept
+      in the canonical flow model.
+    required: [change_id, state, as_of]
+    additionalProperties: false
+    properties:
+      change_id:
+        type: string
+        description: Matches NormalizedChange.provider_id.
+      state:
+        type: string
+        enum:
+          - awaiting_review
+          - under_review
+          - changes_requested
+          - approved
+          - not_required
+      as_of:
+        $ref: "#/$defs/ISOTimestamp"
+        description: When this state was last computed.
+      reviewer_actor_ids:
+        type: array
+        items:
+          type: string
+        description: Actors assigned or who have responded.
+      last_activity_at:
+        $ref: "#/$defs/ISOTimestamp"
+        description: Most recent review action.
+      approval_count:
+        type: integer
+        minimum: 0
+      required_approval_count:
+        type: integer
+        minimum: 0
+
+  NormalizedValidationRun:
+    type: object
+    description: >
+      The state of automated or manual checks verifying a change. Maps to the
+      Validation state concept in the canonical flow model.
+    required: [change_id, scope, state, run_at]
+    additionalProperties: false
+    properties:
+      change_id:
+        type: string
+      scope:
+        type: string
+        enum: [branch, trunk]
+        description: >
+          branch = pre-merge (triggered on the PR or MR).
+          trunk = post-merge integration on the default branch.
+      state:
+        type: string
+        enum: [pending, running, passed, failed, flaky, skipped]
+      run_at:
+        $ref: "#/$defs/ISOTimestamp"
+        description: When the run was recorded or last updated.
+      name:
+        type: string
+        description: Check name or pipeline name.
+      url:
+        type: string
+        format: uri
+        description: Link to run details.
+      duration_seconds:
+        type: integer
+        minimum: 0
+      failure_summary:
+        type: string
+        description: Brief failure description. No stack traces.
+
+  NormalizedMergeEvent:
+    type: object
+    description: >
+      Records the point at which a change was merged. Signals the transition
+      from implementation to post-merge validation. Feeds aging and trunk
+      validation signals.
+    required: [change_id, merged_at, target_branch]
+    additionalProperties: false
+    properties:
+      change_id:
+        type: string
+      merged_at:
+        $ref: "#/$defs/ISOTimestamp"
+      target_branch:
+        type: string
+      merged_by_actor_id:
+        type: string
+        description: Absent when the provider does not expose the merge actor.
+      merge_commit_sha:
+        type: string
+
+  NormalizedOwnershipHint:
+    type: object
+    description: >
+      A hint about who owns a repository scope. Maps to the Ownership state
+      concept in the canonical flow model. At least one of owner_actor_ids or
+      owner_team_names must be present when the hint represents a known owner.
+      An empty-owner hint with confidence inferred signals that ownership data
+      could not be found.
+    required: [repository_id]
+    additionalProperties: false
+    properties:
+      repository_id:
+        type: string
+      owner_actor_ids:
+        type: array
+        items:
+          type: string
+      owner_team_names:
+        type: array
+        items:
+          type: string
+        description: Team or group slugs.
+      path_pattern:
+        type: string
+        description: >
+          Glob pattern from CODEOWNERS. Absent means repository-level hint.
+      source:
+        type: string
+        enum: [codeowners, group_membership, branch_protection, manual]
+        description: How the hint was derived.
+      confidence:
+        type: string
+        enum: [declared, inferred]
+        description: >
+          declared when from an explicit file or rule. inferred when derived
+          from contributor history or heuristics.
+
+  ProviderAdapterInput:
+    type: object
+    description: >
+      The top-level container for all normalized types produced by a provider
+      adapter for a single repository context. All arrays may be empty but must
+      not be null.
+    required: [repository]
+    additionalProperties: false
+    properties:
+      repository:
+        $ref: "#/$defs/NormalizedRepository"
+      changes:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedChange"
+        default: []
+      actors:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedActor"
+        default: []
+      review_states:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedReviewState"
+        default: []
+      validation_runs:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedValidationRun"
+        default: []
+      merge_events:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedMergeEvent"
+        default: []
+      ownership_hints:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedOwnershipHint"
+        default: []
+
+# Root schema — validates a ProviderAdapterInput document
+$ref: "#/$defs/ProviderAdapterInput"


### PR DESCRIPTION
Defines the normalized types that source control and CI provider
adapters must emit so the signal inference engine can remain
provider-neutral. Covers eight normalized types (NormalizedRepository,
NormalizedChange, NormalizedActor, NormalizedReviewState,
NormalizedValidationRun, NormalizedMergeEvent, NormalizedOwnershipHint,
NormalizedWorkItemRef), normalization rules for GitHub and GitLab,
provenance expectations, provider capability notes, missing-data rules,
and a canonical fixture shape with a worked example.

Adds docs/content/flow/adapter-contract.md (prose contract),
schema/provider-adapter-input.yaml (JSON Schema artifact), and
schema/fixtures/provider-adapter-input/blocked-on-review-github.yaml
(worked fixture example). Updates docs/content/flow/index.md and
docs/sidebars.ts to surface the new page.

Closes #221