### PR TITLE
feat(flow): add scenario-based contract tests for provider-neutral flow insights

### DIFF
--- a/docs/content/flow/adapter-contract.md
+++ b/docs/content/flow/adapter-contract.md
@@ -130,6 +130,20 @@ validation signals).
 | `merged_by_actor_id` | no | string | Absent when the provider does not expose the merge actor |
 | `merge_commit_sha` | no | string | |
 
+### NormalizedEvidenceState
+
+Maps to: Evidence state (required evidence for compliance or risk acceptance).
+
+| Field | Required | Type | Notes |
+| --- | --- | --- | --- |
+| `change_id` | yes | string | Matches `NormalizedChange.provider_id` |
+| `state` | yes | enum: `not_required`, `required`, `pending`, `recorded`, `stale` | |
+| `as_of` | yes | ISO 8601 timestamp | When this evidence state was last computed |
+| `required_types` | no | string[] | Names of required evidence types, e.g. `security attestation`, `deployment trace` |
+| `owner_actor_id` | no | string | Actor responsible for supplying the evidence; matches `NormalizedActor.provider_id` |
+| `freshness_at` | no | ISO 8601 timestamp | When evidence was last confirmed fresh; absent when `state` is `pending`, `required`, or `not_required` |
+| `is_partial` | no | boolean | True when evidence requirements could not be fully determined |
+
 ### NormalizedOwnershipHint
 
 Maps to: Ownership state (clarity of accountability for a scope).
@@ -332,6 +346,13 @@ merge_events:
   - change_id: "string"
     merged_at: "ISO 8601"
     target_branch: "string"
+
+evidence_states:
+  - change_id: "string"
+    state: "not_required | required | pending | recorded | stale"
+    as_of: "ISO 8601"
+    required_types: []
+    owner_actor_id: "string"
 
 ownership_hints:
   - repository_id: "string"

--- a/docs/content/flow/intent-scenarios.md
+++ b/docs/content/flow/intent-scenarios.md
@@ -17,6 +17,16 @@ Source: [`tests/features/flow-insights.feature`](https://github.com/ourchitectur
 - **Aging work between implementation and validation:** Implementation finished, yet validation has not started or is stalled beyond the expected window; the signal cites the delay and outstanding checks.
 - **Risk signal by service, team, or flow stage:** Multiple signals cluster in the same scope within a short window, elevating risk and recommending focused remediation.
 
-## Not a conformance profile (yet)
+## Provider-specific and edge-case scenarios
 
-These scenarios are Layer 1 intent only. They do not define harness steps, HTTP routes, or stack obligations. A formal profile and Layer 2 harness will follow once the canonical model is stable.
+The feature file also includes provider-tagged scenarios (`@github`, `@gitlab`,
+`@gitlab-self-managed`, `@cross-provider`) that validate provider-specific
+normalization paths, cross-provider equivalence, ownership ambiguity, evidence
+state inference, and reduced-confidence behavior under partial data.
+
+## Layer 2 conformance profile
+
+A formal Layer 2 profile and TypeScript contract harness now exist for this
+capability. See [Flow Insights Profile](../testing/profiles/flow-insights) for
+the scenario table, fixture catalog, cross-stack equivalence rules, and stack
+declaration requirements.

--- a/docs/content/testing/profiles/flow-insights.md
+++ b/docs/content/testing/profiles/flow-insights.md
@@ -1,0 +1,157 @@
+---
+sidebar_position: 7
+---
+
+# Flow Insights Profile
+
+The `flow-insights` profile proves that a stack can infer the six canonical MVP
+flow insight signals from normalized provider adapter inputs, produce
+human-readable explanations and recommended next actions, and maintain
+semantic equivalence across GitHub and GitLab normalized inputs.
+
+## Why it exists
+
+The MVP depends on consistent interpretation across multiple providers, multiple
+implementation stacks, and multiple transport surfaces. Without shared scenarios
+and expected outcomes, implementations will drift even when each local
+implementation appears correct. This profile makes semantic drift visible and
+unacceptable across stacks.
+
+## Layer 1 spec
+
+Source: [`tests/features/flow-insights.feature`](https://github.com/ourchitecture/idp/blob/main/tests/features/flow-insights.feature)
+
+## Scenarios (16 total)
+
+### Provider-neutral core scenarios
+
+These six scenarios define the canonical signal semantics regardless of
+provider. They are provider-neutral and must pass for any conforming stack.
+
+| Scenario | What is checked |
+| --- | --- |
+| Blocked on review is surfaced with context | `awaiting_review` change past expected window; explanation names reviewers; action targets reviewers |
+| Passed checks but failing trunk integration is highlighted | Branch `passed`, trunk `failed`; explanation contrasts both; action is remediate or roll back |
+| Unclear ownership is flagged for resolution | Ownership `unclear`; explanation lists conflicting owners; action confirms single owner |
+| Waiting on evidence, not effort, is differentiated | Evidence `pending`; explanation lists missing items; action is supply evidence |
+| Aging work between implementation and validation is exposed | Trunk validation `pending` past expected window; explanation cites delay |
+| Risk is aggregated by service from clustered signals | Three signals in 48 hours for one service; explanation aggregates contributing signals |
+
+### Provider-specific scenarios
+
+| Scenario | Tag | What is checked |
+| --- | --- | --- |
+| GitHub blocked on review via CODEOWNERS reviewer identity | `@github` | Named reviewers from CODEOWNERS; action targets them by name |
+| GitLab blocked on review via approval threshold not met | `@gitlab` | Approval count 0 of required 2; explanation reflects threshold |
+| GitLab self-managed blocked on review with partial identity | `@gitlab-self-managed` | `is_partial: true` on review state; confidence reduced |
+| GitHub trunk failure after clean Checks API pass | `@github` | Checks API `passed`, trunk `failed`; explanation references both |
+| GitLab trunk failure after passing MR pipeline | `@gitlab` | MR pipeline `passed`, trunk pipeline `failed` |
+| Ownership ambiguity with two conflicting teams | `@github` | Two CODEOWNERS entries; explanation names both teams |
+| GitHub waiting on evidence with identified responsible actor | `@github` | Evidence `pending`; actor named in explanation |
+| GitLab waiting on evidence with group ownership | `@gitlab` | Compliance attestation `pending`; group owner context |
+| Reduced confidence from partial data | `@github` | `is_partial: true` on review state reduces confidence to `medium` or lower |
+
+### Cross-provider equivalence scenarios
+
+| Scenario | Tag | What is checked |
+| --- | --- | --- |
+| Blocked on review inferred equivalently from GitHub and GitLab | `@cross-provider` | Same signal `id`, same severity intent, same confidence tier |
+
+## Cross-stack equivalence rules
+
+These rules are enforced by the Layer 2 harness. They apply to every
+implementation stack that declares `capabilities.flowInsights.enabled = true`.
+
+### Required to be equivalent across stacks
+
+- **Signal identity:** the same `id` value must be returned for the same
+  inferred condition (e.g., `blocked_on_review`).
+- **Severity / priority intent:** if `blocked_on_review` is `high`, it must be
+  `high` across all stacks.
+- **Confidence behavior:** the same inputs must produce the same confidence tier.
+  Partial inputs (`is_partial: true`) must reduce confidence on all stacks.
+- **Recommended-action intent:** the action category must be equivalent across
+  stacks. "Notify reviewers" and "ping assigned reviewers" are equivalent.
+  "Close the change" is not equivalent to "notify reviewers" for a
+  `blocked_on_review` signal.
+
+### Not required to be identical
+
+- Exact wording of `explanation` — semantic content must match; phrasing may differ.
+- Exact wording of `recommendedNextAction` — intent must match; wording may vary.
+- Ordering of signals when multiple are returned.
+- Incidental metadata fields not explicitly part of the contract.
+
+### Allowed differences
+
+Provider capability gaps may cause GitHub and GitLab to produce slightly
+different signal shapes for the same scenario. Any such difference must be
+documented in this section.
+
+| Signal | Provider | Allowed difference | Reason |
+| --- | --- | --- | --- |
+| `blocked_on_review` | GitLab self-managed (pre-14.x) | `confidence: medium` instead of `high` | Reviewer identity is `is_partial: true` when the API version does not expose individual reviewer assignments |
+
+## Fixture catalog
+
+All fixtures are in `schema/fixtures/provider-adapter-input/`. The table below
+maps each fixture to its targeted signal and provider.
+
+| Fixture file | Signal | Provider |
+| --- | --- | --- |
+| `blocked-on-review-github.yaml` | `blocked_on_review` | GitHub |
+| `blocked-on-review-gitlab.yaml` | `blocked_on_review` | GitLab SaaS |
+| `blocked-on-review-gitlab-self-managed.yaml` | `blocked_on_review` | GitLab self-managed |
+| `trunk-integration-failed-github.yaml` | `trunk_integration_failure` | GitHub |
+| `trunk-integration-failed-gitlab.yaml` | `trunk_integration_failure` | GitLab SaaS |
+| `unclear-ownership-github.yaml` | `unclear_ownership` | GitHub (no owners) |
+| `unclear-ownership-ambiguous-github.yaml` | `unclear_ownership` | GitHub (two conflicting teams) |
+| `unclear-ownership-gitlab.yaml` | `unclear_ownership` | GitLab SaaS |
+| `waiting-on-evidence-github.yaml` | `waiting_on_evidence` | GitHub |
+| `waiting-on-evidence-gitlab.yaml` | `waiting_on_evidence` | GitLab SaaS |
+| `aging-implementation-github.yaml` | `aging_implementation` | GitHub |
+| `aging-implementation-gitlab.yaml` | `aging_implementation` | GitLab SaaS |
+| `risk-aggregation-github.yaml` | `risk_aggregation` | GitHub |
+| `risk-aggregation-gitlab.yaml` | `risk_aggregation` | GitLab SaaS |
+| `partial-data-github.yaml` | `partial_evidence` | GitHub (partial data) |
+| `changes-requested-github.yaml` | `changes_requested` | GitHub |
+| `review-not-required-github.yaml` | `review_not_required` | GitHub |
+
+## Layer 2 harness
+
+Source: [`tests/src/profiles/flow-insights.ts`](https://github.com/ourchitecture/idp/blob/main/tests/src/profiles/flow-insights.ts)
+
+The TypeScript harness is derived from the `.feature` file above. When they
+disagree, the `.feature` file is authoritative (ADR-0009).
+
+### Provisional API assumption
+
+The profile assumes `POST /api/flow/insights` on the BFF base URL. This
+endpoint shape must be confirmed when the inference engine (issue #225) and the
+HTTP API surface (issue #226) land. Stacks must not declare
+`capabilities.flowInsights.enabled = true` until the endpoint is available.
+
+## Stack declarations
+
+Stacks that expose the flow insights capability must declare both the profile
+and the capability flag in `stack.json`:
+
+```jsonc
+{
+  "contractProfiles": ["core", "operational", "flow-insights"],
+  "capabilities": {
+    "flowInsights": {
+      "enabled": true
+    }
+  }
+}
+```
+
+## Related
+
+- [Contract Test Harness](../contract-harness) — Full harness guide
+- [Flow Intent Scenarios](../../flow/intent-scenarios) — Layer 1 source
+- [Signal Catalog](../../flow/signals) — Canonical signal definitions
+- [Provider Adapter Contract](../../flow/adapter-contract) — Normalized input types
+- [ADR-0005](../../architecture/decisions/shared-capability-contract-and-conformance-profiles) — Capability contract and conformance profiles
+- [ADR-0009](../../architecture/decisions/intent-specification-format) — Gherkin as Layer 1 format

--- a/schema/fixtures/provider-adapter-input/aging-implementation-github.yaml
+++ b/schema/fixtures/provider-adapter-input/aging-implementation-github.yaml
@@ -1,0 +1,89 @@
+# Fixture: aging-implementation-github
+#
+# A GitHub pull request for which implementation finished 3 days ago
+# (the change was merged) but post-merge validation has not yet started.
+# The trunk validation run is in pending state. The expected validation
+# start window is 24 hours from the merge event.
+
+fixture_id: "aging-implementation-github"
+scenario: "aging_implementation"
+provider: "github"
+description: >
+  A merged GitHub PR where trunk validation has not started 3 days after merge.
+  The expected validation start window of 24 hours has been exceeded.
+  Ownership declared via CODEOWNERS.
+
+repository:
+  provider: "github"
+  provider_id: "repo-auth-001"
+  full_name: "example-org/auth-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-10T09:00:00Z"
+
+changes:
+  - provider: "github"
+    provider_id: "pr-700"
+    repository_id: "repo-auth-001"
+    source_branch: "feature/oauth-refresh-token"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-rachel"
+    created_at: "2026-04-06T10:00:00Z"
+    updated_at: "2026-04-07T15:00:00Z"
+    title: "Add OAuth refresh token support"
+    work_item_refs:
+      - external_id: "55"
+        provider: "github"
+        title: "Implement OAuth 2.0 refresh tokens"
+        state: "open"
+        url: "https://github.com/example-org/auth-service/issues/55"
+    merged_at: "2026-04-07T15:00:00Z"
+    closed_at: "2026-04-07T15:00:00Z"
+    fetched_at: "2026-04-10T09:00:00Z"
+
+actors:
+  - provider: "github"
+    provider_id: "actor-rachel"
+    display_name: "Rachel"
+    provider_login: "rachel"
+    team_memberships: ["auth-team"]
+
+review_states:
+  - change_id: "pr-700"
+    state: "approved"
+    as_of: "2026-04-07T14:45:00Z"
+    reviewer_actor_ids: ["actor-rachel"]
+    last_activity_at: "2026-04-07T14:45:00Z"
+    approval_count: 1
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "pr-700"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-07T12:00:00Z"
+    name: "ci / test"
+    url: "https://github.com/example-org/auth-service/checks/700"
+    duration_seconds: 250
+  - change_id: "pr-700"
+    # Post-merge validation has not started; pending 3 days after merge.
+    scope: "trunk"
+    state: "pending"
+    run_at: "2026-04-10T09:00:00Z"
+    name: "integration / main"
+    url: "https://github.com/example-org/auth-service/checks/701"
+
+merge_events:
+  - change_id: "pr-700"
+    merged_at: "2026-04-07T15:00:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-rachel"
+    merge_commit_sha: "merge-sha-700"
+
+ownership_hints:
+  - repository_id: "repo-auth-001"
+    owner_team_names: ["auth-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"

--- a/schema/fixtures/provider-adapter-input/aging-implementation-gitlab.yaml
+++ b/schema/fixtures/provider-adapter-input/aging-implementation-gitlab.yaml
@@ -1,0 +1,88 @@
+# Fixture: aging-implementation-gitlab
+#
+# A GitLab merge request for which implementation finished 3 days ago and trunk
+# pipeline validation has not started. The expected validation start window of
+# 24 hours has been exceeded. Ownership declared via Code Owners.
+
+fixture_id: "aging-implementation-gitlab"
+scenario: "aging_implementation"
+provider: "gitlab"
+description: >
+  A merged GitLab MR where trunk pipeline has not started 3 days after merge.
+  The expected validation start window of 24 hours has been exceeded.
+  Ownership declared via Code Owners.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-auth-gl-001"
+  full_name: "example-org/auth-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-10T09:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-700"
+    repository_id: "repo-auth-gl-001"
+    source_branch: "feature/oauth-refresh-token"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-rachel-gl"
+    created_at: "2026-04-06T10:00:00Z"
+    updated_at: "2026-04-07T15:00:00Z"
+    title: "Add OAuth refresh token support"
+    work_item_refs:
+      - external_id: "55"
+        provider: "gitlab"
+        title: "Implement OAuth 2.0 refresh tokens"
+        state: "open"
+        url: "https://gitlab.com/example-org/auth-service/-/issues/55"
+    merged_at: "2026-04-07T15:00:00Z"
+    closed_at: "2026-04-07T15:00:00Z"
+    fetched_at: "2026-04-10T09:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-rachel-gl"
+    display_name: "Rachel"
+    provider_login: "rachel"
+    team_memberships: ["auth-team"]
+
+review_states:
+  - change_id: "mr-700"
+    state: "approved"
+    as_of: "2026-04-07T14:45:00Z"
+    reviewer_actor_ids: ["actor-rachel-gl"]
+    last_activity_at: "2026-04-07T14:45:00Z"
+    approval_count: 1
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "mr-700"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-07T12:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/auth-service/-/pipelines/5001"
+    duration_seconds: 260
+  - change_id: "mr-700"
+    # Post-merge pipeline has not started; pending 3 days after merge.
+    scope: "trunk"
+    state: "pending"
+    run_at: "2026-04-10T09:00:00Z"
+    name: "integration / main"
+    url: "https://gitlab.com/example-org/auth-service/-/pipelines/5002"
+
+merge_events:
+  - change_id: "mr-700"
+    merged_at: "2026-04-07T15:00:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-rachel-gl"
+    merge_commit_sha: "merge-sha-gl-700"
+
+ownership_hints:
+  - repository_id: "repo-auth-gl-001"
+    owner_team_names: ["auth-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"

--- a/schema/fixtures/provider-adapter-input/blocked-on-review-gitlab-self-managed.yaml
+++ b/schema/fixtures/provider-adapter-input/blocked-on-review-gitlab-self-managed.yaml
@@ -1,0 +1,88 @@
+# Fixture: blocked-on-review-gitlab-self-managed
+#
+# A GitLab self-managed merge request blocked on review. The same "blocked on
+# review" semantics apply. The merge actor identity is marked partial because
+# the self-managed instance runs a version that does not expose the merge actor
+# via the API (pre-14.x behavior). Branch validation ran via legacy commit
+# status rather than GitLab Pipelines.
+#
+# is_partial: true on the review state signals that reviewer identities could
+# not be fully resolved, reducing inference confidence.
+
+fixture_id: "blocked-on-review-gitlab-self-managed"
+scenario: "blocked_on_review"
+provider: "gitlab"
+description: >
+  A GitLab self-managed MR blocked on review with partial reviewer identity.
+  Branch validation passed via legacy commit status. Merge actor identity
+  unavailable due to a provider API version gap.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-infra-sm-001"
+  full_name: "example-org/infra"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-05T14:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-512"
+    repository_id: "repo-infra-sm-001"
+    source_branch: "feature/update-network-policy"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-peter-sm"
+    created_at: "2026-04-03T10:00:00Z"
+    updated_at: "2026-04-05T13:00:00Z"
+    title: "Update network policy"
+    work_item_refs:
+      - external_id: "99"
+        provider: "gitlab"
+        title: "Update firewall policy for prod"
+        state: "open"
+    fetched_at: "2026-04-05T14:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-peter-sm"
+    display_name: "Peter"
+    provider_login: "peter"
+    team_memberships: ["infra-team"]
+  - provider: "gitlab"
+    provider_id: "actor-quinn-sm"
+    display_name: "Quinn"
+    provider_login: "quinn"
+    team_memberships: ["infra-team"]
+
+review_states:
+  - change_id: "mr-512"
+    # Reviewer identity partially resolved; self-managed API did not return
+    # individual reviewer assignments for this instance version.
+    state: "awaiting_review"
+    as_of: "2026-04-05T13:00:00Z"
+    reviewer_actor_ids: []
+    reviewer_team_names: ["infra-team"]
+    last_activity_at: "2026-04-05T13:00:00Z"
+    required_approval_count: 1
+    approval_count: 0
+    is_partial: true
+
+validation_runs:
+  - change_id: "mr-512"
+    # Legacy commit status path on self-managed instance.
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-03T11:00:00Z"
+    name: "legacy-ci"
+    duration_seconds: 200
+
+merge_events: []
+
+ownership_hints:
+  - repository_id: "repo-infra-sm-001"
+    owner_team_names: ["infra-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"
+    is_partial: true

--- a/schema/fixtures/provider-adapter-input/blocked-on-review-gitlab.yaml
+++ b/schema/fixtures/provider-adapter-input/blocked-on-review-gitlab.yaml
@@ -1,0 +1,92 @@
+# Fixture: blocked-on-review-gitlab
+#
+# A GitLab merge request blocked on review because approval rules require 2
+# approvals and none have been recorded. The MR pipeline passed all jobs.
+# Group ownership is declared via a Code Owners file.
+#
+# This fixture is the GitLab SaaS counterpart to blocked-on-review-github.yaml.
+# The same "blocked on review" signal must be inferred from both, with the same
+# signal identity and severity intent (cross-stack equivalence rule).
+
+fixture_id: "blocked-on-review-gitlab"
+scenario: "blocked_on_review"
+provider: "gitlab"
+description: >
+  A GitLab MR waiting 36 hours past the expected review window with two
+  assigned approvers who have not responded. MR pipeline passed. Group
+  ownership declared via Code Owners.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-payments-gl-001"
+  full_name: "example-org/payments-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-01T10:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-789"
+    repository_id: "repo-payments-gl-001"
+    source_branch: "feature/add-payment-webhook"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-alice-gl"
+    created_at: "2026-03-30T08:00:00Z"
+    updated_at: "2026-04-01T09:00:00Z"
+    title: "Add payment webhook"
+    work_item_refs:
+      - external_id: "42"
+        provider: "gitlab"
+        title: "Add payment webhook handler"
+        state: "open"
+        url: "https://gitlab.com/example-org/payments-service/-/issues/42"
+    fetched_at: "2026-04-01T10:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-alice-gl"
+    display_name: "Alice"
+    provider_login: "alice"
+    team_memberships: ["payments-team"]
+  - provider: "gitlab"
+    provider_id: "actor-bob-gl"
+    display_name: "Bob"
+    provider_login: "bob"
+    team_memberships: ["payments-team"]
+  - provider: "gitlab"
+    provider_id: "actor-carol-gl"
+    display_name: "Carol"
+    provider_login: "carol"
+    team_memberships: ["payments-team"]
+
+review_states:
+  - change_id: "mr-789"
+    # GitLab: approval rules require 2 approvals; none recorded.
+    # Normalizes to awaiting_review — approval threshold not met.
+    state: "awaiting_review"
+    as_of: "2026-04-01T09:00:00Z"
+    reviewer_actor_ids:
+      - "actor-bob-gl"
+      - "actor-carol-gl"
+    last_activity_at: "2026-04-01T09:00:00Z"
+    required_approval_count: 2
+    approval_count: 0
+
+validation_runs:
+  - change_id: "mr-789"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-03-30T09:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/payments-service/-/pipelines/1001"
+    duration_seconds: 150
+
+merge_events: []
+
+ownership_hints:
+  - repository_id: "repo-payments-gl-001"
+    owner_team_names: ["payments-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"

--- a/schema/fixtures/provider-adapter-input/risk-aggregation-github.yaml
+++ b/schema/fixtures/provider-adapter-input/risk-aggregation-github.yaml
@@ -1,0 +1,164 @@
+# Fixture: risk-aggregation-github
+#
+# Three GitHub pull requests for the "checkout" service within a 48-hour window,
+# each contributing a different risk signal: trunk integration failure, blocked
+# on review, and unclear ownership. The ownership state for the service is
+# declared (owned). This fixture supports the "risk signal by service, team,
+# or flow stage" aggregation scenario.
+
+fixture_id: "risk-aggregation-github"
+scenario: "risk_aggregation"
+provider: "github"
+description: >
+  Three GitHub PRs for the checkout service within 48 hours, each contributing
+  a distinct risk signal: trunk failure, blocked on review, and unclear
+  ownership. Ownership for the service scope is declared.
+
+repository:
+  provider: "github"
+  provider_id: "repo-checkout-001"
+  full_name: "example-org/checkout-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-09T16:00:00Z"
+
+changes:
+  - provider: "github"
+    provider_id: "pr-801"
+    repository_id: "repo-checkout-001"
+    source_branch: "feature/payment-retry"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-tom"
+    created_at: "2026-04-08T09:00:00Z"
+    updated_at: "2026-04-08T14:30:00Z"
+    title: "Add payment retry logic"
+    work_item_refs:
+      - external_id: "200"
+        provider: "github"
+        state: "open"
+    merged_at: "2026-04-08T14:30:00Z"
+    closed_at: "2026-04-08T14:30:00Z"
+    fetched_at: "2026-04-09T16:00:00Z"
+  - provider: "github"
+    provider_id: "pr-802"
+    repository_id: "repo-checkout-001"
+    source_branch: "feature/discount-engine"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-uma"
+    created_at: "2026-04-08T10:00:00Z"
+    updated_at: "2026-04-09T15:00:00Z"
+    title: "Refactor discount engine"
+    work_item_refs:
+      - external_id: "201"
+        provider: "github"
+        state: "open"
+    fetched_at: "2026-04-09T16:00:00Z"
+  - provider: "github"
+    provider_id: "pr-803"
+    repository_id: "repo-checkout-001"
+    source_branch: "feature/cart-persistence"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-victor"
+    created_at: "2026-04-09T08:00:00Z"
+    updated_at: "2026-04-09T15:30:00Z"
+    title: "Add cart persistence"
+    work_item_refs:
+      - external_id: "202"
+        provider: "github"
+        state: "open"
+    fetched_at: "2026-04-09T16:00:00Z"
+
+actors:
+  - provider: "github"
+    provider_id: "actor-tom"
+    display_name: "Tom"
+    provider_login: "tom"
+    team_memberships: ["checkout-team"]
+  - provider: "github"
+    provider_id: "actor-uma"
+    display_name: "Uma"
+    provider_login: "uma"
+    team_memberships: ["checkout-team"]
+  - provider: "github"
+    provider_id: "actor-victor"
+    display_name: "Victor"
+    provider_login: "victor"
+    team_memberships: ["checkout-team"]
+
+review_states:
+  - change_id: "pr-801"
+    state: "approved"
+    as_of: "2026-04-08T14:00:00Z"
+    reviewer_actor_ids: ["actor-uma"]
+    last_activity_at: "2026-04-08T14:00:00Z"
+    approval_count: 1
+    required_approval_count: 1
+  - change_id: "pr-802"
+    # Blocked on review — reviewer has not responded for 29 hours.
+    state: "awaiting_review"
+    as_of: "2026-04-09T15:00:00Z"
+    reviewer_actor_ids: ["actor-tom"]
+    last_activity_at: "2026-04-08T10:00:00Z"
+    approval_count: 0
+    required_approval_count: 1
+  - change_id: "pr-803"
+    # Blocked on review — no reviewers assigned.
+    state: "awaiting_review"
+    as_of: "2026-04-09T15:30:00Z"
+    reviewer_actor_ids: []
+    last_activity_at: "2026-04-09T08:00:00Z"
+    approval_count: 0
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "pr-801"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-08T12:00:00Z"
+    name: "ci / test"
+    duration_seconds: 180
+  - change_id: "pr-801"
+    # Trunk integration failed after merge — contributes risk signal.
+    scope: "trunk"
+    state: "failed"
+    run_at: "2026-04-08T15:00:00Z"
+    name: "deploy / main"
+    url: "https://github.com/example-org/checkout-service/actions/runs/8001"
+    duration_seconds: 500
+    failure_summary: "failure"
+  - change_id: "pr-802"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-08T11:00:00Z"
+    name: "ci / test"
+    duration_seconds: 190
+  - change_id: "pr-803"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-09T09:00:00Z"
+    name: "ci / test"
+    duration_seconds: 195
+
+merge_events:
+  - change_id: "pr-801"
+    merged_at: "2026-04-08T14:30:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-tom"
+    merge_commit_sha: "merge-sha-801"
+
+ownership_hints:
+  - repository_id: "repo-checkout-001"
+    owner_team_names: ["checkout-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"
+  # pr-803 scope has no matching CODEOWNERS entry — unclear ownership.
+  - repository_id: "repo-checkout-001"
+    owner_actor_ids: []
+    owner_team_names: []
+    path_pattern: "src/cart/*"
+    source: "codeowners"
+    confidence: "inferred"

--- a/schema/fixtures/provider-adapter-input/risk-aggregation-gitlab.yaml
+++ b/schema/fixtures/provider-adapter-input/risk-aggregation-gitlab.yaml
@@ -1,0 +1,166 @@
+# Fixture: risk-aggregation-gitlab
+#
+# Three GitLab merge requests for the "checkout" service within a 48-hour
+# window, each contributing a different risk signal: trunk pipeline failure,
+# blocked on review, and unclear ownership. The service ownership is declared.
+# This is the GitLab counterpart to risk-aggregation-github.yaml.
+
+fixture_id: "risk-aggregation-gitlab"
+scenario: "risk_aggregation"
+provider: "gitlab"
+description: >
+  Three GitLab MRs for the checkout service within 48 hours, each contributing
+  a distinct risk signal: trunk failure, blocked on review, and unclear
+  ownership. Service ownership declared.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-checkout-gl-001"
+  full_name: "example-org/checkout-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-09T16:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-801"
+    repository_id: "repo-checkout-gl-001"
+    source_branch: "feature/payment-retry"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-tom-gl"
+    created_at: "2026-04-08T09:00:00Z"
+    updated_at: "2026-04-08T14:30:00Z"
+    title: "Add payment retry logic"
+    work_item_refs:
+      - external_id: "200"
+        provider: "gitlab"
+        state: "open"
+    merged_at: "2026-04-08T14:30:00Z"
+    closed_at: "2026-04-08T14:30:00Z"
+    fetched_at: "2026-04-09T16:00:00Z"
+  - provider: "gitlab"
+    provider_id: "mr-802"
+    repository_id: "repo-checkout-gl-001"
+    source_branch: "feature/discount-engine"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-uma-gl"
+    created_at: "2026-04-08T10:00:00Z"
+    updated_at: "2026-04-09T15:00:00Z"
+    title: "Refactor discount engine"
+    work_item_refs:
+      - external_id: "201"
+        provider: "gitlab"
+        state: "open"
+    fetched_at: "2026-04-09T16:00:00Z"
+  - provider: "gitlab"
+    provider_id: "mr-803"
+    repository_id: "repo-checkout-gl-001"
+    source_branch: "feature/cart-persistence"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-victor-gl"
+    created_at: "2026-04-09T08:00:00Z"
+    updated_at: "2026-04-09T15:30:00Z"
+    title: "Add cart persistence"
+    work_item_refs:
+      - external_id: "202"
+        provider: "gitlab"
+        state: "open"
+    fetched_at: "2026-04-09T16:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-tom-gl"
+    display_name: "Tom"
+    provider_login: "tom"
+    team_memberships: ["checkout-team"]
+  - provider: "gitlab"
+    provider_id: "actor-uma-gl"
+    display_name: "Uma"
+    provider_login: "uma"
+    team_memberships: ["checkout-team"]
+  - provider: "gitlab"
+    provider_id: "actor-victor-gl"
+    display_name: "Victor"
+    provider_login: "victor"
+    team_memberships: ["checkout-team"]
+
+review_states:
+  - change_id: "mr-801"
+    state: "approved"
+    as_of: "2026-04-08T14:00:00Z"
+    reviewer_actor_ids: ["actor-uma-gl"]
+    last_activity_at: "2026-04-08T14:00:00Z"
+    approval_count: 1
+    required_approval_count: 1
+  - change_id: "mr-802"
+    # Blocked on review — approval threshold not met, overdue by 29 hours.
+    state: "awaiting_review"
+    as_of: "2026-04-09T15:00:00Z"
+    reviewer_actor_ids: ["actor-tom-gl"]
+    last_activity_at: "2026-04-08T10:00:00Z"
+    approval_count: 0
+    required_approval_count: 1
+  - change_id: "mr-803"
+    # Blocked on review — no reviewer assigned yet.
+    state: "awaiting_review"
+    as_of: "2026-04-09T15:30:00Z"
+    reviewer_actor_ids: []
+    last_activity_at: "2026-04-09T08:00:00Z"
+    approval_count: 0
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "mr-801"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-08T12:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/checkout-service/-/pipelines/6001"
+    duration_seconds: 185
+  - change_id: "mr-801"
+    # Trunk pipeline failed after merge — contributes risk signal.
+    scope: "trunk"
+    state: "failed"
+    run_at: "2026-04-08T15:00:00Z"
+    name: "deploy / main"
+    url: "https://gitlab.com/example-org/checkout-service/-/pipelines/6002"
+    duration_seconds: 520
+    failure_summary: "failure"
+  - change_id: "mr-802"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-08T11:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/checkout-service/-/pipelines/6003"
+    duration_seconds: 192
+  - change_id: "mr-803"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-09T09:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/checkout-service/-/pipelines/6004"
+    duration_seconds: 198
+
+merge_events:
+  - change_id: "mr-801"
+    merged_at: "2026-04-08T14:30:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-tom-gl"
+    merge_commit_sha: "merge-sha-gl-801"
+
+ownership_hints:
+  - repository_id: "repo-checkout-gl-001"
+    owner_team_names: ["checkout-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"
+  # mr-803 scope has no matching Code Owners entry — unclear ownership.
+  - repository_id: "repo-checkout-gl-001"
+    owner_actor_ids: []
+    owner_team_names: []
+    path_pattern: "src/cart/*"
+    source: "codeowners"
+    confidence: "inferred"

--- a/schema/fixtures/provider-adapter-input/trunk-integration-failed-gitlab.yaml
+++ b/schema/fixtures/provider-adapter-input/trunk-integration-failed-gitlab.yaml
@@ -1,0 +1,104 @@
+# Fixture: trunk-integration-failed-gitlab
+#
+# A GitLab merge request that passed all MR pipeline jobs and was merged, but
+# the trunk pipeline failed within 15 minutes of the merge. This is the GitLab
+# counterpart to trunk-integration-failed-github.yaml.
+#
+# The same "passed checks but failing trunk integration" signal must be inferred
+# from both, with the same signal identity and severity intent
+# (cross-stack equivalence rule).
+
+fixture_id: "trunk-integration-failed-gitlab"
+scenario: "trunk_integration_failure"
+provider: "gitlab"
+description: >
+  A GitLab MR with all pipeline jobs passing pre-merge but the trunk pipeline
+  failing within 15 minutes of merge. Required approvals were met. Ownership
+  declared via Code Owners.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-observability-gl-001"
+  full_name: "example-org/observability"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-02T12:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-1234"
+    repository_id: "repo-observability-gl-001"
+    source_branch: "feature/add-alerting"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-dana-gl"
+    created_at: "2026-04-01T15:00:00Z"
+    updated_at: "2026-04-02T10:20:00Z"
+    title: "Add alerting rules"
+    work_item_refs:
+      - external_id: "105"
+        title: "Add alerting for latency"
+        provider: "gitlab"
+        url: "https://gitlab.com/example-org/observability/-/issues/105"
+        state: "open"
+    merged_at: "2026-04-02T10:15:00Z"
+    closed_at: "2026-04-02T10:15:00Z"
+    fetched_at: "2026-04-02T12:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-dana-gl"
+    display_name: "Dana"
+    provider_login: "dana"
+  - provider: "gitlab"
+    provider_id: "actor-eli-gl"
+    display_name: "Eli"
+    provider_login: "eli"
+  - provider: "gitlab"
+    provider_id: "actor-fay-gl"
+    display_name: "Fay"
+    provider_login: "fay"
+
+review_states:
+  - change_id: "mr-1234"
+    state: "approved"
+    as_of: "2026-04-02T10:10:00Z"
+    reviewer_actor_ids:
+      - "actor-eli-gl"
+      - "actor-fay-gl"
+    last_activity_at: "2026-04-02T10:10:00Z"
+    approval_count: 2
+    required_approval_count: 2
+
+validation_runs:
+  - change_id: "mr-1234"
+    # MR-scoped pipeline — all jobs passed before merge.
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-02T09:45:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/observability/-/pipelines/2001"
+    duration_seconds: 480
+  - change_id: "mr-1234"
+    # Trunk pipeline triggered after merge — failed within 15 minutes.
+    scope: "trunk"
+    state: "failed"
+    run_at: "2026-04-02T10:25:00Z"
+    name: "deploy / main"
+    url: "https://gitlab.com/example-org/observability/-/pipelines/2002"
+    duration_seconds: 600
+    failure_summary: "failure"
+
+merge_events:
+  - change_id: "mr-1234"
+    merged_at: "2026-04-02T10:15:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-dana-gl"
+    merge_commit_sha: "merge-sha-gl-1234"
+
+ownership_hints:
+  - repository_id: "repo-observability-gl-001"
+    owner_team_names: ["sre-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"

--- a/schema/fixtures/provider-adapter-input/unclear-ownership-ambiguous-github.yaml
+++ b/schema/fixtures/provider-adapter-input/unclear-ownership-ambiguous-github.yaml
@@ -1,0 +1,86 @@
+# Fixture: unclear-ownership-ambiguous-github
+#
+# A GitHub pull request scoped to the "notifications" service where two
+# separate teams are listed as accountable owners in CODEOWNERS with no single
+# confirmed owner. The adapter emits two conflicting ownership hints and sets
+# confidence "inferred" on each, per the adapter contract rule for conflicting
+# ownership hints.
+#
+# This is the "two teams, no single owner" ambiguity case from the feature spec.
+
+fixture_id: "unclear-ownership-ambiguous-github"
+scenario: "unclear_ownership"
+provider: "github"
+description: >
+  A GitHub PR scoped to the notifications service with two conflicting CODEOWNERS
+  entries assigning different teams as accountable owners. No single confirmed
+  owner. Both hints are emitted with confidence inferred.
+
+repository:
+  provider: "github"
+  provider_id: "repo-notifications-002"
+  full_name: "example-org/notifications-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-07T11:00:00Z"
+
+changes:
+  - provider: "github"
+    provider_id: "pr-450"
+    repository_id: "repo-notifications-002"
+    source_branch: "feature/notification-routing"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-nina"
+    created_at: "2026-04-06T10:00:00Z"
+    updated_at: "2026-04-07T10:30:00Z"
+    title: "Refactor notification routing"
+    work_item_refs:
+      - external_id: "91"
+        provider: "github"
+        title: "Consolidate notification routing logic"
+        state: "open"
+        url: "https://github.com/example-org/notifications-service/issues/91"
+    fetched_at: "2026-04-07T11:00:00Z"
+
+actors:
+  - provider: "github"
+    provider_id: "actor-nina"
+    display_name: "Nina"
+    provider_login: "nina"
+    team_memberships: ["platform-team"]
+
+review_states:
+  - change_id: "pr-450"
+    state: "awaiting_review"
+    as_of: "2026-04-07T10:30:00Z"
+    reviewer_actor_ids: []
+    reviewer_team_names: ["platform-team", "notifications-team"]
+    last_activity_at: "2026-04-07T10:30:00Z"
+    approval_count: 0
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "pr-450"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-06T11:00:00Z"
+    name: "ci / test"
+    url: "https://github.com/example-org/notifications-service/checks/300"
+    duration_seconds: 160
+
+merge_events: []
+
+ownership_hints:
+  # Two conflicting CODEOWNERS entries for the same path pattern.
+  # Per the adapter contract: emit all hints, set confidence inferred on each.
+  - repository_id: "repo-notifications-002"
+    owner_team_names: ["platform-team"]
+    path_pattern: "src/routing/*"
+    source: "codeowners"
+    confidence: "inferred"
+  - repository_id: "repo-notifications-002"
+    owner_team_names: ["notifications-team"]
+    path_pattern: "src/routing/*"
+    source: "codeowners"
+    confidence: "inferred"

--- a/schema/fixtures/provider-adapter-input/unclear-ownership-github.yaml
+++ b/schema/fixtures/provider-adapter-input/unclear-ownership-github.yaml
@@ -1,0 +1,77 @@
+# Fixture: unclear-ownership-github
+#
+# A GitHub pull request for a change scoped to the "notifications" service where
+# ownership state is unclear because no CODEOWNERS entry covers the affected
+# paths. The adapter emits an ownership hint with empty owner lists and
+# confidence "inferred" to signal that ownership data could not be found.
+
+fixture_id: "unclear-ownership-github"
+scenario: "unclear_ownership"
+provider: "github"
+description: >
+  A GitHub PR scoped to the notifications service with no resolvable ownership.
+  No CODEOWNERS entry matches the changed paths. Ownership hint has empty
+  owner lists and confidence inferred.
+
+repository:
+  provider: "github"
+  provider_id: "repo-notifications-001"
+  full_name: "example-org/notifications-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-06T09:00:00Z"
+
+changes:
+  - provider: "github"
+    provider_id: "pr-400"
+    repository_id: "repo-notifications-001"
+    source_branch: "feature/add-push-notifications"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-marcus"
+    created_at: "2026-04-05T08:00:00Z"
+    updated_at: "2026-04-06T08:30:00Z"
+    title: "Add push notification support"
+    work_item_refs:
+      - external_id: "88"
+        provider: "github"
+        title: "Implement push notifications"
+        state: "open"
+        url: "https://github.com/example-org/notifications-service/issues/88"
+    fetched_at: "2026-04-06T09:00:00Z"
+
+actors:
+  - provider: "github"
+    provider_id: "actor-marcus"
+    display_name: "Marcus"
+    provider_login: "marcus"
+
+review_states:
+  - change_id: "pr-400"
+    state: "awaiting_review"
+    as_of: "2026-04-06T08:30:00Z"
+    reviewer_actor_ids: []
+    last_activity_at: "2026-04-06T08:30:00Z"
+    approval_count: 0
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "pr-400"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-05T09:00:00Z"
+    name: "ci / test"
+    url: "https://github.com/example-org/notifications-service/checks/200"
+    duration_seconds: 120
+
+merge_events: []
+
+ownership_hints:
+  - repository_id: "repo-notifications-001"
+    # No owner resolved — empty owners with inferred confidence signals
+    # that the adapter could not find ownership data for the affected paths.
+    owner_actor_ids: []
+    owner_team_names: []
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "inferred"

--- a/schema/fixtures/provider-adapter-input/unclear-ownership-gitlab.yaml
+++ b/schema/fixtures/provider-adapter-input/unclear-ownership-gitlab.yaml
@@ -1,0 +1,75 @@
+# Fixture: unclear-ownership-gitlab
+#
+# A GitLab merge request scoped to the "notifications" service where ownership
+# could not be determined. The Code Owners file exists but no group or user
+# entry covers the affected paths. The adapter emits an ownership hint with
+# empty owner lists and confidence "inferred".
+
+fixture_id: "unclear-ownership-gitlab"
+scenario: "unclear_ownership"
+provider: "gitlab"
+description: >
+  A GitLab MR scoped to the notifications service with no resolvable ownership.
+  Code Owners file exists but no entry matches the changed paths.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-notifications-gl-001"
+  full_name: "example-org/notifications-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-06T09:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-400"
+    repository_id: "repo-notifications-gl-001"
+    source_branch: "feature/add-push-notifications"
+    target_branch: "main"
+    state: "open"
+    author_actor_id: "actor-marcus-gl"
+    created_at: "2026-04-05T08:00:00Z"
+    updated_at: "2026-04-06T08:30:00Z"
+    title: "Add push notification support"
+    work_item_refs:
+      - external_id: "88"
+        provider: "gitlab"
+        title: "Implement push notifications"
+        state: "open"
+        url: "https://gitlab.com/example-org/notifications-service/-/issues/88"
+    fetched_at: "2026-04-06T09:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-marcus-gl"
+    display_name: "Marcus"
+    provider_login: "marcus"
+
+review_states:
+  - change_id: "mr-400"
+    state: "awaiting_review"
+    as_of: "2026-04-06T08:30:00Z"
+    reviewer_actor_ids: []
+    last_activity_at: "2026-04-06T08:30:00Z"
+    approval_count: 0
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "mr-400"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-05T09:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/notifications-service/-/pipelines/3001"
+    duration_seconds: 120
+
+merge_events: []
+
+ownership_hints:
+  - repository_id: "repo-notifications-gl-001"
+    # No owner resolved — empty owner lists with inferred confidence.
+    owner_actor_ids: []
+    owner_team_names: []
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "inferred"

--- a/schema/fixtures/provider-adapter-input/waiting-on-evidence-github.yaml
+++ b/schema/fixtures/provider-adapter-input/waiting-on-evidence-github.yaml
@@ -1,0 +1,99 @@
+# Fixture: waiting-on-evidence-github
+#
+# A GitHub pull request that has completed implementation (merged) and passed
+# all branch validation, but is waiting on two required evidence items: a
+# security attestation and a deployment trace. The responsible actor is
+# identified. This fixture supports the "waiting on evidence, not effort" signal.
+
+fixture_id: "waiting-on-evidence-github"
+scenario: "waiting_on_evidence"
+provider: "github"
+description: >
+  A merged GitHub PR with passing branch validation but pending evidence state.
+  Security attestation and deployment trace are required but not yet supplied.
+  The responsible actor for supplying evidence is identified.
+
+repository:
+  provider: "github"
+  provider_id: "repo-payments-003"
+  full_name: "example-org/payments-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-08T14:00:00Z"
+
+changes:
+  - provider: "github"
+    provider_id: "pr-600"
+    repository_id: "repo-payments-003"
+    source_branch: "feature/pci-compliance-update"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-olivia"
+    created_at: "2026-04-06T09:00:00Z"
+    updated_at: "2026-04-08T12:00:00Z"
+    title: "PCI compliance update"
+    work_item_refs:
+      - external_id: "130"
+        provider: "github"
+        title: "Implement PCI DSS compliance changes"
+        state: "open"
+        url: "https://github.com/example-org/payments-service/issues/130"
+    merged_at: "2026-04-08T11:45:00Z"
+    closed_at: "2026-04-08T11:45:00Z"
+    fetched_at: "2026-04-08T14:00:00Z"
+
+actors:
+  - provider: "github"
+    provider_id: "actor-olivia"
+    display_name: "Olivia"
+    provider_login: "olivia"
+    team_memberships: ["payments-team"]
+  - provider: "github"
+    provider_id: "actor-sam"
+    display_name: "Sam"
+    provider_login: "sam"
+    team_memberships: ["security-team"]
+
+review_states:
+  - change_id: "pr-600"
+    state: "approved"
+    as_of: "2026-04-08T11:30:00Z"
+    reviewer_actor_ids:
+      - "actor-sam"
+    last_activity_at: "2026-04-08T11:30:00Z"
+    approval_count: 1
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "pr-600"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-07T10:00:00Z"
+    name: "ci / test"
+    url: "https://github.com/example-org/payments-service/checks/600"
+    duration_seconds: 300
+
+merge_events:
+  - change_id: "pr-600"
+    merged_at: "2026-04-08T11:45:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-olivia"
+    merge_commit_sha: "merge-sha-600"
+
+evidence_states:
+  - change_id: "pr-600"
+    # Implementation complete and validation passed, but evidence pending.
+    # Two evidence types required; neither has been supplied yet.
+    state: "pending"
+    as_of: "2026-04-08T14:00:00Z"
+    required_types:
+      - "security attestation"
+      - "deployment trace"
+    owner_actor_id: "actor-sam"
+
+ownership_hints:
+  - repository_id: "repo-payments-003"
+    owner_team_names: ["payments-team"]
+    path_pattern: "*"
+    source: "codeowners"
+    confidence: "declared"

--- a/schema/fixtures/provider-adapter-input/waiting-on-evidence-gitlab.yaml
+++ b/schema/fixtures/provider-adapter-input/waiting-on-evidence-gitlab.yaml
@@ -1,0 +1,94 @@
+# Fixture: waiting-on-evidence-gitlab
+#
+# A GitLab merge request that has been merged and all MR pipeline jobs passed,
+# but a compliance attestation is still pending. Group ownership is declared.
+# The responsible actor for supplying the attestation is identified.
+
+fixture_id: "waiting-on-evidence-gitlab"
+scenario: "waiting_on_evidence"
+provider: "gitlab"
+description: >
+  A merged GitLab MR with passing pipeline but a pending compliance attestation.
+  Group ownership declared. Responsible actor for the attestation identified.
+
+repository:
+  provider: "gitlab"
+  provider_id: "repo-payments-gl-003"
+  full_name: "example-org/payments-service"
+  default_branch: "main"
+  visibility: "private"
+  fetched_at: "2026-04-08T14:00:00Z"
+
+changes:
+  - provider: "gitlab"
+    provider_id: "mr-600"
+    repository_id: "repo-payments-gl-003"
+    source_branch: "feature/pci-compliance-update"
+    target_branch: "main"
+    state: "merged"
+    author_actor_id: "actor-olivia-gl"
+    created_at: "2026-04-06T09:00:00Z"
+    updated_at: "2026-04-08T12:00:00Z"
+    title: "PCI compliance update"
+    work_item_refs:
+      - external_id: "130"
+        provider: "gitlab"
+        title: "Implement PCI DSS compliance changes"
+        state: "open"
+        url: "https://gitlab.com/example-org/payments-service/-/issues/130"
+    merged_at: "2026-04-08T11:45:00Z"
+    closed_at: "2026-04-08T11:45:00Z"
+    fetched_at: "2026-04-08T14:00:00Z"
+
+actors:
+  - provider: "gitlab"
+    provider_id: "actor-olivia-gl"
+    display_name: "Olivia"
+    provider_login: "olivia"
+    team_memberships: ["payments-team"]
+  - provider: "gitlab"
+    provider_id: "actor-sam-gl"
+    display_name: "Sam"
+    provider_login: "sam"
+    team_memberships: ["security-team"]
+
+review_states:
+  - change_id: "mr-600"
+    state: "approved"
+    as_of: "2026-04-08T11:30:00Z"
+    reviewer_actor_ids:
+      - "actor-sam-gl"
+    last_activity_at: "2026-04-08T11:30:00Z"
+    approval_count: 1
+    required_approval_count: 1
+
+validation_runs:
+  - change_id: "mr-600"
+    scope: "branch"
+    state: "passed"
+    run_at: "2026-04-07T10:00:00Z"
+    name: "ci / test"
+    url: "https://gitlab.com/example-org/payments-service/-/pipelines/4001"
+    duration_seconds: 320
+
+merge_events:
+  - change_id: "mr-600"
+    merged_at: "2026-04-08T11:45:00Z"
+    target_branch: "main"
+    merged_by_actor_id: "actor-olivia-gl"
+    merge_commit_sha: "merge-sha-gl-600"
+
+evidence_states:
+  - change_id: "mr-600"
+    state: "pending"
+    as_of: "2026-04-08T14:00:00Z"
+    required_types:
+      - "compliance attestation"
+    owner_actor_id: "actor-sam-gl"
+
+ownership_hints:
+  - repository_id: "repo-payments-gl-003"
+    owner_team_names: ["payments-team"]
+    path_pattern: "*"
+    source: "group_membership"
+    confidence: "declared"

--- a/schema/provider-adapter-input.yaml
+++ b/schema/provider-adapter-input.yaml
@@ -278,6 +278,54 @@ $defs:
       merge_commit_sha:
         type: string
 
+  NormalizedEvidenceState:
+    type: object
+    description: >
+      The status of required evidence (security attestations, approvals,
+      traceability artifacts) needed for a change. Maps to the Evidence state
+      concept in the canonical flow model. Used by the "waiting on evidence,
+      not effort" signal.
+    required: [change_id, state, as_of]
+    additionalProperties: false
+    properties:
+      change_id:
+        type: string
+        description: Matches NormalizedChange.provider_id.
+      state:
+        type: string
+        enum: [not_required, required, pending, recorded, stale]
+        description: >
+          not_required = no evidence required for this change.
+          required = evidence is required but not yet supplied.
+          pending = evidence has been requested but not yet confirmed.
+          recorded = required evidence is on file.
+          stale = previously recorded evidence no longer satisfies freshness requirements.
+      as_of:
+        $ref: "#/$defs/ISOTimestamp"
+        description: When this evidence state was last computed.
+      required_types:
+        type: array
+        items:
+          type: string
+        description: >
+          Names of required evidence types, e.g. "security attestation",
+          "deployment trace". Empty array when state is not_required.
+      owner_actor_id:
+        type: string
+        description: >
+          Actor responsible for supplying the missing evidence. Matches
+          NormalizedActor.provider_id.
+      freshness_at:
+        $ref: "#/$defs/ISOTimestamp"
+        description: >
+          When evidence was last confirmed fresh. Absent when state is
+          pending, required, or not_required.
+      is_partial:
+        type: boolean
+        description: >
+          True when evidence requirements could not be fully determined
+          due to a provider API gap or authorization constraint.
+
   NormalizedOwnershipHint:
     type: object
     description: >
@@ -354,6 +402,11 @@ $defs:
         type: array
         items:
           $ref: "#/$defs/NormalizedMergeEvent"
+        default: []
+      evidence_states:
+        type: array
+        items:
+          $ref: "#/$defs/NormalizedEvidenceState"
         default: []
       ownership_hints:
         type: array

--- a/tests/features/flow-insights.feature
+++ b/tests/features/flow-insights.feature
@@ -59,3 +59,110 @@ Feature: Flow insight signals — canonical MVP
     Then the "risk signal by service, team, or flow stage" is inferred for the "checkout" service
     And the explanation aggregates the contributing signals and the 48-hour window
     And the recommended next action is to escalate to the service owner and focus remediation before accepting new changes
+
+  # Provider-specific and edge-case scenarios
+  # These scenarios validate provider-specific paths and cross-stack equivalence.
+
+  @github
+  Scenario: GitHub blocked on review is inferred from CODEOWNERS reviewer identity
+    Given a GitHub pull request has review state "awaiting_review"
+    And two reviewers are assigned via CODEOWNERS with named identities
+    And the Checks API reports all branch checks as passed
+    And the assigned reviewers have not responded for 36 hours beyond the expected review window
+    When flow insight signals are evaluated
+    Then the "blocked on review" signal is inferred
+    And the explanation names the assigned reviewers by display name
+    And the recommended next action targets the named reviewers directly
+
+  @gitlab
+  Scenario: GitLab blocked on review is inferred when approval threshold is not met
+    Given a GitLab merge request has approval rules requiring 2 approvals
+    And only 0 approvals have been recorded
+    And the MR pipeline reports all jobs as passed
+    And the review window has been exceeded by 36 hours
+    When flow insight signals are evaluated
+    Then the "blocked on review" signal is inferred
+    And the explanation reflects that required approvals were not met
+    And the recommended next action targets the assigned approvers
+
+  @gitlab-self-managed
+  Scenario: GitLab self-managed blocked on review with partial merge actor identity
+    Given a GitLab self-managed merge request has review state "awaiting_review"
+    And the merge actor identity is marked partial due to a provider API gap
+    And the branch legacy commit status reports all checks as passed
+    And the review window has been exceeded
+    When flow insight signals are evaluated
+    Then the "blocked on review" signal is inferred with reduced confidence
+    And the explanation acknowledges the partial reviewer identity data
+
+  @github
+  Scenario: GitHub trunk integration failure is inferred after clean Checks API pass
+    Given a GitHub pull request passed all Checks API branch checks
+    And the pull request was merged to the default branch
+    And a trunk workflow run failed within 15 minutes of the merge commit
+    When flow insight signals are evaluated
+    Then the "passed checks but failing trunk integration" signal is inferred
+    And the explanation references the passing branch checks and the failing trunk run
+    And the recommended next action is to remediate or roll back on trunk
+
+  @gitlab
+  Scenario: GitLab trunk integration failure is inferred after passing MR pipeline
+    Given a GitLab merge request passed all MR pipeline jobs
+    And the merge request was merged to the default branch
+    And the trunk pipeline failed within 15 minutes of the merge
+    When flow insight signals are evaluated
+    Then the "passed checks but failing trunk integration" signal is inferred
+    And the explanation references the passing MR pipeline and the failing trunk pipeline
+    And the recommended next action is to remediate or roll back on trunk
+
+  @cross-provider
+  Scenario: Blocked on review signal is inferred equivalently from GitHub and GitLab normalized inputs
+    Given a GitHub normalized input with review state "awaiting_review" and reviewers overdue by 36 hours
+    And a GitLab normalized input for the equivalent scenario with approval threshold not met and review overdue by 36 hours
+    When flow insight signals are evaluated for both inputs
+    Then the "blocked on review" signal is inferred for both inputs
+    And the signal identity is the same for both inputs
+    And the severity intent is equivalent for both inputs
+    And the recommended-action intent is equivalent for both inputs
+
+  @github
+  Scenario: Ownership ambiguity is flagged when two teams are listed with no confirmed owner
+    Given a work item scoped to the "notifications" service
+    And two teams are listed as accountable owners via CODEOWNERS with no single confirmed owner
+    And the ownership state is "unclear"
+    When flow insight signals are evaluated
+    Then the "unclear ownership" signal is inferred
+    And the explanation names both conflicting teams and the affected service scope
+    And the recommended next action is to confirm a single accountable owner
+
+  @github
+  Scenario: Waiting on evidence is inferred when implementation and validation are both complete
+    Given a change has completed implementation and was merged
+    And the validation state is "passed" for all branch checks
+    And the evidence state is "pending" for security attestation and deployment trace
+    And the responsible actor for supplying evidence is identified
+    When flow insight signals are evaluated
+    Then the "waiting on evidence, not effort" signal is inferred
+    And the explanation names the pending evidence types and the responsible actor
+    And the recommended next action is to supply the missing evidence rather than request more code changes
+
+  @gitlab
+  Scenario: GitLab waiting on evidence with group ownership is inferred correctly
+    Given a GitLab merge request was merged and all MR pipeline jobs passed
+    And the evidence state is "pending" for a compliance attestation
+    And group ownership is declared for the repository scope
+    And the responsible actor for supplying evidence is identified
+    When flow insight signals are evaluated
+    Then the "waiting on evidence, not effort" signal is inferred
+    And the explanation names the pending evidence type and the responsible actor
+    And the recommended next action is to supply the compliance attestation
+
+  @github
+  Scenario: Reduced confidence is applied when adapter reports partial data
+    Given a GitHub pull request with is_partial set to true on the review state
+    And the partial field prevents full reviewer identity resolution
+    And the change is in review state "awaiting_review" with elapsed time beyond the review window
+    When flow insight signals are evaluated
+    Then the "blocked on review" signal is inferred
+    And the signal confidence is reduced from high to medium or lower
+    And the explanation acknowledges the incomplete reviewer identity data

--- a/tests/src/profiles/flow-insights.ts
+++ b/tests/src/profiles/flow-insights.ts
@@ -1,0 +1,385 @@
+// Layer 2 contract profile for the flow insight capability.
+//
+// This profile is derived from tests/features/flow-insights.feature. When the
+// feature file and this profile disagree, the feature file is authoritative
+// (ADR-0009).
+//
+// NOTE: The inference API endpoint assumed here is provisional.
+// This profile assumes POST /api/flow/insights on the BFF base URL.
+// The exact endpoint shape must be confirmed when issue #225 (inference engine)
+// and issue #226 (HTTP API surface) land. Stacks should declare
+// capabilities.flowInsights.enabled = true only once they expose the endpoint.
+//
+// Cross-stack equivalence rules enforced by this profile:
+//   Required to be equivalent across stacks:
+//     - signal identity (same id value for the same inferred condition)
+//     - severity / priority intent
+//     - confidence behavior for the same inputs
+//     - recommended-action intent (category must match; exact wording may vary)
+//   Not required to be identical:
+//     - exact wording of explanation or recommendedNextAction
+//     - ordering of signals when multiple are returned
+//     - incidental metadata fields not part of the contract
+//   Allowed differences must be documented in docs/content/testing/profiles/flow-insights.md
+
+import * as fs from "fs";
+import * as path from "path";
+// js-yaml is available in node_modules but has no bundled type declarations;
+// use require with a narrow inline type to avoid adding a dev dependency.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+const yaml = require("js-yaml") as { load: (input: string) => unknown };
+import { post } from "../http";
+import { ensureServiceAvailable } from "../runtime";
+import type { ContractContext, TestCase } from "../types";
+
+const FIXTURE_DIR = path.resolve(__dirname, "../../../schema/fixtures/provider-adapter-input");
+
+const PROVISIONAL_ENDPOINT = "/api/flow/insights";
+
+type FlowSignal = {
+  id: string;
+  title: string;
+  severity?: string;
+  confidence?: string;
+  explanation?: string;
+  recommendedNextAction?: string;
+  relatedEntities?: unknown[];
+};
+
+type FlowInsightsResponse = {
+  signals: FlowSignal[];
+};
+
+function isFlowInsightsEnabled(context: ContractContext): boolean {
+  return context.stackMetadata?.capabilities?.flowInsights?.enabled === true;
+}
+
+function loadFixture(fixtureId: string): unknown {
+  const filePath = path.join(FIXTURE_DIR, `${fixtureId}.yaml`);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return yaml.load(raw);
+}
+
+async function postFixture(
+  bffBaseUrl: URL,
+  fixture: unknown,
+): Promise<FlowInsightsResponse> {
+  const response = await post(new URL(PROVISIONAL_ENDPOINT, bffBaseUrl), fixture);
+
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(
+      `POST ${PROVISIONAL_ENDPOINT} returned ${response.status}: ${response.body}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response.body);
+  } catch {
+    throw new Error(
+      `POST ${PROVISIONAL_ENDPOINT} response is not valid JSON: ${response.body}`,
+    );
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !Array.isArray((parsed as FlowInsightsResponse).signals)
+  ) {
+    throw new Error(
+      `POST ${PROVISIONAL_ENDPOINT} response must contain a 'signals' array`,
+    );
+  }
+
+  return parsed as FlowInsightsResponse;
+}
+
+function assertSignalPresent(
+  signals: FlowSignal[],
+  expectedId: string,
+  context: string,
+): FlowSignal {
+  const match = signals.find((s) => s.id === expectedId);
+  if (!match) {
+    const found = signals.map((s) => s.id).join(", ") || "(none)";
+    throw new Error(
+      `${context}: expected signal '${expectedId}' not found. Got: ${found}`,
+    );
+  }
+  return match;
+}
+
+function assertNonEmpty(value: string | undefined, field: string, context: string): void {
+  if (!value || value.trim() === "") {
+    throw new Error(`${context}: '${field}' must be a non-empty string`);
+  }
+}
+
+function assertConfidenceReduced(
+  signal: FlowSignal,
+  context: string,
+): void {
+  const reduced = ["medium", "low"];
+  if (!signal.confidence || !reduced.includes(signal.confidence)) {
+    throw new Error(
+      `${context}: confidence must be 'medium' or 'low' for partial-data inputs; got '${signal.confidence}'`,
+    );
+  }
+}
+
+export function createFlowInsightsTests(context: ContractContext): TestCase[] {
+  if (!isFlowInsightsEnabled(context)) {
+    return [];
+  }
+
+  const { bffBaseUrl } = context;
+
+  return [
+    // ── Core provider-neutral scenarios ─────────────────────────────────────
+
+    {
+      name: "flow-insights:blocked-on-review signal is inferred from GitHub fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("blocked-on-review-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "blocked_on_review", "blocked-on-review-github");
+        assertNonEmpty(signal.explanation, "explanation", "blocked-on-review-github");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "blocked-on-review-github");
+      },
+    },
+    {
+      name: "flow-insights:blocked-on-review signal is inferred from GitLab fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("blocked-on-review-gitlab");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "blocked_on_review", "blocked-on-review-gitlab");
+        assertNonEmpty(signal.explanation, "explanation", "blocked-on-review-gitlab");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "blocked-on-review-gitlab");
+      },
+    },
+    {
+      name: "flow-insights:blocked-on-review equivalence across GitHub and GitLab",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const ghFixture = loadFixture("blocked-on-review-github");
+        const glFixture = loadFixture("blocked-on-review-gitlab");
+        const [ghResult, glResult] = await Promise.all([
+          postFixture(bffBaseUrl, ghFixture),
+          postFixture(bffBaseUrl, glFixture),
+        ]);
+        const ghSignal = assertSignalPresent(ghResult.signals, "blocked_on_review", "github");
+        const glSignal = assertSignalPresent(glResult.signals, "blocked_on_review", "gitlab");
+
+        // Signal identity must be equal.
+        if (ghSignal.id !== glSignal.id) {
+          throw new Error(
+            `Cross-provider: signal id must match — github '${ghSignal.id}' vs gitlab '${glSignal.id}'`,
+          );
+        }
+
+        // Severity intent must be equivalent.
+        if (ghSignal.severity !== glSignal.severity) {
+          throw new Error(
+            `Cross-provider: severity must be equivalent — github '${ghSignal.severity}' vs gitlab '${glSignal.severity}'`,
+          );
+        }
+
+        // Confidence tier must be equivalent for equivalent inputs.
+        if (ghSignal.confidence !== glSignal.confidence) {
+          throw new Error(
+            `Cross-provider: confidence must be equivalent — github '${ghSignal.confidence}' vs gitlab '${glSignal.confidence}'`,
+          );
+        }
+      },
+    },
+    {
+      name: "flow-insights:trunk-integration-failure signal is inferred from GitHub fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("trunk-integration-failed-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(
+          result.signals,
+          "trunk_integration_failure",
+          "trunk-integration-failed-github",
+        );
+        assertNonEmpty(signal.explanation, "explanation", "trunk-integration-failed-github");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "trunk-integration-failed-github");
+      },
+    },
+    {
+      name: "flow-insights:trunk-integration-failure signal is inferred from GitLab fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("trunk-integration-failed-gitlab");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(
+          result.signals,
+          "trunk_integration_failure",
+          "trunk-integration-failed-gitlab",
+        );
+        assertNonEmpty(signal.explanation, "explanation", "trunk-integration-failed-gitlab");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "trunk-integration-failed-gitlab");
+      },
+    },
+    {
+      name: "flow-insights:unclear-ownership signal is inferred from GitHub fixture (no owners)",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("unclear-ownership-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "unclear_ownership", "unclear-ownership-github");
+        assertNonEmpty(signal.explanation, "explanation", "unclear-ownership-github");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "unclear-ownership-github");
+      },
+    },
+    {
+      name: "flow-insights:unclear-ownership signal is inferred from ambiguous GitHub fixture (two teams)",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("unclear-ownership-ambiguous-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "unclear_ownership", "unclear-ownership-ambiguous-github");
+        assertNonEmpty(signal.explanation, "explanation", "unclear-ownership-ambiguous-github");
+      },
+    },
+    {
+      name: "flow-insights:unclear-ownership signal is inferred from GitLab fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("unclear-ownership-gitlab");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "unclear_ownership", "unclear-ownership-gitlab");
+        assertNonEmpty(signal.explanation, "explanation", "unclear-ownership-gitlab");
+      },
+    },
+    {
+      name: "flow-insights:waiting-on-evidence signal is inferred from GitHub fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("waiting-on-evidence-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "waiting_on_evidence", "waiting-on-evidence-github");
+        assertNonEmpty(signal.explanation, "explanation", "waiting-on-evidence-github");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "waiting-on-evidence-github");
+      },
+    },
+    {
+      name: "flow-insights:waiting-on-evidence signal is inferred from GitLab fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("waiting-on-evidence-gitlab");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "waiting_on_evidence", "waiting-on-evidence-gitlab");
+        assertNonEmpty(signal.explanation, "explanation", "waiting-on-evidence-gitlab");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "waiting-on-evidence-gitlab");
+      },
+    },
+    {
+      name: "flow-insights:aging-implementation signal is inferred from GitHub fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("aging-implementation-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(
+          result.signals,
+          "aging_implementation",
+          "aging-implementation-github",
+        );
+        assertNonEmpty(signal.explanation, "explanation", "aging-implementation-github");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "aging-implementation-github");
+      },
+    },
+    {
+      name: "flow-insights:aging-implementation signal is inferred from GitLab fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("aging-implementation-gitlab");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(
+          result.signals,
+          "aging_implementation",
+          "aging-implementation-gitlab",
+        );
+        assertNonEmpty(signal.explanation, "explanation", "aging-implementation-gitlab");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "aging-implementation-gitlab");
+      },
+    },
+    {
+      name: "flow-insights:risk-aggregation signal is inferred from GitHub fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("risk-aggregation-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "risk_aggregation", "risk-aggregation-github");
+        assertNonEmpty(signal.explanation, "explanation", "risk-aggregation-github");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "risk-aggregation-github");
+      },
+    },
+    {
+      name: "flow-insights:risk-aggregation signal is inferred from GitLab fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("risk-aggregation-gitlab");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(result.signals, "risk_aggregation", "risk-aggregation-gitlab");
+        assertNonEmpty(signal.explanation, "explanation", "risk-aggregation-gitlab");
+        assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", "risk-aggregation-gitlab");
+      },
+    },
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    {
+      name: "flow-insights:partial data reduces signal confidence",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("blocked-on-review-gitlab-self-managed");
+        const result = await postFixture(bffBaseUrl, fixture);
+        const signal = assertSignalPresent(
+          result.signals,
+          "blocked_on_review",
+          "blocked-on-review-gitlab-self-managed",
+        );
+        assertConfidenceReduced(signal, "blocked-on-review-gitlab-self-managed");
+      },
+    },
+    {
+      name: "flow-insights:partial-data fixture produces reduced confidence signal",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("partial-data-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        if (result.signals.length === 0) {
+          throw new Error("partial-data-github: expected at least one signal to be inferred");
+        }
+        for (const signal of result.signals) {
+          assertConfidenceReduced(signal, `partial-data-github:${signal.id}`);
+        }
+      },
+    },
+
+    // ── Signal shape invariants ──────────────────────────────────────────────
+
+    {
+      name: "flow-insights:every inferred signal carries required fields",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const fixture = loadFixture("blocked-on-review-github");
+        const result = await postFixture(bffBaseUrl, fixture);
+        for (const signal of result.signals) {
+          if (!signal.id || signal.id.trim() === "") {
+            throw new Error("Each signal must have a non-empty 'id' field");
+          }
+          if (!signal.title || signal.title.trim() === "") {
+            throw new Error(`Signal '${signal.id}': 'title' must be non-empty`);
+          }
+          assertNonEmpty(signal.explanation, "explanation", signal.id);
+          assertNonEmpty(signal.recommendedNextAction, "recommendedNextAction", signal.id);
+        }
+      },
+    },
+  ];
+}

--- a/tests/src/profiles/index.ts
+++ b/tests/src/profiles/index.ts
@@ -1,5 +1,6 @@
 import { createAuthProfileTests } from "./auth-profile";
 import { createCoreTests } from "./core";
+import { createFlowInsightsTests } from "./flow-insights";
 import { createMcpProfileTests } from "./mcp-profile";
 import { createOperationalTests } from "./operational";
 import { createStatusProfileTests } from "./status-profile";
@@ -25,6 +26,10 @@ export function buildTestsForProfile(profile: ProfileName, context: ContractCont
 
   if (profile === "auth-profile") {
     return createAuthProfileTests(context);
+  }
+
+  if (profile === "flow-insights") {
+    return createFlowInsightsTests(context);
   }
 
   return createUiProfileTests(context);

--- a/tests/src/types.ts
+++ b/tests/src/types.ts
@@ -4,7 +4,8 @@ export type ProfileName =
   | "status-profile"
   | "ui-profile"
   | "mcp-profile"
-  | "auth-profile";
+  | "auth-profile"
+  | "flow-insights";
 
 export type UiMode = "spa" | "ssr" | "server-rendered";
 
@@ -25,6 +26,9 @@ export type StackMetadata = {
       enabled?: boolean;
     };
     auth?: {
+      enabled?: boolean;
+    };
+    flowInsights?: {
       enabled?: boolean;
     };
   };


### PR DESCRIPTION
## Summary

Implements issue #229 — the scenario-based contract and integration test scaffold for the flow insight capability (Phase 0 final item).

- Adds `NormalizedEvidenceState` to `schema/provider-adapter-input.yaml` with states `not_required`, `required`, `pending`, `recorded`, `stale` — the minimal addition needed to support the "waiting on evidence, not effort" signal. Updates `docs/content/flow/adapter-contract.md` and the fixture shape reference to match.
- Expands `tests/features/flow-insights.feature` with 10 provider-tagged scenarios (`@github`, `@gitlab`, `@gitlab-self-managed`, `@cross-provider`) covering blocked-on-review, trunk integration failure, ownership ambiguity, waiting-on-evidence, partial data with reduced confidence, and cross-provider equivalence.
- Adds 12 new YAML fixture files in `schema/fixtures/provider-adapter-input/` covering all six MVP signals across GitHub SaaS, GitLab SaaS, and GitLab self-managed.
- Creates `tests/src/profiles/flow-insights.ts` — a Layer 2 TypeScript contract profile with 17 test cases asserting signal identity, cross-provider equivalence, required field presence, and confidence degradation under partial data. Registered in `index.ts`; `flowInsights` capability flag added to `types.ts`.
- Creates `docs/content/testing/profiles/flow-insights.md` with the scenario table, fixture catalog, cross-stack equivalence rules, and stack declaration requirements (satisfies the Test Harness Sync Rule in `AGENTS.md`).
- Updates `docs/content/flow/intent-scenarios.md` to remove the "not a conformance profile yet" qualifier and link to the new Layer 2 profile.

The inference endpoint (`POST /api/flow/insights`) is marked provisional in the profile until issues #225 and #226 confirm the contract. Stacks declare `capabilities.flowInsights.enabled = true` only after exposing the endpoint.

Closes #229