### PR TITLE
docs(agents): expand iterative change guidance with commit-as-you-go

### DIFF
--- a/.agents/skills/ship-changes/SKILL.md
+++ b/.agents/skills/ship-changes/SKILL.md
@@ -163,17 +163,37 @@ criteria):
    `git worktree` commands. If already inside the matching issue
    worktree, continue there. If the current checkout is dirty and does
    not belong to the same issue worktree, stop and surface the conflict.
-3. **Implement** the required code and documentation in-repo following
-   `AGENTS.md` and existing patterns. Run the issue’s validation
-   commands (or stack-equivalent checks) and fix failures before
-   staging.
-4. If requirements are ambiguous, the issue is blocked, or scope is too
-   large for a single pass, **stop** and ask the user instead of
-   guessing.
+3. **Implement incrementally** following `AGENTS.md` and existing
+   patterns. Break the implementation into the smallest useful steps
+   and commit each step before starting the next:
+   - Plan only the next small step — not the entire implementation.
+   - Make the edit (create, update, or delete one file, or a tightly
+     related group of files that must change together).
+   - Run the fast validation relevant to the change (lint the file,
+     run the narrow test) when it is cheap.
+   - Stage the exact paths you touched and create a commit with a
+     descriptive Conventional Commits message.
+   - Push the branch (see Step 11) so the commit is visible.
+   - Re-read the repo state and plan the next small step from the
+     newly-committed baseline.
+   Repeat this loop until the issue's acceptance criteria are met.
+   Run the issue's full validation commands (or stack-equivalent
+   checks) before handing off to Step 12, and fix failures with
+   additional small commits rather than by rewriting earlier ones.
+4. **Revise with follow-up commits, not rewrites.** If an earlier
+   commit in the series turns out to be wrong or incomplete, land a
+   new commit that corrects it. The squash-merge in Step 13 will
+   collapse the whole series into a single commit on `main`, so
+   intermediate "change direction" commits on the feature branch are
+   expected and healthy.
+5. If requirements are ambiguous, the issue is blocked, or an
+   individual step is still too large to commit cleanly, **stop** and
+   ask the user instead of guessing or batching many unrelated
+   changes into one commit.
 
-When Step 0b runs, the rest of the workflow operates on the new
-changes. If the working tree already contains a complete implementation
-for the issue, **skip Step 0b** and start at Step 1.
+When Step 0b runs, the rest of the workflow operates on the committed
+series of changes. If the working tree already contains a complete
+implementation for the issue, **skip Step 0b** and start at Step 1.
 
 ## Step 1: Review All Unstaged and Untracked Files
 

--- a/.agents/skills/ship-changes/SKILL.md
+++ b/.agents/skills/ship-changes/SKILL.md
@@ -393,6 +393,11 @@ git commit -m "<validated commit message>"
 Run `git log -1 --format="%H %s"` to confirm the commit was created
 successfully.
 
+When the feature branch needs to carry more than one logical change,
+return to Step 1 after this commit and process the next slice. Each
+slice should be its own small commit — do not try to consolidate
+several unrelated changes into the message composed in Steps 4–7.
+
 ## Step 11: Push to Remote
 
 Run `git remote get-url <remote>` (default: `upstream`) to confirm
@@ -424,6 +429,11 @@ REMOTE_SHA=$(git rev-parse <remote>/<branch>)
 ```
 
 If they do not match, stop and report the failure.
+
+Push after every new commit, not just the last one in the series.
+Early pushes make in-progress work visible to concurrent agents and
+reviewers, and keep the remote branch close to the local branch so a
+later failure does not lose work.
 
 ## Step 12: Create a Pull Request
 

--- a/.agents/skills/ship-changes/SKILL.md
+++ b/.agents/skills/ship-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-changes
-version: 1.4.0
+version: 1.5.0
 description: >
   End-to-end workflow that reviews working tree changes, creates a
   feature branch, commits with strict Conventional Commits format,

--- a/.agents/skills/ship-changes/SKILL.md
+++ b/.agents/skills/ship-changes/SKILL.md
@@ -80,6 +80,51 @@ outputs:
 End-to-end workflow: review working tree, create a feature branch,
 commit, push, open a PR, merge to main, and clean up.
 
+## Operating Mode: Iterate in Small Commits
+
+This skill is the final "ship" step, but the implementation work that
+feeds it (Step 0b and any refinement loops along the way) must be
+performed as a sequence of small, granular commits — not as one
+large, in-memory edit session that lands a single monster commit at
+the end.
+
+Follow these rules whenever the skill is actively editing the repo:
+
+- **Commit after every meaningful change.** Every new file, every
+  edit to an existing file, and every deletion is a candidate for
+  its own commit. Do not batch unrelated changes into a single
+  commit just because they happened in the same session.
+- **Do not hold the whole implementation in memory.** Plan the
+  smallest next step, edit, stage, commit, and then re-read the repo
+  to plan the step after that. The commit history is the working
+  memory of the task.
+- **It is okay to revise a previous commit with a new commit.**
+  When a commit turns out to be wrong or incomplete, land a
+  follow-up commit that fixes it rather than trying to rewrite the
+  earlier one in place. The squash-merge at Step 13 collapses the
+  series into a single clean commit on `main`, so intermediate
+  "change direction" commits on the feature branch are expected and
+  healthy.
+- **Stage explicit file paths per commit.** Prefer
+  `git add <path>` over `git add .` / `git add -A` so each commit's
+  scope matches the change you just made and unrelated working-tree
+  changes do not leak in.
+- **Push early and often.** Once the feature branch has its first
+  commit, push it (Step 11) so concurrent agents and reviewers can
+  see progress. Continue pushing after each additional commit rather
+  than waiting until the end.
+- **Re-read before re-editing.** Before modifying a file you already
+  edited earlier in this session, re-read it from disk. Your mental
+  model can drift; the committed state is ground truth.
+
+The numbered steps below describe a single ship pass. When a pass
+produces more than one logical change, repeat Steps 1–11 for each
+slice (stage → classify → lint → commit → push) before moving on to
+Steps 12–15 to open and merge the pull request.
+
+See the top-level [`AGENTS.md`](../../../AGENTS.md) "Iterative Small
+Commits" section for the repo-wide rule this skill implements.
+
 ## Step 0a: Claim the issue (conditional, mandatory when issue_number provided)
 
 When **`issue_number` is provided**, immediately add the `in-progress`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,58 @@ Multiple agents may work in this repo concurrently. Each agent operates independ
 - Automatic cleanup is allowed only after successful merge confirmation and only for clean issue worktrees. Dirty or ambiguous worktrees must be reported and audited rather than deleted blindly.
 - All worktree paths must remain inside the repository root. Do not create sibling-directory or parent-directory worktrees.
 
+## Iterative Small Commits (Required)
+
+Source control is the agent's working memory. Use it instead of trying to
+plan, implement, and perfect a large change in a single edit pass.
+
+### Commit on every meaningful step
+
+- Commit after every meaningful step: a new file created, an existing file
+  edited, or a file deleted. "Meaningful" is small — a single file change
+  that leaves the repo in a coherent state is enough.
+- Prefer many small commits on a feature branch over one large commit.
+  Small commits are easier to review, revert, rebase, and reason about.
+- Stage and commit related files together when they only make sense as a
+  unit (for example, a generated artifact and the source that produced it).
+  Otherwise, commit each change on its own.
+- Run the relevant lint/test/validation for the touched scope before the
+  commit when it is cheap to do so; rely on follow-up commits to fix
+  issues surfaced by broader validation later in the loop.
+
+### Do not hold the whole change in memory
+
+- Do not accumulate edits across many files before writing any of them to
+  disk. Edit, save, and commit in small slices so the working tree always
+  reflects the latest decision.
+- Re-read a file just before editing it, even if you edited it earlier in
+  the same session. Your mental model goes stale; the commit history and
+  the file on disk are ground truth.
+- When a task looks too large to commit in one step, split it into a
+  sequence of small commits (scaffolding → wiring → behavior → docs → tests,
+  or similar). Land each slice before planning the next.
+
+### Iterate through commits, not through rework
+
+- It is expected and normal to change a file one way, learn that a
+  different approach is required, and then update it again in a later
+  commit. Do not treat the first attempt as wasted work — the earlier
+  commit is a checkpoint that makes the revision safe.
+- Prefer a follow-up commit (`fix:`, `refactor:`, or a squash at merge)
+  over silently rewriting an earlier commit. Other agents and reviewers
+  may already be reading the intermediate state.
+- If a direction turns out to be wrong, revert or adjust with a new
+  commit. Do not force-push to erase the exploration from history on a
+  shared branch.
+
+### Delete and move with commits too
+
+- Deleting a file is a change worth committing on its own. Do not bundle
+  unrelated deletions into a larger feature commit.
+- Renames and moves should be committed separately from behavioral
+  changes so git can detect the rename cleanly and reviewers can see the
+  intent of each step.
+
 ## Core Principles
 
 - Secure by default: zero-trust, least privilege, no secrets in code, TLS 1.3+.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -660,7 +660,10 @@ Agents must validate that requested changes actually took effect and report evid
 
 - Conventional Commits are required for maintainers.
 - Include issue references: `Refs #N` or `Closes #N`.
-- Keep commits atomic and scoped to one logical change.
+- Keep commits atomic and scoped to one logical change. See
+  [Iterative Small Commits](#iterative-small-commits-required) — prefer
+  many small commits over one large commit, and commit after each new
+  file, edit, or deletion rather than batching many changes together.
 - Branch naming: `<type>/<short-description>`.
 
 ### Branch Protection (GitHub Rulesets)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,13 @@ Multiple agents may work in this repo concurrently. Each agent operates independ
 - Make the smallest change that satisfies the current task. Do not refactor or reorganize unrelated code.
 - Prefer appending or patching over rewriting. Wholesale rewrites increase merge conflicts and wasted effort.
 - Commit atomically and frequently so concurrent agents can rebase cleanly.
+- Do not try to hold an entire implementation in memory before editing files
+  and committing. Break the work into the smallest useful step, apply it,
+  commit it, and then plan the next step from the newly-committed state.
+- It is expected and healthy to change a file one way, learn that a
+  different approach is required, and then update it again in a follow-up
+  commit. Rely on source control for iteration — do not try to land the
+  "perfect" version in a single edit.
 
 ### Real-time adaptation
 


### PR DESCRIPTION
Clarify that agents should not hold entire implementations in memory
before editing and committing. Iteration across multiple commits is
the expected mode, and it is fine to revise an earlier change in a
later commit as understanding improves.

Refs #0