### PR TITLE
ci(workflow): add weekly orphaned branch cleanup and hygiene rules

### DIFF
--- a/.agents/skills/plan-work/SKILL.md
+++ b/.agents/skills/plan-work/SKILL.md
@@ -45,6 +45,16 @@ implementation plan posted as a comment for maintainer approval.
 The GitHub issue comment is the authoritative review artifact.
 This skill never implements code -- it only plans.
 
+## Branch Policy
+
+This skill is non-mutating with respect to git branches. It runs entirely
+from the main checkout and must not create any branches. If the agent
+runtime automatically creates a branch at session start, this skill must
+delete that branch before completing — no commits should exist on it and
+no PR should be opened from it. Leaving an agent-created branch without
+commits or a PR is an integrity violation that will be flagged by the
+audit-work-integrity skill and removed by the weekly branch cleanup workflow.
+
 ## Step 1: Fetch the Issue
 
 Use the GitHub MCP `get_issue` tool to retrieve the full issue
@@ -221,3 +231,5 @@ This skill is done only when all of the following are true:
 2. The issue is labeled for review (`needs-review`) rather than left only
    in `in-progress`.
 3. The local output includes the posted-plan summary and the comment link.
+4. No agent-created branch exists as a result of running this skill. If the
+   runtime auto-created a branch, it has been deleted before this skill exits.

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,0 +1,100 @@
+name: Branch Cleanup
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # Every Sunday at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-orphaned-branches:
+    name: Remove orphaned zero-commit branches
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Identify and delete orphaned branches
+        run: |
+          BASE_BRANCH="main"
+          EXEMPT_EXACT=("main" "master")
+          EXEMPT_PREFIXES=("release-please--")
+
+          deleted=()
+          skipped_open_pr=()
+          skipped_commits=()
+
+          branches=$(gh api "repos/{owner}/{repo}/branches?per_page=100" --paginate -q '.[].name')
+
+          while IFS= read -r branch; do
+            # Skip exempt exact matches
+            exempt=false
+            for exact in "${EXEMPT_EXACT[@]}"; do
+              if [[ "$branch" == "$exact" ]]; then
+                exempt=true
+                break
+              fi
+            done
+            $exempt && continue
+
+            # Skip exempt prefixes
+            for prefix in "${EXEMPT_PREFIXES[@]}"; do
+              if [[ "$branch" == "$prefix"* ]]; then
+                exempt=true
+                break
+              fi
+            done
+            $exempt && continue
+
+            # Count commits ahead of base branch
+            commit_count=$(git rev-list --count "origin/${BASE_BRANCH}..origin/${branch}" 2>/dev/null || echo "0")
+
+            if [[ "$commit_count" -gt 0 ]]; then
+              skipped_commits+=("${branch} (${commit_count} commits)")
+              continue
+            fi
+
+            # Check for any open PR with this branch as head
+            open_prs=$(gh pr list --head "$branch" --state open --json number -q 'length' 2>/dev/null || echo "0")
+
+            if [[ "$open_prs" -gt 0 ]]; then
+              skipped_open_pr+=("$branch")
+              continue
+            fi
+
+            # Delete the orphaned branch
+            gh api -X DELETE "repos/{owner}/{repo}/git/refs/heads/${branch}"
+            deleted+=("$branch")
+
+          done <<< "$branches"
+
+          {
+            echo "## Branch Cleanup Summary"
+            echo ""
+            echo "### Deleted (orphaned: zero commits ahead of \`${BASE_BRANCH}\`, no open PR)"
+            if [[ ${#deleted[@]} -eq 0 ]]; then
+              echo "_None_"
+            else
+              for b in "${deleted[@]}"; do echo "- \`${b}\`"; done
+            fi
+            echo ""
+            echo "### Skipped (has open PR)"
+            if [[ ${#skipped_open_pr[@]} -eq 0 ]]; then
+              echo "_None_"
+            else
+              for b in "${skipped_open_pr[@]}"; do echo "- \`${b}\`"; done
+            fi
+            echo ""
+            echo "### Skipped (has commits ahead of \`${BASE_BRANCH}\`)"
+            if [[ ${#skipped_commits[@]} -eq 0 ]]; then
+              echo "_None_"
+            else
+              for b in "${skipped_commits[@]}"; do echo "- \`${b}\`"; done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,26 @@ Multiple agents may work in this repo concurrently. Each agent operates independ
 - Automatic cleanup is allowed only after successful merge confirmation and only for clean issue worktrees. Dirty or ambiguous worktrees must be reported and audited rather than deleted blindly.
 - All worktree paths must remain inside the repository root. Do not create sibling-directory or parent-directory worktrees.
 
+### Branch Hygiene
+
+Agent-created branches must not accumulate without corresponding open pull
+requests. The weekly branch cleanup workflow removes orphaned zero-commit
+branches, but agents are responsible for not creating branches they do not need.
+
+- Planning, triage, review, and read-only skills run from the main checkout
+  and must not create branches.
+- If the agent runtime automatically creates a branch at session start, the
+  skill must detect this and delete the branch before completing when no
+  commits were made and no PR was opened from it.
+- Any non-exempt branch with zero commits ahead of `main` and no open PR is
+  considered orphaned. The automated weekly cleanup workflow will delete it.
+- Do not create multiple branches for the same issue. Repeated invocations
+  that produce branch names like `fix/foo-again` or `fix/foo-another-one`
+  signal a process failure, not a workflow pattern. Stop and reconcile the
+  existing branch instead.
+- Exempt from cleanup: `main`, `master`, and any branch matching the prefix
+  `release-please--`.
+
 ## Iterative Small Commits (Required)
 
 Source control is the agent's working memory. Use it instead of trying to


### PR DESCRIPTION
Adds branch hygiene rules and automated cleanup for orphaned agent-created
branches.

## Changes

**AGENTS.md** — New `Branch Hygiene` subsection under Multi-Agent
Collaboration. Explicitly prohibits planning/read-only skills from creating
branches, requires agents to delete auto-created zero-commit branches before
completing, and names the exempt branch patterns.

**plan-work SKILL.md** — New `Branch Policy` section and a fourth
Definition of Done item. Makes explicit that this skill must not create
branches and must clean up any runtime-auto-created branch before exit.

**.github/workflows/branch-cleanup.yml** — Weekly scheduled job (Sundays
midnight UTC, also `workflow_dispatch`) that deletes remote branches with
zero commits ahead of `main` and no associated open PR. Exempts `main`,
`master`, and `release-please--*`. Outputs a categorised step summary.

## Motivation

Audit of open remote branches found 11 zero-commit orphaned branches and
16 additional abandoned branches — all created by AI agent runtimes (Claude,
Codex, Copilot) during planning-only skill invocations. The root cause is
agent runtimes auto-creating a branch at session start even when the skill
never commits anything.

These changes address the leak at both the policy level (rules agents must
follow) and the automation level (weekly reclamation of what slips through).