### PR TITLE
Add GitHub and GitLab provider adapters and fixture-driven tests for flow normalization

### DIFF
--- a/docs/content/architecture/decisions/0014-mvp-flow-observation-technical-foundations.md
+++ b/docs/content/architecture/decisions/0014-mvp-flow-observation-technical-foundations.md
@@ -107,7 +107,7 @@ Deferred to post-MVP or later capability phases:
 
 ## Validation
 
-- Cross-stack equivalence has been confirmed; see [Cross-Stack Equivalence](../../flow/cross-stack-equivalence.md) for the documented results and harness coverage.
+- Cross-stack equivalence is validated through the shared flow insight contract tests (`tests/features/flow-insights.feature`, `tests/src/profiles/flow-insights.ts`) and the provider adapter fixtures in `schema/fixtures/provider-adapter-input/`. Documented results and harness coverage are captured in [Cross-Stack Equivalence](../../flow/cross-stack-equivalence.md).
 
 ## Confirmation
 

--- a/docs/content/architecture/decisions/0014-mvp-flow-observation-technical-foundations.md
+++ b/docs/content/architecture/decisions/0014-mvp-flow-observation-technical-foundations.md
@@ -107,7 +107,7 @@ Deferred to post-MVP or later capability phases:
 
 ## Validation
 
-- Cross-stack equivalence is validated through the shared flow insight contract tests (`tests/features/flow-insights.feature`, `tests/src/profiles/flow-insights.ts`) and the provider adapter fixtures in `schema/fixtures/provider-adapter-input/`. Documented results and harness coverage are captured in [Cross-Stack Equivalence](../../flow/cross-stack-equivalence.md).
+- Cross-stack equivalence is validated through the shared flow insight contract tests (`tests/features/flow-insights.feature`, `tests/src/profiles/flow-insights.ts`) and the provider adapter fixtures in `schema/fixtures/provider-adapter-input/`.
 
 ## Confirmation
 

--- a/stacks/go/net-http/rest/bff/flow/github/adapter.go
+++ b/stacks/go/net-http/rest/bff/flow/github/adapter.go
@@ -1,0 +1,763 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"idp-go-net-http-rest/bff/flow"
+)
+
+const providerName flow.Provider = "github"
+
+func actorID(user User) string {
+	if user.NodeID != "" {
+		return user.NodeID
+	}
+	id := user.ID
+	if id == "" {
+		id = user.Login
+	}
+	return "github-user-" + id
+}
+
+func displayName(user User) string {
+	if strings.TrimSpace(user.Name) != "" {
+		return user.Name
+	}
+	return user.Login
+}
+
+func repoProviderID(repo Repository) string {
+	if repo.NodeID != "" {
+		return repo.NodeID
+	}
+	return repo.ID
+}
+
+func prProviderID(pr PullRequest) string {
+	if pr.NodeID != "" {
+		return pr.NodeID
+	}
+	return pr.ID
+}
+
+func normalizeRepository(repo Repository, fetchedAt string) flow.NormalizedRepository {
+	visibility := repo.Visibility
+	if visibility == "" {
+		if repo.Private {
+			visibility = "private"
+		} else {
+			visibility = "public"
+		}
+	}
+	return flow.NormalizedRepository{
+		Provider:      providerName,
+		ProviderID:    repoProviderID(repo),
+		FullName:      repo.FullName,
+		DefaultBranch: repo.DefaultBranch,
+		Visibility:    visibility,
+		Archived:      repo.Archived,
+		FetchedAt:     fetchedAt,
+	}
+}
+
+var workItemPattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|closes|closed|closing|fix|fixe[sd]?|fixing|resolve[sd]?|resolving)\s+#(\d+)`)
+
+func extractWorkItemRefs(pr PullRequest, repo Repository, issues []Issue) ([]flow.NormalizedWorkItemRef, bool) {
+	order := []string{}
+	refs := map[string]*flow.NormalizedWorkItemRef{}
+	text := pr.Title + "\n" + pr.Body
+	for _, m := range workItemPattern.FindAllStringSubmatch(text, -1) {
+		external := m[1]
+		if _, ok := refs[external]; ok {
+			continue
+		}
+		refs[external] = &flow.NormalizedWorkItemRef{
+			ExternalID: external,
+			Provider:   "github",
+		}
+		order = append(order, external)
+	}
+
+	isPartial := false
+	if len(issues) > 0 {
+		for _, external := range order {
+			ref := refs[external]
+			var matched *Issue
+			for i := range issues {
+				if fmt.Sprintf("%d", issues[i].Number) == external {
+					matched = &issues[i]
+					break
+				}
+			}
+			if matched != nil {
+				ref.Title = matched.Title
+				ref.State = matched.State
+				if matched.HTMLURL != "" {
+					ref.URL = matched.HTMLURL
+				} else {
+					ref.URL = fmt.Sprintf("https://github.com/%s/issues/%d", repo.FullName, matched.Number)
+				}
+			} else {
+				ref.URL = fmt.Sprintf("https://github.com/%s/issues/%s", repo.FullName, external)
+				isPartial = true
+			}
+		}
+	} else if len(order) > 0 {
+		for _, external := range order {
+			ref := refs[external]
+			if ref.URL == "" {
+				ref.URL = fmt.Sprintf("https://github.com/%s/issues/%s", repo.FullName, external)
+			}
+		}
+		isPartial = true
+	}
+
+	out := make([]flow.NormalizedWorkItemRef, 0, len(order))
+	for _, external := range order {
+		out = append(out, *refs[external])
+	}
+	return out, isPartial
+}
+
+func normalizeChange(pr PullRequest, repo Repository, fetchedAt string, issues []Issue) flow.NormalizedChange {
+	refs, isPartialRefs := extractWorkItemRefs(pr, repo, issues)
+
+	state := "open"
+	if pr.State == "closed" {
+		if pr.MergedAt != "" {
+			state = "merged"
+		} else {
+			state = "closed"
+		}
+	}
+
+	return flow.NormalizedChange{
+		Provider:      providerName,
+		ProviderID:    prProviderID(pr),
+		RepositoryID:  repoProviderID(repo),
+		SourceBranch:  pr.Head.Ref,
+		TargetBranch:  pr.Base.Ref,
+		State:         state,
+		AuthorActorID: actorID(pr.User),
+		CreatedAt:     pr.CreatedAt,
+		UpdatedAt:     pr.UpdatedAt,
+		Title:         pr.Title,
+		IsDraft:       pr.Draft,
+		WorkItemRefs:  refs,
+		MergedAt:      pr.MergedAt,
+		ClosedAt:      pr.ClosedAt,
+		FetchedAt:     fetchedAt,
+		IsPartial:     isPartialRefs,
+	}
+}
+
+type reviewerState struct {
+	state       string
+	submittedAt string
+	reviewer    User
+}
+
+func mapReviewState(pr PullRequest, reviews []Review, protection *BranchProtection, fetchedAt string) flow.NormalizedReviewState {
+	requiredApprovalCount := 0
+	requiredUserIDs := []string{}
+	protectionTeamNames := []string{}
+	if protection != nil {
+		requiredApprovalCount = protection.RequiredApprovingReviewCount
+		for _, r := range protection.RequiredReviewers {
+			switch r.Type {
+			case "User":
+				id := r.ID
+				if id == "" {
+					id = r.Name
+				}
+				requiredUserIDs = append(requiredUserIDs, actorID(User{ID: id, Login: r.Name}))
+			case "Team":
+				if r.Name != "" {
+					protectionTeamNames = append(protectionTeamNames, r.Name)
+				}
+			}
+		}
+	}
+
+	requestedTeamNames := []string{}
+	for _, t := range pr.RequestedTeams {
+		name := t.Slug
+		if name == "" {
+			name = t.Name
+		}
+		if name != "" {
+			requestedTeamNames = append(requestedTeamNames, name)
+		}
+	}
+
+	teamSet := map[string]struct{}{}
+	reviewerTeamNames := []string{}
+	for _, n := range append(append([]string{}, requestedTeamNames...), protectionTeamNames...) {
+		if _, ok := teamSet[n]; ok {
+			continue
+		}
+		teamSet[n] = struct{}{}
+		reviewerTeamNames = append(reviewerTeamNames, n)
+	}
+
+	reviewerStates := map[string]reviewerState{}
+	reviewerOrder := []string{}
+	for _, review := range reviews {
+		key := actorID(review.User)
+		existing, ok := reviewerStates[key]
+		if !ok {
+			reviewerOrder = append(reviewerOrder, key)
+			reviewerStates[key] = reviewerState{state: review.State, submittedAt: review.SubmittedAt, reviewer: review.User}
+			continue
+		}
+		// later submission wins (mirroring TS: when current >= existing).
+		var existingTime int64
+		if existing.submittedAt != "" {
+			if t, err := time.Parse(time.RFC3339, existing.submittedAt); err == nil {
+				existingTime = t.UnixNano()
+			}
+		}
+		var currentTime int64
+		if review.SubmittedAt != "" {
+			if t, err := time.Parse(time.RFC3339, review.SubmittedAt); err == nil {
+				currentTime = t.UnixNano()
+			}
+		} else {
+			currentTime = 1<<62 - 1
+		}
+		if currentTime >= existingTime {
+			reviewerStates[key] = reviewerState{state: review.State, submittedAt: review.SubmittedAt, reviewer: review.User}
+		}
+	}
+
+	approvalCount := 0
+	changesRequestedCount := 0
+	underReviewCount := 0
+	for _, key := range reviewerOrder {
+		s := reviewerStates[key]
+		switch s.state {
+		case "APPROVED":
+			approvalCount++
+		case "CHANGES_REQUESTED":
+			changesRequestedCount++
+		case "COMMENTED", "DISMISSED":
+			underReviewCount++
+		}
+	}
+
+	requestedReviewerIDs := []string{}
+	for _, u := range pr.RequestedReviewers {
+		requestedReviewerIDs = append(requestedReviewerIDs, actorID(u))
+	}
+
+	idSet := map[string]struct{}{}
+	reviewerIDs := []string{}
+	for _, id := range requestedReviewerIDs {
+		if _, ok := idSet[id]; !ok {
+			idSet[id] = struct{}{}
+			reviewerIDs = append(reviewerIDs, id)
+		}
+	}
+	for _, id := range requiredUserIDs {
+		if _, ok := idSet[id]; !ok {
+			idSet[id] = struct{}{}
+			reviewerIDs = append(reviewerIDs, id)
+		}
+	}
+	for _, id := range reviewerOrder {
+		if _, ok := idSet[id]; !ok {
+			idSet[id] = struct{}{}
+			reviewerIDs = append(reviewerIDs, id)
+		}
+	}
+
+	submitted := []string{}
+	for _, key := range reviewerOrder {
+		if reviewerStates[key].submittedAt != "" {
+			submitted = append(submitted, reviewerStates[key].submittedAt)
+		}
+	}
+	sort.Strings(submitted)
+	lastActivity := ""
+	if len(submitted) > 0 {
+		lastActivity = submitted[len(submitted)-1]
+	}
+	if lastActivity == "" {
+		lastActivity = pr.UpdatedAt
+	}
+
+	state := "awaiting_review"
+	if pr.Draft {
+		state = "not_required"
+	} else {
+		switch {
+		case changesRequestedCount > 0:
+			state = "changes_requested"
+		case requiredApprovalCount > 0 && approvalCount >= requiredApprovalCount:
+			state = "approved"
+		case approvalCount > 0 || underReviewCount > 0:
+			state = "under_review"
+		case len(reviewerIDs) == 0 && requiredApprovalCount == 0:
+			state = "not_required"
+		}
+	}
+
+	asOf := lastActivity
+	if asOf == "" {
+		asOf = fetchedAt
+	}
+
+	out := flow.NormalizedReviewState{
+		ChangeID:              prProviderID(pr),
+		State:                 state,
+		AsOf:                  asOf,
+		ReviewerActorIDs:      reviewerIDs,
+		LastActivityAt:        lastActivity,
+		ApprovalCount:         approvalCount,
+		RequiredApprovalCount: requiredApprovalCount,
+	}
+	if len(reviewerTeamNames) > 0 {
+		out.ReviewerTeamNames = reviewerTeamNames
+		out.IsPartial = true
+	}
+	return out
+}
+
+func mapCheckState(status, conclusion string) string {
+	if conclusion != "" {
+		switch conclusion {
+		case "success":
+			return "passed"
+		case "failure", "timed_out", "action_required", "startup_failure":
+			return "failed"
+		case "neutral", "skipped", "cancelled":
+			return "skipped"
+		}
+	}
+	switch status {
+	case "queued":
+		return "pending"
+	case "in_progress":
+		return "running"
+	case "completed":
+		return "running"
+	}
+	return "pending"
+}
+
+func normalizeCheckRuns(pr PullRequest, fetchedAt string, runs []CheckRun) []flow.NormalizedValidationRun {
+	out := make([]flow.NormalizedValidationRun, 0, len(runs))
+	for _, run := range runs {
+		scope := "branch"
+		if run.HeadSHA != "" && pr.MergeCommitSHA != "" && run.HeadSHA == pr.MergeCommitSHA {
+			scope = "trunk"
+		} else if len(run.PullRequests) > 0 || run.HeadBranch == pr.Head.Ref {
+			scope = "branch"
+		}
+
+		duration := 0
+		if run.StartedAt != "" && run.CompletedAt != "" {
+			start, errStart := time.Parse(time.RFC3339, run.StartedAt)
+			end, errEnd := time.Parse(time.RFC3339, run.CompletedAt)
+			if errStart == nil && errEnd == nil {
+				secs := int(end.Sub(start).Seconds())
+				if secs < 0 {
+					secs = 0
+				}
+				duration = secs
+			}
+		}
+
+		runAt := run.CompletedAt
+		if runAt == "" {
+			runAt = run.StartedAt
+		}
+		if runAt == "" {
+			runAt = fetchedAt
+		}
+
+		failureSummary := ""
+		if run.Conclusion != "" && run.Conclusion != "success" {
+			failureSummary = run.Conclusion
+		}
+
+		out = append(out, flow.NormalizedValidationRun{
+			ChangeID:        prProviderID(pr),
+			Scope:           scope,
+			State:           mapCheckState(run.Status, run.Conclusion),
+			RunAt:           runAt,
+			Name:            run.Name,
+			URL:             run.HTMLURL,
+			DurationSeconds: duration,
+			FailureSummary:  failureSummary,
+		})
+	}
+	return out
+}
+
+func normalizeStatuses(pr PullRequest, fetchedAt string, statuses []Status, scope string, ambiguous bool) []flow.NormalizedValidationRun {
+	out := make([]flow.NormalizedValidationRun, 0, len(statuses))
+	for _, s := range statuses {
+		state := "failed"
+		switch s.State {
+		case "success":
+			state = "passed"
+		case "pending":
+			state = "running"
+		}
+		runAt := s.UpdatedAt
+		if runAt == "" {
+			runAt = fetchedAt
+		}
+		failureSummary := ""
+		if state == "failed" {
+			failureSummary = s.State
+		}
+		out = append(out, flow.NormalizedValidationRun{
+			ChangeID:       prProviderID(pr),
+			Scope:          scope,
+			State:          state,
+			RunAt:          runAt,
+			Name:           s.Context,
+			URL:            s.TargetURL,
+			FailureSummary: failureSummary,
+			IsPartial:      ambiguous,
+		})
+	}
+	return out
+}
+
+func normalizeWorkflowRuns(pr PullRequest, fetchedAt string, runs []WorkflowRun, scope string, partial bool) []flow.NormalizedValidationRun {
+	out := make([]flow.NormalizedValidationRun, 0, len(runs))
+	for _, run := range runs {
+		runAt := run.UpdatedAt
+		if runAt == "" {
+			runAt = run.RunStartedAt
+		}
+		if runAt == "" {
+			runAt = fetchedAt
+		}
+
+		duration := 0
+		if run.RunStartedAt != "" && run.UpdatedAt != "" {
+			start, errStart := time.Parse(time.RFC3339, run.RunStartedAt)
+			end, errEnd := time.Parse(time.RFC3339, run.UpdatedAt)
+			if errStart == nil && errEnd == nil {
+				secs := int(end.Sub(start).Seconds())
+				if secs < 0 {
+					secs = 0
+				}
+				duration = secs
+			}
+		}
+
+		var state string
+		switch {
+		case run.Conclusion == "success":
+			state = "passed"
+		case run.Conclusion == "failure" || run.Conclusion == "startup_failure" || run.Conclusion == "timed_out":
+			state = "failed"
+		case run.Status == "in_progress":
+			state = "running"
+		case run.Status == "queued":
+			state = "pending"
+		case run.Conclusion == "cancelled" || run.Conclusion == "skipped":
+			state = "skipped"
+		default:
+			state = "running"
+		}
+
+		failureSummary := ""
+		if state == "failed" {
+			if run.Conclusion != "" {
+				failureSummary = run.Conclusion
+			} else {
+				failureSummary = "failed"
+			}
+		}
+
+		out = append(out, flow.NormalizedValidationRun{
+			ChangeID:        prProviderID(pr),
+			Scope:           scope,
+			State:           state,
+			RunAt:           runAt,
+			Name:            run.Name,
+			URL:             run.HTMLURL,
+			DurationSeconds: duration,
+			FailureSummary:  failureSummary,
+			IsPartial:       partial,
+		})
+	}
+	return out
+}
+
+func collectActors(prs []PullRequest, reviewsByPullNumber map[int][]Review, protection *BranchProtection) []flow.NormalizedActor {
+	order := []string{}
+	actors := map[string]flow.NormalizedActor{}
+	add := func(user User) {
+		if user.Login == "" && user.ID == "" && user.NodeID == "" {
+			return
+		}
+		id := actorID(user)
+		if _, ok := actors[id]; ok {
+			return
+		}
+		actors[id] = flow.NormalizedActor{
+			Provider:        providerName,
+			ProviderID:      id,
+			DisplayName:     displayName(user),
+			ProviderLogin:   user.Login,
+			TeamMemberships: user.Teams,
+		}
+		order = append(order, id)
+	}
+
+	for _, pr := range prs {
+		add(pr.User)
+		if pr.MergedBy != nil {
+			add(*pr.MergedBy)
+		}
+		for _, r := range pr.RequestedReviewers {
+			add(r)
+		}
+		for _, r := range reviewsByPullNumber[pr.Number] {
+			add(r.User)
+		}
+	}
+
+	if protection != nil {
+		for _, r := range protection.RequiredReviewers {
+			if r.Type == "User" {
+				id := r.ID
+				if id == "" {
+					id = r.Name
+				}
+				add(User{ID: id, Login: r.Name})
+			}
+		}
+	}
+
+	out := make([]flow.NormalizedActor, 0, len(order))
+	for _, id := range order {
+		out = append(out, actors[id])
+	}
+	return out
+}
+
+func normalizeOwnershipHints(repo Repository, codeownersText string, protection *BranchProtection, actors []flow.NormalizedActor) []flow.NormalizedOwnershipHint {
+	repositoryID := repoProviderID(repo)
+	hints := []flow.NormalizedOwnershipHint{}
+
+	actorByLogin := map[string]string{}
+	actorByID := map[string]struct{}{}
+	for _, a := range actors {
+		if a.ProviderLogin != "" {
+			actorByLogin[strings.ToLower(a.ProviderLogin)] = a.ProviderID
+		}
+		actorByID[a.ProviderID] = struct{}{}
+	}
+
+	if codeownersText != "" {
+		for _, entry := range ParseCodeowners(codeownersText) {
+			ownerActorIDs := []string{}
+			ownerTeamNames := []string{}
+			isPartial := false
+			for _, owner := range entry.Owners {
+				if !strings.HasPrefix(owner, "@") {
+					continue
+				}
+				token := owner[1:]
+				if strings.Contains(token, "/") {
+					parts := strings.Split(token, "/")
+					ownerTeamNames = append(ownerTeamNames, parts[len(parts)-1])
+				} else {
+					normalized := strings.ToLower(token)
+					if id, ok := actorByLogin[normalized]; ok {
+						ownerActorIDs = append(ownerActorIDs, id)
+					} else if _, ok := actorByID[token]; ok {
+						ownerActorIDs = append(ownerActorIDs, token)
+					} else {
+						ownerActorIDs = append(ownerActorIDs, "github-user-"+token)
+						isPartial = true
+					}
+				}
+			}
+			if len(ownerActorIDs) > 0 || len(ownerTeamNames) > 0 {
+				hint := flow.NormalizedOwnershipHint{
+					RepositoryID: repositoryID,
+					PathPattern:  entry.Pattern,
+					Source:       "codeowners",
+					Confidence:   "declared",
+					IsPartial:    isPartial,
+				}
+				if len(ownerActorIDs) > 0 {
+					hint.OwnerActorIDs = ownerActorIDs
+				}
+				if len(ownerTeamNames) > 0 {
+					hint.OwnerTeamNames = ownerTeamNames
+				}
+				hints = append(hints, hint)
+			}
+		}
+	}
+
+	if protection != nil && len(protection.RequiredReviewers) > 0 {
+		users := []string{}
+		teams := []string{}
+		isPartial := false
+		for _, r := range protection.RequiredReviewers {
+			if r.Type == "User" {
+				normalized := strings.ToLower(r.Name)
+				if id, ok := actorByLogin[normalized]; ok {
+					users = append(users, id)
+				} else if _, ok := actorByID[r.Name]; ok {
+					users = append(users, r.Name)
+				} else {
+					users = append(users, "github-user-"+r.Name)
+					isPartial = true
+				}
+			} else if r.Type == "Team" {
+				teams = append(teams, r.Name)
+			}
+		}
+		if len(users) > 0 || len(teams) > 0 {
+			hint := flow.NormalizedOwnershipHint{
+				RepositoryID: repositoryID,
+				Source:       "branch_protection",
+				Confidence:   "declared",
+				IsPartial:    isPartial,
+			}
+			if len(users) > 0 {
+				hint.OwnerActorIDs = users
+			}
+			if len(teams) > 0 {
+				hint.OwnerTeamNames = teams
+			}
+			hints = append(hints, hint)
+		}
+	}
+
+	if len(hints) == 0 {
+		hints = append(hints, flow.NormalizedOwnershipHint{
+			RepositoryID:   repositoryID,
+			OwnerActorIDs:  []string{},
+			OwnerTeamNames: []string{},
+			Confidence:     "inferred",
+		})
+	}
+
+	return hints
+}
+
+func normalizeMergeEvent(pr PullRequest) *flow.NormalizedMergeEvent {
+	if pr.MergedAt == "" {
+		return nil
+	}
+	event := &flow.NormalizedMergeEvent{
+		ChangeID:       prProviderID(pr),
+		MergedAt:       pr.MergedAt,
+		TargetBranch:   pr.Base.Ref,
+		MergeCommitSHA: pr.MergeCommitSHA,
+	}
+	if pr.MergedBy != nil {
+		event.MergedByActorID = actorID(*pr.MergedBy)
+	}
+	return event
+}
+
+// BuildProviderInput converts a GitHub adapter source into the normalized
+// provider adapter input contract shared across stacks.
+func BuildProviderInput(source GitHubAdapterSource) flow.ProviderAdapterInput {
+	repo := normalizeRepository(source.Repository, source.FetchedAt)
+
+	changes := make([]flow.NormalizedChange, 0, len(source.PullRequests))
+	for _, pr := range source.PullRequests {
+		changes = append(changes, normalizeChange(pr, source.Repository, source.FetchedAt, source.Issues))
+	}
+
+	mergeEvents := []flow.NormalizedMergeEvent{}
+	for _, pr := range source.PullRequests {
+		if event := normalizeMergeEvent(pr); event != nil {
+			mergeEvents = append(mergeEvents, *event)
+		}
+	}
+
+	reviewStates := make([]flow.NormalizedReviewState, 0, len(source.PullRequests))
+	for _, pr := range source.PullRequests {
+		reviewStates = append(reviewStates, mapReviewState(pr, source.ReviewsByPullNumber[pr.Number], source.BranchProtection, source.FetchedAt))
+	}
+
+	actors := collectActors(source.PullRequests, source.ReviewsByPullNumber, source.BranchProtection)
+
+	validationRuns := []flow.NormalizedValidationRun{}
+	for _, pr := range source.PullRequests {
+		validationRuns = append(validationRuns, normalizeCheckRuns(pr, source.FetchedAt, source.CheckRunsByPullNumber[pr.Number])...)
+
+		if pr.Head.SHA != "" {
+			if statuses, ok := source.StatusesByHeadSHA[pr.Head.SHA]; ok && len(statuses) > 0 {
+				validationRuns = append(validationRuns, normalizeStatuses(pr, source.FetchedAt, statuses, "branch", false)...)
+			}
+		}
+
+		if pr.MergeCommitSHA != "" {
+			if statuses, ok := source.StatusesByHeadSHA[pr.MergeCommitSHA]; ok && len(statuses) > 0 {
+				validationRuns = append(validationRuns, normalizeStatuses(pr, source.FetchedAt, statuses, "trunk", false)...)
+			}
+		}
+
+		branchRuns := source.WorkflowRunsByBranch[pr.Head.Ref]
+		if len(branchRuns) == 0 {
+			branchRuns = source.WorkflowRunsByBranch["refs/heads/"+pr.Head.Ref]
+		}
+		if len(branchRuns) > 0 {
+			validationRuns = append(validationRuns, normalizeWorkflowRuns(pr, source.FetchedAt, branchRuns, "branch", false)...)
+		}
+
+		var trunkRuns []WorkflowRun
+		if pr.MergeCommitSHA != "" {
+			for _, run := range source.WorkflowRunsByBranch[source.Repository.DefaultBranch] {
+				if run.HeadSHA == pr.MergeCommitSHA {
+					trunkRuns = append(trunkRuns, run)
+				}
+			}
+		}
+		if len(trunkRuns) > 0 {
+			validationRuns = append(validationRuns, normalizeWorkflowRuns(pr, source.FetchedAt, trunkRuns, "trunk", false)...)
+		}
+
+		hasMergeStatuses := false
+		if pr.MergeCommitSHA != "" {
+			if statuses, ok := source.StatusesByHeadSHA[pr.MergeCommitSHA]; ok && len(statuses) > 0 {
+				hasMergeStatuses = true
+			}
+		}
+
+		if pr.MergedAt != "" && pr.MergeCommitSHA != "" && !hasMergeStatuses && len(trunkRuns) == 0 {
+			validationRuns = append(validationRuns, flow.NormalizedValidationRun{
+				ChangeID:       prProviderID(pr),
+				Scope:          "trunk",
+				State:          "pending",
+				RunAt:          source.FetchedAt,
+				Name:           "post-merge-validation",
+				IsPartial:      true,
+				FailureSummary: "post-merge validation evidence not available",
+			})
+		}
+	}
+
+	ownershipHints := normalizeOwnershipHints(source.Repository, source.CodeownersText, source.BranchProtection, actors)
+
+	return flow.ProviderAdapterInput{
+		Repository:     repo,
+		Changes:        changes,
+		Actors:         actors,
+		ReviewStates:   reviewStates,
+		ValidationRuns: validationRuns,
+		MergeEvents:    mergeEvents,
+		OwnershipHints: ownershipHints,
+	}
+}

--- a/stacks/go/net-http/rest/bff/flow/github/adapter_test.go
+++ b/stacks/go/net-http/rest/bff/flow/github/adapter_test.go
@@ -1,0 +1,140 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"idp-go-net-http-rest/bff/flow"
+)
+
+func loadFixture(t *testing.T, name string) flow.ProviderAdapterInput {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("unable to resolve caller")
+	}
+	base := filepath.Dir(file)
+	// stacks/go/net-http/rest/bff/flow/github -> repo root is six levels up.
+	path := filepath.Join(base, "..", "..", "..", "..", "..", "..", "..", "schema", "fixtures", "provider-adapter-input", name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	var input flow.ProviderAdapterInput
+	if err := yaml.Unmarshal(data, &input); err != nil {
+		t.Fatalf("unmarshal fixture %s: %v", name, err)
+	}
+	if input.EvidenceStates == nil {
+		input.EvidenceStates = []flow.NormalizedEvidenceState{}
+	}
+	if input.MergeEvents == nil {
+		input.MergeEvents = []flow.NormalizedMergeEvent{}
+	}
+	return input
+}
+
+func sortInput(input flow.ProviderAdapterInput) flow.ProviderAdapterInput {
+	out := input
+	out.Changes = append([]flow.NormalizedChange(nil), input.Changes...)
+	sort.SliceStable(out.Changes, func(i, j int) bool { return out.Changes[i].ProviderID < out.Changes[j].ProviderID })
+
+	out.Actors = append([]flow.NormalizedActor(nil), input.Actors...)
+	sort.SliceStable(out.Actors, func(i, j int) bool { return out.Actors[i].ProviderID < out.Actors[j].ProviderID })
+
+	out.ReviewStates = append([]flow.NormalizedReviewState(nil), input.ReviewStates...)
+	sort.SliceStable(out.ReviewStates, func(i, j int) bool { return out.ReviewStates[i].ChangeID < out.ReviewStates[j].ChangeID })
+
+	out.ValidationRuns = append([]flow.NormalizedValidationRun(nil), input.ValidationRuns...)
+	sort.SliceStable(out.ValidationRuns, func(i, j int) bool {
+		a := out.ValidationRuns[i]
+		b := out.ValidationRuns[j]
+		if a.ChangeID != b.ChangeID {
+			return a.ChangeID < b.ChangeID
+		}
+		if a.Scope != b.Scope {
+			return a.Scope < b.Scope
+		}
+		return a.RunAt < b.RunAt
+	})
+
+	out.MergeEvents = append([]flow.NormalizedMergeEvent(nil), input.MergeEvents...)
+	sort.SliceStable(out.MergeEvents, func(i, j int) bool { return out.MergeEvents[i].ChangeID < out.MergeEvents[j].ChangeID })
+
+	out.OwnershipHints = append([]flow.NormalizedOwnershipHint(nil), input.OwnershipHints...)
+	sort.SliceStable(out.OwnershipHints, func(i, j int) bool {
+		a := out.OwnershipHints[i]
+		b := out.OwnershipHints[j]
+		if a.PathPattern != b.PathPattern {
+			return a.PathPattern < b.PathPattern
+		}
+		return a.Source < b.Source
+	})
+
+	for i := range out.Changes {
+		if out.Changes[i].WorkItemRefs == nil {
+			out.Changes[i].WorkItemRefs = []flow.NormalizedWorkItemRef{}
+		}
+	}
+
+	for i := range out.OwnershipHints {
+		if out.OwnershipHints[i].OwnerActorIDs == nil {
+			out.OwnershipHints[i].OwnerActorIDs = []string{}
+		}
+		if out.OwnershipHints[i].OwnerTeamNames == nil {
+			out.OwnershipHints[i].OwnerTeamNames = []string{}
+		}
+	}
+
+	if out.MergeEvents == nil {
+		out.MergeEvents = []flow.NormalizedMergeEvent{}
+	}
+	if out.EvidenceStates == nil {
+		out.EvidenceStates = []flow.NormalizedEvidenceState{}
+	}
+	return out
+}
+
+func assertProviderInputEqual(t *testing.T, got, want flow.ProviderAdapterInput) {
+	t.Helper()
+	gotS := sortInput(got)
+	wantS := sortInput(want)
+	if !reflect.DeepEqual(gotS, wantS) {
+		t.Fatalf("provider input mismatch\n got: %#v\nwant: %#v", gotS, wantS)
+	}
+}
+
+func TestGitHubAdapterBlockedOnReview(t *testing.T) {
+	got := BuildProviderInput(blockedOnReviewSource())
+	want := loadFixture(t, "blocked-on-review-github")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitHubAdapterChangesRequested(t *testing.T) {
+	got := BuildProviderInput(changesRequestedSource())
+	want := loadFixture(t, "changes-requested-github")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitHubAdapterReviewNotRequired(t *testing.T) {
+	got := BuildProviderInput(reviewNotRequiredSource())
+	want := loadFixture(t, "review-not-required-github")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitHubAdapterTrunkIntegrationFailure(t *testing.T) {
+	got := BuildProviderInput(trunkIntegrationFailureSource())
+	want := loadFixture(t, "trunk-integration-failed-github")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitHubAdapterPartialEvidence(t *testing.T) {
+	got := BuildProviderInput(partialEvidenceSource())
+	want := loadFixture(t, "partial-data-github")
+	assertProviderInputEqual(t, got, want)
+}

--- a/stacks/go/net-http/rest/bff/flow/github/codeowners.go
+++ b/stacks/go/net-http/rest/bff/flow/github/codeowners.go
@@ -1,0 +1,27 @@
+package github
+
+import "strings"
+
+type CodeownersEntry struct {
+	Pattern string
+	Owners  []string
+}
+
+func ParseCodeowners(content string) []CodeownersEntry {
+	entries := []CodeownersEntry{}
+	for _, raw := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		entries = append(entries, CodeownersEntry{
+			Pattern: parts[0],
+			Owners:  parts[1:],
+		})
+	}
+	return entries
+}

--- a/stacks/go/net-http/rest/bff/flow/github/fixtures_test.go
+++ b/stacks/go/net-http/rest/bff/flow/github/fixtures_test.go
@@ -1,0 +1,313 @@
+package github
+
+// Fixture helpers used by adapter_test.go. Mirrors
+// stacks/nodejs/react-fastify/rest/bff/src/flow/github/fixtures.ts so the Go
+// adapter normalizes equivalent inputs to the shared fixture catalog under
+// schema/fixtures/provider-adapter-input/.
+
+func blockedOnReviewSource() AdapterSource {
+	return GitHubAdapterSource{
+		Repository: Repository{
+			ID:            "repo-payments-001",
+			NodeID:        "repo-payments-001",
+			Name:          "payments-service",
+			FullName:      "example-org/payments-service",
+			DefaultBranch: "main",
+			Visibility:    "private",
+		},
+		PullRequests: []PullRequest{{
+			ID:        "pr-789",
+			NodeID:    "pr-789",
+			Number:    789,
+			Title:     "Add payment webhook",
+			Body:      "Implements webhook handler. Closes #42",
+			State:     "open",
+			User:      User{ID: "actor-alice", NodeID: "actor-alice", Login: "alice", Name: "Alice", Teams: []string{"payments-team"}},
+			CreatedAt: "2026-03-30T08:00:00Z",
+			UpdatedAt: "2026-04-01T09:00:00Z",
+			Base:      PullRequestRef{Ref: "main"},
+			Head:      PullRequestRef{Ref: "feature/add-payment-webhook", SHA: "sha-pr-789"},
+			RequestedReviewers: []User{
+				{ID: "actor-bob", NodeID: "actor-bob", Login: "bob", Name: "Bob", Teams: []string{"payments-team"}},
+				{ID: "actor-carol", NodeID: "actor-carol", Login: "carol", Name: "Carol", Teams: []string{"payments-team"}},
+			},
+		}},
+		ReviewsByPullNumber: map[int][]Review{789: {}},
+		CheckRunsByPullNumber: map[int][]CheckRun{
+			789: {{
+				ID:          "check-1",
+				Name:        "ci / test",
+				Status:      "completed",
+				Conclusion:  "success",
+				StartedAt:   "2026-03-30T08:57:38Z",
+				CompletedAt: "2026-03-30T09:00:00Z",
+				HeadBranch:  "feature/add-payment-webhook",
+				HTMLURL:     "https://github.com/example-org/payments-service/checks/1",
+			}},
+		},
+		BranchProtection: &BranchProtection{RequiredApprovingReviewCount: 1},
+		CodeownersText:   "* @example-org/payments-team",
+		Issues: []Issue{{
+			Number:  42,
+			Title:   "Add payment webhook handler",
+			State:   "open",
+			HTMLURL: "https://github.com/example-org/payments-service/issues/42",
+		}},
+		FetchedAt: "2026-04-01T10:00:00Z",
+	}
+}
+
+func trunkIntegrationFailureSource() AdapterSource {
+	return GitHubAdapterSource{
+		Repository: Repository{
+			ID:            "repo-observability-001",
+			NodeID:        "repo-observability-001",
+			Name:          "observability",
+			FullName:      "example-org/observability",
+			DefaultBranch: "main",
+			Visibility:    "private",
+		},
+		PullRequests: []PullRequest{{
+			ID:             "pr-1234",
+			NodeID:         "pr-1234",
+			Number:         1234,
+			Title:          "Add alerting rules",
+			Body:           "Adds alerting for latency. Resolves #105",
+			State:          "closed",
+			MergedAt:       "2026-04-02T10:15:00Z",
+			ClosedAt:       "2026-04-02T10:15:00Z",
+			MergeCommitSHA: "merge-sha-1234",
+			Merged:         true,
+			User:           User{ID: "actor-dana", NodeID: "actor-dana", Login: "dana", Name: "Dana"},
+			CreatedAt:      "2026-04-01T15:00:00Z",
+			UpdatedAt:      "2026-04-02T10:20:00Z",
+			Base:           PullRequestRef{Ref: "main"},
+			Head:           PullRequestRef{Ref: "feature/add-alerting", SHA: "sha-pr-1234"},
+			RequestedReviewers: []User{
+				{ID: "actor-eli", NodeID: "actor-eli", Login: "eli", Name: "Eli"},
+				{ID: "actor-fay", NodeID: "actor-fay", Login: "fay", Name: "Fay"},
+			},
+			MergedBy: &User{ID: "actor-dana", NodeID: "actor-dana", Login: "dana", Name: "Dana"},
+		}},
+		ReviewsByPullNumber: map[int][]Review{
+			1234: {
+				{ID: "review-1", User: User{ID: "actor-eli", NodeID: "actor-eli", Login: "eli", Name: "Eli"}, State: "APPROVED", SubmittedAt: "2026-04-02T10:05:00Z"},
+				{ID: "review-2", User: User{ID: "actor-fay", NodeID: "actor-fay", Login: "fay", Name: "Fay"}, State: "APPROVED", SubmittedAt: "2026-04-02T10:10:00Z"},
+			},
+		},
+		CheckRunsByPullNumber: map[int][]CheckRun{
+			1234: {{
+				ID:           "check-branch",
+				Name:         "ci / test",
+				Status:       "completed",
+				Conclusion:   "success",
+				StartedAt:    "2026-04-02T09:37:00Z",
+				CompletedAt:  "2026-04-02T09:45:00Z",
+				HeadBranch:   "feature/add-alerting",
+				PullRequests: []PullRequestNumberRef{{Number: 1234}},
+			}},
+		},
+		WorkflowRunsByBranch: map[string][]WorkflowRun{
+			"main": {{
+				ID:           "trunk-run",
+				Name:         "deploy / main",
+				Status:       "completed",
+				Conclusion:   "failure",
+				RunStartedAt: "2026-04-02T10:10:00Z",
+				UpdatedAt:    "2026-04-02T10:25:00Z",
+				HTMLURL:      "https://github.com/example-org/observability/actions/runs/5002",
+				HeadBranch:   "main",
+				HeadSHA:      "merge-sha-1234",
+				Event:        "push",
+			}},
+		},
+		BranchProtection: &BranchProtection{RequiredApprovingReviewCount: 2},
+		CodeownersText:   "* @example-org/sre-team",
+		Issues: []Issue{{
+			Number:  105,
+			Title:   "Add alerting for latency",
+			State:   "open",
+			HTMLURL: "https://github.com/example-org/observability/issues/105",
+		}},
+		FetchedAt: "2026-04-02T12:00:00Z",
+	}
+}
+
+func changesRequestedSource() AdapterSource {
+	return GitHubAdapterSource{
+		Repository: Repository{
+			ID:            "repo-config-001",
+			NodeID:        "repo-config-001",
+			Name:          "config-service",
+			FullName:      "example-org/config-service",
+			DefaultBranch: "main",
+			Visibility:    "private",
+		},
+		PullRequests: []PullRequest{{
+			ID:        "pr-321",
+			NodeID:    "pr-321",
+			Number:    321,
+			Title:     "Tighten config validation",
+			Body:      "Fixes #210",
+			State:     "open",
+			User:      User{ID: "actor-ivy", NodeID: "actor-ivy", Login: "ivy", Name: "Ivy", Teams: []string{"config-team"}},
+			CreatedAt: "2026-04-03T10:30:00Z",
+			UpdatedAt: "2026-04-03T12:02:00Z",
+			Base:      PullRequestRef{Ref: "main"},
+			Head:      PullRequestRef{Ref: "feature/config", SHA: "sha-pr-321"},
+			RequestedReviewers: []User{
+				{ID: "actor-gary", NodeID: "actor-gary", Login: "gary", Name: "Gary", Teams: []string{"config-team"}},
+			},
+		}},
+		ReviewsByPullNumber: map[int][]Review{
+			321: {{
+				ID: "review-1", User: User{ID: "actor-gary", NodeID: "actor-gary", Login: "gary", Name: "Gary"},
+				State: "CHANGES_REQUESTED", SubmittedAt: "2026-04-03T12:00:00Z",
+			}},
+		},
+		CheckRunsByPullNumber: map[int][]CheckRun{
+			321: {{
+				ID:          "check-config",
+				Name:        "ci / lint",
+				Status:      "completed",
+				Conclusion:  "failure",
+				StartedAt:   "2026-04-03T11:55:00Z",
+				CompletedAt: "2026-04-03T12:00:00Z",
+				HeadBranch:  "feature/config",
+				HTMLURL:     "https://github.com/example-org/config-service/checks/42",
+			}},
+		},
+		StatusesByHeadSHA: map[string][]Status{
+			"sha-pr-321": {{
+				State:     "failure",
+				Context:   "legacy-ci",
+				UpdatedAt: "2026-04-03T12:02:00Z",
+				TargetURL: "https://github.com/example-org/config-service/status/1",
+			}},
+		},
+		BranchProtection: &BranchProtection{RequiredApprovingReviewCount: 1},
+		CodeownersText:   "* @example-org/config-team",
+		Issues: []Issue{{
+			Number:  210,
+			Title:   "Improve config validation",
+			State:   "open",
+			HTMLURL: "https://github.com/example-org/config-service/issues/210",
+		}},
+		FetchedAt: "2026-04-03T12:05:00Z",
+	}
+}
+
+func reviewNotRequiredSource() AdapterSource {
+	return GitHubAdapterSource{
+		Repository: Repository{
+			ID:            "repo-docs-001",
+			NodeID:        "repo-docs-001",
+			Name:          "docs",
+			FullName:      "example-org/docs",
+			DefaultBranch: "main",
+			Visibility:    "public",
+		},
+		PullRequests: []PullRequest{{
+			ID:        "pr-555",
+			NodeID:    "pr-555",
+			Number:    555,
+			Title:     "Draft: update onboarding checklist",
+			Body:      "Early draft; no review needed yet.",
+			State:     "open",
+			Draft:     true,
+			User:      User{ID: "actor-jules", NodeID: "actor-jules", Login: "jules", Name: "Jules", Teams: []string{"docs-team"}},
+			CreatedAt: "2026-04-02T09:00:00Z",
+			UpdatedAt: "2026-04-02T09:15:00Z",
+			Base:      PullRequestRef{Ref: "main"},
+			Head:      PullRequestRef{Ref: "docs/draft-onboarding", SHA: "sha-pr-555"},
+		}},
+		ReviewsByPullNumber: map[int][]Review{555: {}},
+		CheckRunsByPullNumber: map[int][]CheckRun{
+			555: {{
+				ID:         "check-docs",
+				Name:       "docs / preview",
+				Status:     "queued",
+				StartedAt:  "2026-04-02T09:10:00Z",
+				HeadBranch: "docs/draft-onboarding",
+				HTMLURL:    "https://github.com/example-org/docs/checks/12",
+			}},
+		},
+		BranchProtection: &BranchProtection{RequiredApprovingReviewCount: 0},
+		CodeownersText:   "* @example-org/docs-team",
+		FetchedAt:        "2026-04-02T09:20:00Z",
+	}
+}
+
+func partialEvidenceSource() AdapterSource {
+	return GitHubAdapterSource{
+		Repository: Repository{
+			ID:            "repo-frontend-001",
+			NodeID:        "repo-frontend-001",
+			Name:          "frontend",
+			FullName:      "example-org/frontend",
+			DefaultBranch: "main",
+			Visibility:    "private",
+		},
+		PullRequests: []PullRequest{{
+			ID:             "pr-888",
+			NodeID:         "pr-888",
+			Number:         888,
+			Title:          "Refactor header layout",
+			Body:           "Refactors header layout. Closes #77",
+			State:          "closed",
+			MergedAt:       "2026-04-04T09:10:00Z",
+			ClosedAt:       "2026-04-04T09:10:00Z",
+			MergeCommitSHA: "merge-sha-888",
+			Merged:         true,
+			User:           User{ID: "actor-henry", NodeID: "actor-henry", Login: "henry", Name: "Henry"},
+			CreatedAt:      "2026-04-03T18:00:00Z",
+			UpdatedAt:      "2026-04-04T09:12:00Z",
+			Base:           PullRequestRef{Ref: "main"},
+			Head:           PullRequestRef{Ref: "feature/header-refactor", SHA: "sha-pr-888"},
+			RequestedTeams: []Team{{ID: "team-frontend", Slug: "frontend-team", Name: "Frontend Team"}},
+			MergedBy:       &User{ID: "actor-henry", NodeID: "actor-henry", Login: "henry", Name: "Henry"},
+		}},
+		ReviewsByPullNumber: map[int][]Review{888: {}},
+		CheckRunsByPullNumber: map[int][]CheckRun{
+			888: {{
+				ID:          "check-ui",
+				Name:        "ci / ui",
+				Status:      "completed",
+				Conclusion:  "success",
+				StartedAt:   "2026-04-04T08:40:00Z",
+				CompletedAt: "2026-04-04T08:50:00Z",
+				HeadBranch:  "feature/header-refactor",
+				HeadSHA:     "sha-pr-888",
+				HTMLURL:     "https://github.com/example-org/frontend/checks/88",
+			}},
+		},
+		WorkflowRunsByBranch: map[string][]WorkflowRun{
+			"main": {{
+				ID:           "trunk-run-1",
+				Name:         "deploy / main",
+				Status:       "completed",
+				Conclusion:   "failure",
+				RunStartedAt: "2026-04-04T09:20:00Z",
+				UpdatedAt:    "2026-04-04T09:35:00Z",
+				HTMLURL:      "https://github.com/example-org/frontend/actions/runs/9001",
+				HeadBranch:   "main",
+				HeadSHA:      "other-commit",
+				Event:        "push",
+			}},
+		},
+		StatusesByHeadSHA: map[string][]Status{
+			"sha-pr-888": {{
+				State:     "success",
+				Context:   "legacy-ui",
+				UpdatedAt: "2026-04-04T08:52:00Z",
+				TargetURL: "https://github.com/example-org/frontend/status/42",
+			}},
+		},
+		BranchProtection: &BranchProtection{
+			RequiredApprovingReviewCount: 1,
+			RequiredReviewers:            []RequiredReviewer{{Type: "Team", Name: "frontend-team"}},
+		},
+		CodeownersText: "* @example-org/frontend-team @octocat",
+		FetchedAt:      "2026-04-04T09:30:00Z",
+	}
+}

--- a/stacks/go/net-http/rest/bff/flow/github/types.go
+++ b/stacks/go/net-http/rest/bff/flow/github/types.go
@@ -1,0 +1,131 @@
+package github
+
+type User struct {
+	ID     string   `json:"id" yaml:"id"`
+	NodeID string   `json:"node_id,omitempty" yaml:"node_id,omitempty"`
+	Login  string   `json:"login" yaml:"login"`
+	Name   string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Teams  []string `json:"teams,omitempty" yaml:"teams,omitempty"`
+}
+
+type Team struct {
+	ID   string `json:"id,omitempty" yaml:"id,omitempty"`
+	Slug string `json:"slug" yaml:"slug"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type Repository struct {
+	ID            string `json:"id" yaml:"id"`
+	NodeID        string `json:"node_id,omitempty" yaml:"node_id,omitempty"`
+	Name          string `json:"name" yaml:"name"`
+	FullName      string `json:"full_name" yaml:"full_name"`
+	DefaultBranch string `json:"default_branch" yaml:"default_branch"`
+	Visibility    string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+	Private       bool   `json:"private,omitempty" yaml:"private,omitempty"`
+	Archived      bool   `json:"archived,omitempty" yaml:"archived,omitempty"`
+}
+
+type PullRequestRef struct {
+	Ref string `json:"ref" yaml:"ref"`
+	SHA string `json:"sha,omitempty" yaml:"sha,omitempty"`
+}
+
+type PullRequestNumberRef struct {
+	Number int `json:"number" yaml:"number"`
+}
+
+type PullRequest struct {
+	ID                 string         `json:"id" yaml:"id"`
+	NodeID             string         `json:"node_id,omitempty" yaml:"node_id,omitempty"`
+	Number             int            `json:"number" yaml:"number"`
+	Title              string         `json:"title" yaml:"title"`
+	Body               string         `json:"body,omitempty" yaml:"body,omitempty"`
+	State              string         `json:"state" yaml:"state"`
+	Draft              bool           `json:"draft,omitempty" yaml:"draft,omitempty"`
+	MergedAt           string         `json:"merged_at,omitempty" yaml:"merged_at,omitempty"`
+	ClosedAt           string         `json:"closed_at,omitempty" yaml:"closed_at,omitempty"`
+	MergeCommitSHA     string         `json:"merge_commit_sha,omitempty" yaml:"merge_commit_sha,omitempty"`
+	Merged             bool           `json:"merged,omitempty" yaml:"merged,omitempty"`
+	User               User           `json:"user" yaml:"user"`
+	CreatedAt          string         `json:"created_at" yaml:"created_at"`
+	UpdatedAt          string         `json:"updated_at" yaml:"updated_at"`
+	Base               PullRequestRef `json:"base" yaml:"base"`
+	Head               PullRequestRef `json:"head" yaml:"head"`
+	RequestedReviewers []User         `json:"requested_reviewers,omitempty" yaml:"requested_reviewers,omitempty"`
+	RequestedTeams     []Team         `json:"requested_teams,omitempty" yaml:"requested_teams,omitempty"`
+	MergedBy           *User          `json:"merged_by,omitempty" yaml:"merged_by,omitempty"`
+}
+
+type Review struct {
+	ID          string `json:"id" yaml:"id"`
+	User        User   `json:"user" yaml:"user"`
+	State       string `json:"state" yaml:"state"`
+	SubmittedAt string `json:"submitted_at,omitempty" yaml:"submitted_at,omitempty"`
+}
+
+type CheckRun struct {
+	ID           string                 `json:"id" yaml:"id"`
+	Name         string                 `json:"name" yaml:"name"`
+	Status       string                 `json:"status" yaml:"status"`
+	Conclusion   string                 `json:"conclusion,omitempty" yaml:"conclusion,omitempty"`
+	StartedAt    string                 `json:"started_at,omitempty" yaml:"started_at,omitempty"`
+	CompletedAt  string                 `json:"completed_at,omitempty" yaml:"completed_at,omitempty"`
+	HTMLURL      string                 `json:"html_url,omitempty" yaml:"html_url,omitempty"`
+	HeadBranch   string                 `json:"head_branch,omitempty" yaml:"head_branch,omitempty"`
+	HeadSHA      string                 `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
+	PullRequests []PullRequestNumberRef `json:"pull_requests,omitempty" yaml:"pull_requests,omitempty"`
+}
+
+type WorkflowRun struct {
+	ID            string `json:"id" yaml:"id"`
+	Name          string `json:"name" yaml:"name"`
+	Status        string `json:"status" yaml:"status"`
+	Conclusion    string `json:"conclusion,omitempty" yaml:"conclusion,omitempty"`
+	RunStartedAt  string `json:"run_started_at,omitempty" yaml:"run_started_at,omitempty"`
+	UpdatedAt     string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	HTMLURL       string `json:"html_url,omitempty" yaml:"html_url,omitempty"`
+	HeadBranch    string `json:"head_branch,omitempty" yaml:"head_branch,omitempty"`
+	HeadSHA       string `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
+	Event         string `json:"event,omitempty" yaml:"event,omitempty"`
+}
+
+type Status struct {
+	State     string `json:"state" yaml:"state"`
+	Context   string `json:"context" yaml:"context"`
+	UpdatedAt string `json:"updated_at" yaml:"updated_at"`
+	TargetURL string `json:"target_url,omitempty" yaml:"target_url,omitempty"`
+}
+
+type RequiredReviewer struct {
+	Type string `json:"type" yaml:"type"`
+	Name string `json:"name" yaml:"name"`
+	ID   string `json:"id,omitempty" yaml:"id,omitempty"`
+}
+
+type BranchProtection struct {
+	RequiredApprovingReviewCount int                `json:"required_approving_review_count,omitempty" yaml:"required_approving_review_count,omitempty"`
+	RequiredReviewers            []RequiredReviewer `json:"required_reviewers,omitempty" yaml:"required_reviewers,omitempty"`
+}
+
+type Issue struct {
+	Number  int    `json:"number" yaml:"number"`
+	Title   string `json:"title,omitempty" yaml:"title,omitempty"`
+	State   string `json:"state,omitempty" yaml:"state,omitempty"`
+	HTMLURL string `json:"html_url,omitempty" yaml:"html_url,omitempty"`
+}
+
+type GitHubAdapterSource struct {
+	Repository            Repository
+	PullRequests          []PullRequest
+	ReviewsByPullNumber   map[int][]Review
+	CheckRunsByPullNumber map[int][]CheckRun
+	WorkflowRunsByBranch  map[string][]WorkflowRun
+	StatusesByHeadSHA     map[string][]Status
+	BranchProtection      *BranchProtection
+	CodeownersText        string
+	Issues                []Issue
+	FetchedAt             string
+}
+
+// AdapterSource is kept as a compatibility alias.
+type AdapterSource = GitHubAdapterSource

--- a/stacks/go/net-http/rest/bff/flow/gitlab/adapter.go
+++ b/stacks/go/net-http/rest/bff/flow/gitlab/adapter.go
@@ -1,0 +1,732 @@
+package gitlab
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"idp-go-net-http-rest/bff/flow"
+	gh "idp-go-net-http-rest/bff/flow/github"
+)
+
+const providerName flow.Provider = "gitlab"
+
+func actorID(user User) string {
+	if strings.TrimSpace(user.ID) != "" {
+		return user.ID
+	}
+	return "gitlab-user-" + user.Username
+}
+
+func displayName(user User) string {
+	if strings.TrimSpace(user.Name) != "" {
+		return user.Name
+	}
+	return user.Username
+}
+
+func repositoryURL(baseURL, path string) string {
+	if baseURL == "" {
+		return ""
+	}
+	trimmed := baseURL
+	if !strings.HasSuffix(trimmed, "/") {
+		trimmed += "/"
+	}
+	return trimmed + path
+}
+
+func issueURL(baseURL, path string, issue Issue) string {
+	if issue.WebURL != "" {
+		return issue.WebURL
+	}
+	if baseURL == "" {
+		return ""
+	}
+	id := issue.IID
+	if id == "" {
+		id = issue.ID
+	}
+	return repositoryURL(baseURL, path) + "/-/issues/" + id
+}
+
+func normalizeRepository(project Project, fetchedAt string) flow.NormalizedRepository {
+	return flow.NormalizedRepository{
+		Provider:      providerName,
+		ProviderID:    project.ID,
+		FullName:      project.PathWithNamespace,
+		DefaultBranch: project.DefaultBranch,
+		Visibility:    project.Visibility,
+		Archived:      project.Archived,
+		FetchedAt:     fetchedAt,
+	}
+}
+
+var workItemPattern = regexp.MustCompile(`(?i)\b(?:close[sd]?|closes|closed|closing|fix|fixe[sd]?|fixing|resolve[sd]?|resolving)\s+#(\d+)`)
+
+func extractWorkItemRefs(mr MergeRequest, project Project, issues []Issue, baseURL string) ([]flow.NormalizedWorkItemRef, bool) {
+	order := []string{}
+	refs := map[string]*flow.NormalizedWorkItemRef{}
+	text := mr.Title + "\n" + mr.Description
+	for _, m := range workItemPattern.FindAllStringSubmatch(text, -1) {
+		external := m[1]
+		if _, ok := refs[external]; ok {
+			continue
+		}
+		refs[external] = &flow.NormalizedWorkItemRef{
+			ExternalID: external,
+			Provider:   "gitlab",
+		}
+		order = append(order, external)
+	}
+
+	isPartial := false
+	if len(issues) > 0 {
+		for _, external := range order {
+			ref := refs[external]
+			var matched *Issue
+			for i := range issues {
+				candidate := issues[i].IID
+				if candidate == "" {
+					candidate = issues[i].ID
+				}
+				if candidate == external {
+					matched = &issues[i]
+					break
+				}
+			}
+			if matched != nil {
+				ref.Title = matched.Title
+				if matched.State == "closed" {
+					ref.State = "closed"
+				} else {
+					ref.State = "open"
+				}
+				ref.URL = issueURL(baseURL, project.PathWithNamespace, *matched)
+			} else {
+				ref.URL = issueURL(baseURL, project.PathWithNamespace, Issue{ID: external})
+				isPartial = true
+			}
+		}
+	} else if len(order) > 0 {
+		for _, external := range order {
+			ref := refs[external]
+			ref.URL = issueURL(baseURL, project.PathWithNamespace, Issue{ID: external})
+		}
+		isPartial = true
+	}
+
+	out := make([]flow.NormalizedWorkItemRef, 0, len(order))
+	for _, external := range order {
+		out = append(out, *refs[external])
+	}
+	return out, isPartial
+}
+
+func normalizeChange(mr MergeRequest, project Project, fetchedAt string, issues []Issue, baseURL string) flow.NormalizedChange {
+	refs, refsPartial := extractWorkItemRefs(mr, project, issues, baseURL)
+
+	state := "open"
+	switch mr.State {
+	case "merged":
+		state = "merged"
+	case "closed":
+		state = "closed"
+	case "locked":
+		state = "locked"
+	}
+
+	change := flow.NormalizedChange{
+		Provider:      providerName,
+		ProviderID:    mr.ID,
+		RepositoryID:  project.ID,
+		SourceBranch:  mr.SourceBranch,
+		TargetBranch:  mr.TargetBranch,
+		State:         state,
+		AuthorActorID: actorID(mr.Author),
+		CreatedAt:     mr.CreatedAt,
+		UpdatedAt:     mr.UpdatedAt,
+		Title:         mr.Title,
+		IsDraft:       mr.Draft || mr.WorkInProgress,
+		MergedAt:      mr.MergedAt,
+		ClosedAt:      mr.ClosedAt,
+		FetchedAt:     fetchedAt,
+		IsPartial:     refsPartial,
+	}
+	if len(refs) > 0 {
+		change.WorkItemRefs = refs
+	}
+	return change
+}
+
+func reviewStateFromApprovals(approvals *ApprovalState, mr MergeRequest, fetchedAt string, selfManaged bool) flow.NormalizedReviewState {
+	approvalCount := 0
+	if approvals != nil {
+		approvalCount = len(approvals.ApprovedBy)
+	}
+	requiredApprovalCount := 0
+	if approvals != nil {
+		requiredApprovalCount = approvals.ApprovalsRequired
+		if requiredApprovalCount == 0 {
+			max := 0
+			for _, rule := range approvals.Rules {
+				if rule.ApprovalsRequired > max {
+					max = rule.ApprovalsRequired
+				}
+			}
+			requiredApprovalCount = max
+		}
+	}
+	var approvalsLeft *int
+	if approvals != nil {
+		approvalsLeft = approvals.ApprovalsLeft
+	}
+
+	state := "awaiting_review"
+	switch {
+	case requiredApprovalCount == 0:
+		state = "not_required"
+	case approvalCount >= requiredApprovalCount || (approvalsLeft != nil && *approvalsLeft == 0):
+		state = "approved"
+	case approvalCount > 0:
+		state = "under_review"
+	}
+
+	reviewerIDs := []string{}
+	seenIDs := map[string]struct{}{}
+	addReviewer := func(id string) {
+		if id == "" {
+			return
+		}
+		if _, ok := seenIDs[id]; ok {
+			return
+		}
+		seenIDs[id] = struct{}{}
+		reviewerIDs = append(reviewerIDs, id)
+	}
+
+	reviewerTeamsSet := map[string]struct{}{}
+	reviewerTeams := []string{}
+	addTeam := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := reviewerTeamsSet[name]; ok {
+			return
+		}
+		reviewerTeamsSet[name] = struct{}{}
+		reviewerTeams = append(reviewerTeams, name)
+	}
+
+	for _, u := range mr.Reviewers {
+		addReviewer(actorID(u))
+	}
+	if approvals != nil {
+		for _, u := range approvals.SuggestedApprovers {
+			addReviewer(actorID(u))
+		}
+		for _, entry := range approvals.ApprovedBy {
+			addReviewer(actorID(entry.User))
+		}
+		for _, rule := range approvals.Rules {
+			for _, u := range rule.Users {
+				addReviewer(actorID(u))
+			}
+			for _, g := range rule.Groups {
+				if g.Name != "" {
+					addTeam(g.Name)
+				} else if g.FullPath != "" {
+					parts := strings.Split(g.FullPath, "/")
+					addTeam(parts[len(parts)-1])
+				}
+			}
+			for _, entry := range rule.ApprovedBy {
+				addReviewer(actorID(entry.User))
+			}
+		}
+	}
+
+	approvalTimes := []string{}
+	if approvals != nil {
+		for _, entry := range approvals.ApprovedBy {
+			if entry.ApprovedAt != "" {
+				approvalTimes = append(approvalTimes, entry.ApprovedAt)
+			}
+		}
+	}
+	sort.Strings(approvalTimes)
+	lastApprovalTime := ""
+	if len(approvalTimes) > 0 {
+		lastApprovalTime = approvalTimes[len(approvalTimes)-1]
+	}
+
+	lastActivity := ""
+	switch {
+	case approvals != nil && approvals.LastActivityAt != "":
+		lastActivity = approvals.LastActivityAt
+	case lastApprovalTime != "":
+		lastActivity = lastApprovalTime
+	case mr.UpdatedAt != "":
+		lastActivity = mr.UpdatedAt
+	default:
+		lastActivity = fetchedAt
+	}
+
+	asOf := ""
+	switch {
+	case approvals != nil && approvals.AsOf != "":
+		asOf = approvals.AsOf
+	case approvals != nil && approvals.LastActivityAt != "":
+		asOf = approvals.LastActivityAt
+	case lastApprovalTime != "":
+		asOf = lastApprovalTime
+	case mr.UpdatedAt != "":
+		asOf = mr.UpdatedAt
+	default:
+		asOf = fetchedAt
+	}
+
+	isPartial := false
+	if selfManaged && requiredApprovalCount > 0 && len(reviewerIDs) == 0 {
+		isPartial = true
+	}
+
+	out := flow.NormalizedReviewState{
+		ChangeID:              mr.ID,
+		State:                 state,
+		AsOf:                  asOf,
+		ReviewerActorIDs:      reviewerIDs,
+		LastActivityAt:        lastActivity,
+		ApprovalCount:         approvalCount,
+		RequiredApprovalCount: requiredApprovalCount,
+		IsPartial:             isPartial,
+	}
+	if len(reviewerTeams) > 0 {
+		out.ReviewerTeamNames = reviewerTeams
+	}
+	return out
+}
+
+func mapPipelineState(status string) string {
+	switch status {
+	case "success":
+		return "passed"
+	case "failed":
+		return "failed"
+	case "running":
+		return "running"
+	case "pending", "manual":
+		return "pending"
+	case "canceled", "skipped":
+		return "skipped"
+	}
+	return "pending"
+}
+
+func normalizePipeline(pipeline Pipeline, scope, changeID, fetchedAt string) flow.NormalizedValidationRun {
+	runAt := pipeline.FinishedAt
+	if runAt == "" {
+		runAt = pipeline.UpdatedAt
+	}
+	if runAt == "" {
+		runAt = pipeline.StartedAt
+	}
+	if runAt == "" {
+		runAt = fetchedAt
+	}
+
+	name := pipeline.Name
+	if name == "" {
+		name = pipeline.Ref
+	}
+
+	failureSummary := ""
+	if pipeline.Status == "failed" {
+		failureSummary = pipeline.FailureReason
+		if failureSummary == "" {
+			failureSummary = "failure"
+		}
+	}
+
+	return flow.NormalizedValidationRun{
+		ChangeID:        changeID,
+		Scope:           scope,
+		State:           mapPipelineState(pipeline.Status),
+		RunAt:           runAt,
+		Name:            name,
+		URL:             pipeline.WebURL,
+		DurationSeconds: pipeline.Duration,
+		FailureSummary:  failureSummary,
+	}
+}
+
+func mapStatusToState(status string) string {
+	switch status {
+	case "success":
+		return "passed"
+	case "failed":
+		return "failed"
+	case "running":
+		return "running"
+	case "pending":
+		return "pending"
+	case "canceled":
+		return "skipped"
+	}
+	return "pending"
+}
+
+func normalizeCommitStatuses(statuses []CommitStatus, changeID, fetchedAt, scope string) []flow.NormalizedValidationRun {
+	out := make([]flow.NormalizedValidationRun, 0, len(statuses))
+	for _, s := range statuses {
+		runAt := s.UpdatedAt
+		if runAt == "" {
+			runAt = s.CreatedAt
+		}
+		if runAt == "" {
+			runAt = fetchedAt
+		}
+		out = append(out, flow.NormalizedValidationRun{
+			ChangeID: changeID,
+			Scope:    scope,
+			State:    mapStatusToState(s.Status),
+			RunAt:    runAt,
+			Name:     s.Name,
+			URL:      s.TargetURL,
+		})
+	}
+	return out
+}
+
+func normalizeMergeEvent(mr MergeRequest) *flow.NormalizedMergeEvent {
+	if mr.MergedAt == "" {
+		return nil
+	}
+	event := &flow.NormalizedMergeEvent{
+		ChangeID:       mr.ID,
+		MergedAt:       mr.MergedAt,
+		TargetBranch:   mr.TargetBranch,
+		MergeCommitSHA: mr.MergeCommitSHA,
+	}
+	if mr.MergedBy != nil {
+		event.MergedByActorID = actorID(*mr.MergedBy)
+	}
+	return event
+}
+
+func collectActors(
+	mrs []MergeRequest,
+	approvalsByMerge map[string]ApprovalState,
+	evidenceByMerge map[string][]EvidenceState,
+	additionalActors []User,
+) []flow.NormalizedActor {
+	order := []string{}
+	actors := map[string]flow.NormalizedActor{}
+
+	add := func(u *User) {
+		if u == nil {
+			return
+		}
+		if u.Username == "" && u.ID == "" {
+			return
+		}
+		id := actorID(*u)
+		if _, ok := actors[id]; ok {
+			return
+		}
+		actors[id] = flow.NormalizedActor{
+			Provider:        providerName,
+			ProviderID:      id,
+			DisplayName:     displayName(*u),
+			ProviderLogin:   u.Username,
+			TeamMemberships: u.Groups,
+		}
+		order = append(order, id)
+	}
+
+	for _, mr := range mrs {
+		author := mr.Author
+		add(&author)
+		if mr.MergedBy != nil {
+			mb := *mr.MergedBy
+			add(&mb)
+		}
+		for _, r := range mr.Reviewers {
+			add(&r)
+		}
+		if approvalsByMerge != nil {
+			if approvals, ok := approvalsByMerge[mr.IID]; ok {
+				for _, entry := range approvals.ApprovedBy {
+					u := entry.User
+					add(&u)
+				}
+				for _, u := range approvals.SuggestedApprovers {
+					add(&u)
+				}
+				for _, rule := range approvals.Rules {
+					for _, u := range rule.Users {
+						add(&u)
+					}
+					for _, entry := range rule.ApprovedBy {
+						u := entry.User
+						add(&u)
+					}
+				}
+			}
+		}
+		if evidenceByMerge != nil {
+			if states, ok := evidenceByMerge[mr.IID]; ok {
+				for _, state := range states {
+					if state.Owner != nil {
+						owner := *state.Owner
+						add(&owner)
+					}
+				}
+			}
+		}
+	}
+
+	for _, u := range additionalActors {
+		add(&u)
+	}
+
+	out := make([]flow.NormalizedActor, 0, len(order))
+	for _, id := range order {
+		out = append(out, actors[id])
+	}
+	return out
+}
+
+func normalizeEvidenceStates(mr MergeRequest, evidenceByMerge map[string][]EvidenceState) []flow.NormalizedEvidenceState {
+	states := evidenceByMerge[mr.IID]
+	out := make([]flow.NormalizedEvidenceState, 0, len(states))
+	for _, state := range states {
+		entry := flow.NormalizedEvidenceState{
+			ChangeID:      mr.ID,
+			State:         state.State,
+			AsOf:          state.AsOf,
+			RequiredTypes: state.RequiredTypes,
+			FreshnessAt:   state.FreshnessAt,
+			IsPartial:     state.IsPartial,
+		}
+		if state.Owner != nil {
+			entry.OwnerActorID = actorID(*state.Owner)
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+func normalizeOwnershipHints(
+	project Project,
+	codeownersText string,
+	groupOwners []string,
+	actors []flow.NormalizedActor,
+	unownedPaths map[string][]string,
+	selfManaged bool,
+) []flow.NormalizedOwnershipHint {
+	repositoryID := project.ID
+	hints := []flow.NormalizedOwnershipHint{}
+
+	actorByLogin := map[string]string{}
+	actorByID := map[string]struct{}{}
+	for _, a := range actors {
+		if a.ProviderLogin != "" {
+			actorByLogin[strings.ToLower(a.ProviderLogin)] = a.ProviderID
+		}
+		actorByID[a.ProviderID] = struct{}{}
+	}
+
+	if len(groupOwners) > 0 {
+		hints = append(hints, flow.NormalizedOwnershipHint{
+			RepositoryID:   repositoryID,
+			OwnerTeamNames: groupOwners,
+			PathPattern:    "*",
+			Source:         "group_membership",
+			Confidence:     "declared",
+		})
+	}
+
+	if codeownersText != "" {
+		for _, entry := range gh.ParseCodeowners(codeownersText) {
+			ownerActorIDs := []string{}
+			ownerTeamNames := []string{}
+			isPartial := false
+			for _, owner := range entry.Owners {
+				if !strings.HasPrefix(owner, "@") {
+					continue
+				}
+				token := owner[1:]
+				if strings.Contains(token, "/") {
+					parts := strings.Split(token, "/")
+					ownerTeamNames = append(ownerTeamNames, parts[len(parts)-1])
+				} else {
+					normalized := strings.ToLower(token)
+					if id, ok := actorByLogin[normalized]; ok {
+						ownerActorIDs = append(ownerActorIDs, id)
+					} else if _, ok := actorByID[token]; ok {
+						ownerActorIDs = append(ownerActorIDs, token)
+					} else {
+						ownerActorIDs = append(ownerActorIDs, "gitlab-user-"+token)
+						isPartial = true
+					}
+				}
+			}
+			if len(ownerActorIDs) > 0 || len(ownerTeamNames) > 0 {
+				hint := flow.NormalizedOwnershipHint{
+					RepositoryID: repositoryID,
+					PathPattern:  entry.Pattern,
+					Source:       "codeowners",
+					Confidence:   "declared",
+					IsPartial:    isPartial || selfManaged,
+				}
+				if len(ownerActorIDs) > 0 {
+					hint.OwnerActorIDs = ownerActorIDs
+				}
+				if len(ownerTeamNames) > 0 {
+					hint.OwnerTeamNames = ownerTeamNames
+				}
+				hints = append(hints, hint)
+			}
+		}
+	}
+
+	if len(unownedPaths) > 0 {
+		unique := []string{}
+		seen := map[string]struct{}{}
+		mergeKeys := make([]string, 0, len(unownedPaths))
+		for key := range unownedPaths {
+			mergeKeys = append(mergeKeys, key)
+		}
+		sort.Strings(mergeKeys)
+		for _, key := range mergeKeys {
+			for _, p := range unownedPaths[key] {
+				if _, ok := seen[p]; ok {
+					continue
+				}
+				seen[p] = struct{}{}
+				unique = append(unique, p)
+			}
+		}
+		for _, p := range unique {
+			hints = append(hints, flow.NormalizedOwnershipHint{
+				RepositoryID:   repositoryID,
+				OwnerActorIDs:  []string{},
+				OwnerTeamNames: []string{},
+				PathPattern:    p,
+				Source:         "codeowners",
+				Confidence:     "inferred",
+				IsPartial:      selfManaged,
+			})
+		}
+	}
+
+	if len(hints) == 0 {
+		hints = append(hints, flow.NormalizedOwnershipHint{
+			RepositoryID:   repositoryID,
+			OwnerActorIDs:  []string{},
+			OwnerTeamNames: []string{},
+			PathPattern:    "*",
+			Confidence:     "inferred",
+		})
+	}
+
+	return hints
+}
+
+// BuildProviderInput converts a GitLab adapter source into the normalized
+// provider adapter input contract shared across stacks.
+func BuildProviderInput(source GitLabAdapterSource) flow.ProviderAdapterInput {
+	repo := normalizeRepository(source.Project, source.FetchedAt)
+
+	changes := make([]flow.NormalizedChange, 0, len(source.MergeRequests))
+	for _, mr := range source.MergeRequests {
+		changes = append(changes, normalizeChange(mr, source.Project, source.FetchedAt, source.Issues, source.BaseURL))
+	}
+
+	mergeEvents := []flow.NormalizedMergeEvent{}
+	for _, mr := range source.MergeRequests {
+		if event := normalizeMergeEvent(mr); event != nil {
+			mergeEvents = append(mergeEvents, *event)
+		}
+	}
+
+	actors := collectActors(source.MergeRequests, source.ApprovalsByMergeIID, source.EvidenceStatesByMergeIID, source.AdditionalActors)
+
+	reviewStates := make([]flow.NormalizedReviewState, 0, len(source.MergeRequests))
+	for _, mr := range source.MergeRequests {
+		var approvals *ApprovalState
+		if source.ApprovalsByMergeIID != nil {
+			if a, ok := source.ApprovalsByMergeIID[mr.IID]; ok {
+				approvals = &a
+			}
+		}
+		reviewStates = append(reviewStates, reviewStateFromApprovals(approvals, mr, source.FetchedAt, source.SelfManaged))
+	}
+
+	validationRuns := []flow.NormalizedValidationRun{}
+	for _, mr := range source.MergeRequests {
+		changeID := mr.ID
+		branchPipelines := source.PipelinesByMergeIID[mr.IID]
+		for _, pipeline := range branchPipelines {
+			validationRuns = append(validationRuns, normalizePipeline(pipeline, "branch", changeID, source.FetchedAt))
+		}
+
+		if mr.SHA != "" {
+			if statuses, ok := source.CommitStatusesBySHA[mr.SHA]; ok && len(statuses) > 0 {
+				validationRuns = append(validationRuns, normalizeCommitStatuses(statuses, changeID, source.FetchedAt, "branch")...)
+			}
+		}
+
+		trunkPipelines := source.TrunkPipelinesByBranch[mr.TargetBranch]
+		trunkMatches := []Pipeline{}
+		for _, pipeline := range trunkPipelines {
+			switch {
+			case mr.MergeCommitSHA != "" && pipeline.SHA != "":
+				if pipeline.SHA == mr.MergeCommitSHA {
+					trunkMatches = append(trunkMatches, pipeline)
+				}
+			case mr.State == "merged":
+				if pipeline.PipelineType == "trunk" || pipeline.Ref == mr.TargetBranch {
+					trunkMatches = append(trunkMatches, pipeline)
+				}
+			}
+		}
+		for _, pipeline := range trunkMatches {
+			validationRuns = append(validationRuns, normalizePipeline(pipeline, "trunk", changeID, source.FetchedAt))
+		}
+
+		if source.AddTrunkValidationPlaceholder && mr.MergedAt != "" && len(trunkMatches) == 0 {
+			validationRuns = append(validationRuns, flow.NormalizedValidationRun{
+				ChangeID:       changeID,
+				Scope:          "trunk",
+				State:          "pending",
+				RunAt:          source.FetchedAt,
+				Name:           "post-merge-validation",
+				IsPartial:      true,
+				FailureSummary: "post-merge validation evidence not available",
+			})
+		}
+	}
+
+	evidenceStates := []flow.NormalizedEvidenceState{}
+	for _, mr := range source.MergeRequests {
+		evidenceStates = append(evidenceStates, normalizeEvidenceStates(mr, source.EvidenceStatesByMergeIID)...)
+	}
+
+	ownershipHints := normalizeOwnershipHints(source.Project, source.CodeownersText, source.GroupOwners, actors, source.UnownedPathsByMergeIID, source.SelfManaged)
+
+	out := flow.ProviderAdapterInput{
+		Repository:     repo,
+		Changes:        changes,
+		Actors:         actors,
+		ReviewStates:   reviewStates,
+		ValidationRuns: validationRuns,
+		MergeEvents:    mergeEvents,
+		OwnershipHints: ownershipHints,
+	}
+	if len(evidenceStates) > 0 {
+		out.EvidenceStates = evidenceStates
+	}
+	return out
+}

--- a/stacks/go/net-http/rest/bff/flow/gitlab/adapter_test.go
+++ b/stacks/go/net-http/rest/bff/flow/gitlab/adapter_test.go
@@ -1,0 +1,162 @@
+package gitlab
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"idp-go-net-http-rest/bff/flow"
+)
+
+func loadFixture(t *testing.T, name string) flow.ProviderAdapterInput {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("unable to resolve caller")
+	}
+	base := filepath.Dir(file)
+	// stacks/go/net-http/rest/bff/flow/gitlab -> repo root is seven levels up.
+	path := filepath.Join(base, "..", "..", "..", "..", "..", "..", "..", "schema", "fixtures", "provider-adapter-input", name+".yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	var input flow.ProviderAdapterInput
+	if err := yaml.Unmarshal(data, &input); err != nil {
+		t.Fatalf("unmarshal fixture %s: %v", name, err)
+	}
+	if input.EvidenceStates == nil {
+		input.EvidenceStates = []flow.NormalizedEvidenceState{}
+	}
+	if input.MergeEvents == nil {
+		input.MergeEvents = []flow.NormalizedMergeEvent{}
+	}
+	return input
+}
+
+func sortInput(input flow.ProviderAdapterInput) flow.ProviderAdapterInput {
+	out := input
+	out.Changes = append([]flow.NormalizedChange(nil), input.Changes...)
+	sort.SliceStable(out.Changes, func(i, j int) bool { return out.Changes[i].ProviderID < out.Changes[j].ProviderID })
+
+	out.Actors = append([]flow.NormalizedActor(nil), input.Actors...)
+	sort.SliceStable(out.Actors, func(i, j int) bool { return out.Actors[i].ProviderID < out.Actors[j].ProviderID })
+
+	out.ReviewStates = append([]flow.NormalizedReviewState(nil), input.ReviewStates...)
+	sort.SliceStable(out.ReviewStates, func(i, j int) bool { return out.ReviewStates[i].ChangeID < out.ReviewStates[j].ChangeID })
+
+	out.ValidationRuns = append([]flow.NormalizedValidationRun(nil), input.ValidationRuns...)
+	sort.SliceStable(out.ValidationRuns, func(i, j int) bool {
+		a := out.ValidationRuns[i]
+		b := out.ValidationRuns[j]
+		if a.ChangeID != b.ChangeID {
+			return a.ChangeID < b.ChangeID
+		}
+		if a.Scope != b.Scope {
+			return a.Scope < b.Scope
+		}
+		return a.RunAt < b.RunAt
+	})
+
+	out.MergeEvents = append([]flow.NormalizedMergeEvent(nil), input.MergeEvents...)
+	sort.SliceStable(out.MergeEvents, func(i, j int) bool { return out.MergeEvents[i].ChangeID < out.MergeEvents[j].ChangeID })
+
+	out.OwnershipHints = append([]flow.NormalizedOwnershipHint(nil), input.OwnershipHints...)
+	sort.SliceStable(out.OwnershipHints, func(i, j int) bool {
+		a := out.OwnershipHints[i]
+		b := out.OwnershipHints[j]
+		if a.PathPattern != b.PathPattern {
+			return a.PathPattern < b.PathPattern
+		}
+		return a.Source < b.Source
+	})
+
+	out.EvidenceStates = append([]flow.NormalizedEvidenceState(nil), input.EvidenceStates...)
+	sort.SliceStable(out.EvidenceStates, func(i, j int) bool {
+		a := out.EvidenceStates[i]
+		b := out.EvidenceStates[j]
+		if a.ChangeID != b.ChangeID {
+			return a.ChangeID < b.ChangeID
+		}
+		return a.AsOf < b.AsOf
+	})
+
+	for i := range out.Changes {
+		if out.Changes[i].WorkItemRefs == nil {
+			out.Changes[i].WorkItemRefs = []flow.NormalizedWorkItemRef{}
+		}
+	}
+
+	for i := range out.OwnershipHints {
+		if out.OwnershipHints[i].OwnerActorIDs == nil {
+			out.OwnershipHints[i].OwnerActorIDs = []string{}
+		}
+		if out.OwnershipHints[i].OwnerTeamNames == nil {
+			out.OwnershipHints[i].OwnerTeamNames = []string{}
+		}
+	}
+
+	if out.MergeEvents == nil {
+		out.MergeEvents = []flow.NormalizedMergeEvent{}
+	}
+	if out.EvidenceStates == nil {
+		out.EvidenceStates = []flow.NormalizedEvidenceState{}
+	}
+	return out
+}
+
+func assertProviderInputEqual(t *testing.T, got, want flow.ProviderAdapterInput) {
+	t.Helper()
+	gotS := sortInput(got)
+	wantS := sortInput(want)
+	if !reflect.DeepEqual(gotS, wantS) {
+		t.Fatalf("provider input mismatch\n got: %#v\nwant: %#v", gotS, wantS)
+	}
+}
+
+func TestGitLabAdapterBlockedOnReview(t *testing.T) {
+	got := BuildProviderInput(blockedOnReviewSource())
+	want := loadFixture(t, "blocked-on-review-gitlab")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitLabAdapterBlockedOnReviewSelfManaged(t *testing.T) {
+	got := BuildProviderInput(blockedOnReviewSelfManagedSource())
+	want := loadFixture(t, "blocked-on-review-gitlab-self-managed")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitLabAdapterTrunkIntegrationFailure(t *testing.T) {
+	got := BuildProviderInput(trunkIntegrationFailureSource())
+	want := loadFixture(t, "trunk-integration-failed-gitlab")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitLabAdapterUnclearOwnership(t *testing.T) {
+	got := BuildProviderInput(unclearOwnershipSource())
+	want := loadFixture(t, "unclear-ownership-gitlab")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitLabAdapterWaitingOnEvidence(t *testing.T) {
+	got := BuildProviderInput(waitingOnEvidenceSource())
+	want := loadFixture(t, "waiting-on-evidence-gitlab")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitLabAdapterAgingImplementation(t *testing.T) {
+	got := BuildProviderInput(agingImplementationSource())
+	want := loadFixture(t, "aging-implementation-gitlab")
+	assertProviderInputEqual(t, got, want)
+}
+
+func TestGitLabAdapterRiskAggregation(t *testing.T) {
+	got := BuildProviderInput(riskAggregationSource())
+	want := loadFixture(t, "risk-aggregation-gitlab")
+	assertProviderInputEqual(t, got, want)
+}

--- a/stacks/go/net-http/rest/bff/flow/gitlab/fixtures_test.go
+++ b/stacks/go/net-http/rest/bff/flow/gitlab/fixtures_test.go
@@ -1,0 +1,545 @@
+package gitlab
+
+// Fixture helpers used by adapter_test.go. Mirrors
+// stacks/nodejs/react-fastify/rest/bff/src/flow/gitlab/fixtures.ts so the Go
+// adapter normalizes equivalent inputs to the shared fixture catalog under
+// schema/fixtures/provider-adapter-input/.
+
+func intPtr(n int) *int { return &n }
+
+func blockedOnReviewSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-payments-gl-001",
+			PathWithNamespace: "example-org/payments-service",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		BaseURL: "https://gitlab.com",
+		MergeRequests: []MergeRequest{{
+			ID:           "mr-789",
+			IID:          "789",
+			Title:        "Add payment webhook",
+			Description:  "Implements webhook handler. Closes #42",
+			State:        "opened",
+			SourceBranch: "feature/add-payment-webhook",
+			TargetBranch: "main",
+			Author:       User{ID: "actor-alice-gl", Username: "alice", Name: "Alice", Groups: []string{"payments-team"}},
+			Reviewers: []User{
+				{ID: "actor-bob-gl", Username: "bob", Name: "Bob", Groups: []string{"payments-team"}},
+				{ID: "actor-carol-gl", Username: "carol", Name: "Carol", Groups: []string{"payments-team"}},
+			},
+			CreatedAt: "2026-03-30T08:00:00Z",
+			UpdatedAt: "2026-04-01T09:00:00Z",
+			SHA:       "sha-mr-789",
+		}},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"789": {
+				ApprovalsRequired: 2,
+				ApprovalsLeft:     intPtr(2),
+				ApprovedBy:        []ApprovalEntry{},
+				Rules: []ApprovalRule{{
+					Name:              "payments",
+					ApprovalsRequired: 2,
+					Users: []User{
+						{ID: "actor-bob-gl", Username: "bob", Name: "Bob"},
+						{ID: "actor-carol-gl", Username: "carol", Name: "Carol"},
+					},
+				}},
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"789": {{
+				ID:         "pipeline-1001",
+				Status:     "success",
+				Ref:        "feature/add-payment-webhook",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/payments-service/-/pipelines/1001",
+				Duration:   150,
+				FinishedAt: "2026-03-30T09:00:00Z",
+			}},
+		},
+		Issues: []Issue{{
+			ID:     "42",
+			IID:    "42",
+			Title:  "Add payment webhook handler",
+			State:  "opened",
+			WebURL: "https://gitlab.com/example-org/payments-service/-/issues/42",
+		}},
+		CodeownersText: "* @example-org/payments-team",
+		FetchedAt:      "2026-04-01T10:00:00Z",
+	}
+}
+
+func trunkIntegrationFailureSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-observability-gl-001",
+			PathWithNamespace: "example-org/observability",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		BaseURL: "https://gitlab.com",
+		MergeRequests: []MergeRequest{{
+			ID:             "mr-1234",
+			IID:            "1234",
+			Title:          "Add alerting rules",
+			Description:    "Adds alerting for latency. Resolves #105",
+			State:          "merged",
+			MergedAt:       "2026-04-02T10:15:00Z",
+			ClosedAt:       "2026-04-02T10:15:00Z",
+			MergeCommitSHA: "merge-sha-gl-1234",
+			SourceBranch:   "feature/add-alerting",
+			TargetBranch:   "main",
+			Author:         User{ID: "actor-dana-gl", Username: "dana", Name: "Dana"},
+			Reviewers: []User{
+				{ID: "actor-eli-gl", Username: "eli", Name: "Eli"},
+				{ID: "actor-fay-gl", Username: "fay", Name: "Fay"},
+			},
+			CreatedAt: "2026-04-01T15:00:00Z",
+			UpdatedAt: "2026-04-02T10:20:00Z",
+			SHA:       "sha-mr-1234",
+			MergedBy:  &User{ID: "actor-dana-gl", Username: "dana", Name: "Dana"},
+		}},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"1234": {
+				ApprovalsRequired: 2,
+				ApprovalsLeft:     intPtr(0),
+				ApprovedBy: []ApprovalEntry{
+					{User: User{ID: "actor-eli-gl", Username: "eli", Name: "Eli"}, ApprovedAt: "2026-04-02T10:05:00Z"},
+					{User: User{ID: "actor-fay-gl", Username: "fay", Name: "Fay"}, ApprovedAt: "2026-04-02T10:10:00Z"},
+				},
+				LastActivityAt: "2026-04-02T10:10:00Z",
+				Rules: []ApprovalRule{{
+					Name:              "sre",
+					ApprovalsRequired: 2,
+					ApprovedBy: []ApprovalEntry{
+						{User: User{ID: "actor-eli-gl", Username: "eli", Name: "Eli"}, ApprovedAt: "2026-04-02T10:05:00Z"},
+						{User: User{ID: "actor-fay-gl", Username: "fay", Name: "Fay"}, ApprovedAt: "2026-04-02T10:10:00Z"},
+					},
+				}},
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"1234": {{
+				ID:         "pipeline-branch-2001",
+				Status:     "success",
+				Ref:        "feature/add-alerting",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/observability/-/pipelines/2001",
+				Duration:   480,
+				FinishedAt: "2026-04-02T09:45:00Z",
+			}},
+		},
+		TrunkPipelinesByBranch: map[string][]Pipeline{
+			"main": {{
+				ID:            "pipeline-trunk-2002",
+				Status:        "failed",
+				Ref:           "main",
+				SHA:           "merge-sha-gl-1234",
+				Name:          "deploy / main",
+				WebURL:        "https://gitlab.com/example-org/observability/-/pipelines/2002",
+				Duration:      600,
+				FinishedAt:    "2026-04-02T10:25:00Z",
+				FailureReason: "failure",
+			}},
+		},
+		Issues: []Issue{{
+			ID:     "105",
+			IID:    "105",
+			Title:  "Add alerting for latency",
+			State:  "opened",
+			WebURL: "https://gitlab.com/example-org/observability/-/issues/105",
+		}},
+		CodeownersText: "* @example-org/sre-team",
+		FetchedAt:      "2026-04-02T12:00:00Z",
+	}
+}
+
+func blockedOnReviewSelfManagedSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-infra-sm-001",
+			PathWithNamespace: "example-org/infra",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		MergeRequests: []MergeRequest{{
+			ID:           "mr-512",
+			IID:          "512",
+			Title:        "Update network policy",
+			Description:  "Closes #99",
+			State:        "opened",
+			SourceBranch: "feature/update-network-policy",
+			TargetBranch: "main",
+			Author:       User{ID: "actor-peter-sm", Username: "peter", Name: "Peter", Groups: []string{"infra-team"}},
+			CreatedAt:    "2026-04-03T10:00:00Z",
+			UpdatedAt:    "2026-04-05T13:00:00Z",
+			SHA:          "sha-mr-512",
+		}},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"512": {
+				ApprovalsRequired: 1,
+				ApprovalsLeft:     intPtr(1),
+				ApprovedBy:        []ApprovalEntry{},
+				LastActivityAt:    "2026-04-05T13:00:00Z",
+				Rules: []ApprovalRule{{
+					Name:              "infra",
+					ApprovalsRequired: 1,
+					Groups:            []Group{{FullPath: "example-org/infra-team"}},
+				}},
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"512": {{
+				ID:         "pipeline-legacy-1",
+				Status:     "success",
+				Ref:        "feature/update-network-policy",
+				Name:       "legacy-ci",
+				Duration:   200,
+				FinishedAt: "2026-04-03T11:00:00Z",
+			}},
+		},
+		Issues: []Issue{{
+			ID:    "99",
+			IID:   "99",
+			Title: "Update firewall policy for prod",
+			State: "opened",
+		}},
+		CodeownersText:   "* @example-org/infra-team",
+		SelfManaged:      true,
+		AdditionalActors: []User{{ID: "actor-quinn-sm", Username: "quinn", Name: "Quinn", Groups: []string{"infra-team"}}},
+		FetchedAt:        "2026-04-05T14:00:00Z",
+	}
+}
+
+func unclearOwnershipSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-notifications-gl-001",
+			PathWithNamespace: "example-org/notifications-service",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		BaseURL: "https://gitlab.com",
+		MergeRequests: []MergeRequest{{
+			ID:           "mr-400",
+			IID:          "400",
+			Title:        "Add push notification support",
+			Description:  "Implements push notifications. Resolves #88",
+			State:        "opened",
+			SourceBranch: "feature/add-push-notifications",
+			TargetBranch: "main",
+			Author:       User{ID: "actor-marcus-gl", Username: "marcus", Name: "Marcus"},
+			CreatedAt:    "2026-04-05T08:00:00Z",
+			UpdatedAt:    "2026-04-06T08:30:00Z",
+			SHA:          "sha-mr-400",
+		}},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"400": {
+				ApprovalsRequired: 1,
+				ApprovalsLeft:     intPtr(1),
+				ApprovedBy:        []ApprovalEntry{},
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"400": {{
+				ID:         "pipeline-3001",
+				Status:     "success",
+				Ref:        "feature/add-push-notifications",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/notifications-service/-/pipelines/3001",
+				Duration:   120,
+				FinishedAt: "2026-04-05T09:00:00Z",
+			}},
+		},
+		Issues: []Issue{{
+			ID:     "88",
+			IID:    "88",
+			Title:  "Implement push notifications",
+			State:  "opened",
+			WebURL: "https://gitlab.com/example-org/notifications-service/-/issues/88",
+		}},
+		UnownedPathsByMergeIID: map[string][]string{"400": {"*"}},
+		FetchedAt:              "2026-04-06T09:00:00Z",
+	}
+}
+
+func waitingOnEvidenceSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-payments-gl-003",
+			PathWithNamespace: "example-org/payments-service",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		BaseURL: "https://gitlab.com",
+		MergeRequests: []MergeRequest{{
+			ID:             "mr-600",
+			IID:            "600",
+			Title:          "PCI compliance update",
+			Description:    "Implements compliance changes. Closes #130",
+			State:          "merged",
+			MergedAt:       "2026-04-08T11:45:00Z",
+			ClosedAt:       "2026-04-08T11:45:00Z",
+			MergeCommitSHA: "merge-sha-gl-600",
+			SourceBranch:   "feature/pci-compliance-update",
+			TargetBranch:   "main",
+			Author:         User{ID: "actor-olivia-gl", Username: "olivia", Name: "Olivia", Groups: []string{"payments-team"}},
+			Reviewers:      []User{{ID: "actor-sam-gl", Username: "sam", Name: "Sam", Groups: []string{"security-team"}}},
+			CreatedAt:      "2026-04-06T09:00:00Z",
+			UpdatedAt:      "2026-04-08T12:00:00Z",
+			SHA:            "sha-mr-600",
+			MergedBy:       &User{ID: "actor-olivia-gl", Username: "olivia", Name: "Olivia"},
+		}},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"600": {
+				ApprovalsRequired: 1,
+				ApprovalsLeft:     intPtr(0),
+				ApprovedBy: []ApprovalEntry{
+					{User: User{ID: "actor-sam-gl", Username: "sam", Name: "Sam"}, ApprovedAt: "2026-04-08T11:30:00Z"},
+				},
+				LastActivityAt: "2026-04-08T11:30:00Z",
+				Rules: []ApprovalRule{{
+					Name:              "security",
+					ApprovalsRequired: 1,
+					ApprovedBy: []ApprovalEntry{
+						{User: User{ID: "actor-sam-gl", Username: "sam", Name: "Sam"}, ApprovedAt: "2026-04-08T11:30:00Z"},
+					},
+				}},
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"600": {{
+				ID:         "pipeline-4001",
+				Status:     "success",
+				Ref:        "feature/pci-compliance-update",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/payments-service/-/pipelines/4001",
+				Duration:   320,
+				FinishedAt: "2026-04-07T10:00:00Z",
+			}},
+		},
+		Issues: []Issue{{
+			ID:     "130",
+			IID:    "130",
+			Title:  "Implement PCI DSS compliance changes",
+			State:  "opened",
+			WebURL: "https://gitlab.com/example-org/payments-service/-/issues/130",
+		}},
+		EvidenceStatesByMergeIID: map[string][]EvidenceState{
+			"600": {{
+				State:         "pending",
+				AsOf:          "2026-04-08T14:00:00Z",
+				RequiredTypes: []string{"compliance attestation"},
+				Owner:         &User{ID: "actor-sam-gl", Username: "sam", Name: "Sam"},
+			}},
+		},
+		GroupOwners: []string{"payments-team"},
+		FetchedAt:   "2026-04-08T14:00:00Z",
+	}
+}
+
+func agingImplementationSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-auth-gl-001",
+			PathWithNamespace: "example-org/auth-service",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		BaseURL: "https://gitlab.com",
+		MergeRequests: []MergeRequest{{
+			ID:             "mr-700",
+			IID:            "700",
+			Title:          "Add OAuth refresh token support",
+			Description:    "Adds refresh token support. Closes #55",
+			State:          "merged",
+			MergedAt:       "2026-04-07T15:00:00Z",
+			ClosedAt:       "2026-04-07T15:00:00Z",
+			MergeCommitSHA: "merge-sha-gl-700",
+			SourceBranch:   "feature/oauth-refresh-token",
+			TargetBranch:   "main",
+			Author:         User{ID: "actor-rachel-gl", Username: "rachel", Name: "Rachel", Groups: []string{"auth-team"}},
+			CreatedAt:      "2026-04-06T10:00:00Z",
+			UpdatedAt:      "2026-04-07T15:00:00Z",
+			SHA:            "sha-mr-700",
+			MergedBy:       &User{ID: "actor-rachel-gl", Username: "rachel", Name: "Rachel"},
+		}},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"700": {
+				ApprovalsRequired: 1,
+				ApprovalsLeft:     intPtr(0),
+				ApprovedBy: []ApprovalEntry{
+					{User: User{ID: "actor-rachel-gl", Username: "rachel", Name: "Rachel"}, ApprovedAt: "2026-04-07T14:45:00Z"},
+				},
+				LastActivityAt: "2026-04-07T14:45:00Z",
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"700": {{
+				ID:         "pipeline-5001",
+				Status:     "success",
+				Ref:        "feature/oauth-refresh-token",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/auth-service/-/pipelines/5001",
+				Duration:   260,
+				FinishedAt: "2026-04-07T12:00:00Z",
+			}},
+		},
+		TrunkPipelinesByBranch: map[string][]Pipeline{
+			"main": {{
+				ID:        "pipeline-5002",
+				Status:    "pending",
+				Ref:       "main",
+				SHA:       "merge-sha-gl-700",
+				Name:      "integration / main",
+				WebURL:    "https://gitlab.com/example-org/auth-service/-/pipelines/5002",
+				UpdatedAt: "2026-04-10T09:00:00Z",
+			}},
+		},
+		Issues: []Issue{{
+			ID:     "55",
+			IID:    "55",
+			Title:  "Implement OAuth 2.0 refresh tokens",
+			State:  "opened",
+			WebURL: "https://gitlab.com/example-org/auth-service/-/issues/55",
+		}},
+		CodeownersText: "* @example-org/auth-team",
+		FetchedAt:      "2026-04-10T09:00:00Z",
+	}
+}
+
+func riskAggregationSource() AdapterSource {
+	return GitLabAdapterSource{
+		Project: Project{
+			ID:                "repo-checkout-gl-001",
+			PathWithNamespace: "example-org/checkout-service",
+			DefaultBranch:     "main",
+			Visibility:        "private",
+		},
+		MergeRequests: []MergeRequest{
+			{
+				ID:             "mr-801",
+				IID:            "801",
+				Title:          "Add payment retry logic",
+				Description:    "Closes #200",
+				State:          "merged",
+				MergedAt:       "2026-04-08T14:30:00Z",
+				ClosedAt:       "2026-04-08T14:30:00Z",
+				MergeCommitSHA: "merge-sha-gl-801",
+				SourceBranch:   "feature/payment-retry",
+				TargetBranch:   "main",
+				Author:         User{ID: "actor-tom-gl", Username: "tom", Name: "Tom", Groups: []string{"checkout-team"}},
+				Reviewers:      []User{{ID: "actor-uma-gl", Username: "uma", Name: "Uma", Groups: []string{"checkout-team"}}},
+				CreatedAt:      "2026-04-08T09:00:00Z",
+				UpdatedAt:      "2026-04-08T14:30:00Z",
+				SHA:            "sha-mr-801",
+				MergedBy:       &User{ID: "actor-tom-gl", Username: "tom", Name: "Tom"},
+			},
+			{
+				ID:           "mr-802",
+				IID:          "802",
+				Title:        "Refactor discount engine",
+				Description:  "Closes #201",
+				State:        "opened",
+				SourceBranch: "feature/discount-engine",
+				TargetBranch: "main",
+				Author:       User{ID: "actor-uma-gl", Username: "uma", Name: "Uma", Groups: []string{"checkout-team"}},
+				Reviewers:    []User{{ID: "actor-tom-gl", Username: "tom", Name: "Tom", Groups: []string{"checkout-team"}}},
+				CreatedAt:    "2026-04-08T10:00:00Z",
+				UpdatedAt:    "2026-04-09T15:00:00Z",
+				SHA:          "sha-mr-802",
+			},
+			{
+				ID:           "mr-803",
+				IID:          "803",
+				Title:        "Add cart persistence",
+				Description:  "Implements cart persistence. Fixes #202",
+				State:        "opened",
+				SourceBranch: "feature/cart-persistence",
+				TargetBranch: "main",
+				Author:       User{ID: "actor-victor-gl", Username: "victor", Name: "Victor", Groups: []string{"checkout-team"}},
+				CreatedAt:    "2026-04-09T08:00:00Z",
+				UpdatedAt:    "2026-04-09T15:30:00Z",
+				SHA:          "sha-mr-803",
+			},
+		},
+		ApprovalsByMergeIID: map[string]ApprovalState{
+			"801": {
+				ApprovalsRequired: 1,
+				ApprovalsLeft:     intPtr(0),
+				ApprovedBy: []ApprovalEntry{
+					{User: User{ID: "actor-uma-gl", Username: "uma", Name: "Uma"}, ApprovedAt: "2026-04-08T14:00:00Z"},
+				},
+				LastActivityAt: "2026-04-08T14:00:00Z",
+				AsOf:           "2026-04-08T14:00:00Z",
+			},
+			"802": {
+				ApprovalsRequired:  1,
+				ApprovalsLeft:      intPtr(1),
+				ApprovedBy:         []ApprovalEntry{},
+				LastActivityAt:     "2026-04-08T10:00:00Z",
+				AsOf:               "2026-04-09T15:00:00Z",
+				SuggestedApprovers: []User{{ID: "actor-tom-gl", Username: "tom", Name: "Tom"}},
+			},
+			"803": {
+				ApprovalsRequired: 1,
+				ApprovalsLeft:     intPtr(1),
+				ApprovedBy:        []ApprovalEntry{},
+				LastActivityAt:    "2026-04-09T08:00:00Z",
+				AsOf:              "2026-04-09T15:30:00Z",
+			},
+		},
+		PipelinesByMergeIID: map[string][]Pipeline{
+			"801": {{
+				ID:         "pipeline-6001",
+				Status:     "success",
+				Ref:        "feature/payment-retry",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/checkout-service/-/pipelines/6001",
+				Duration:   185,
+				FinishedAt: "2026-04-08T12:00:00Z",
+			}},
+			"802": {{
+				ID:         "pipeline-6003",
+				Status:     "success",
+				Ref:        "feature/discount-engine",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/checkout-service/-/pipelines/6003",
+				Duration:   192,
+				FinishedAt: "2026-04-08T11:00:00Z",
+			}},
+			"803": {{
+				ID:         "pipeline-6004",
+				Status:     "success",
+				Ref:        "feature/cart-persistence",
+				Name:       "ci / test",
+				WebURL:     "https://gitlab.com/example-org/checkout-service/-/pipelines/6004",
+				Duration:   198,
+				FinishedAt: "2026-04-09T09:00:00Z",
+			}},
+		},
+		TrunkPipelinesByBranch: map[string][]Pipeline{
+			"main": {{
+				ID:            "pipeline-6002",
+				Status:        "failed",
+				Ref:           "main",
+				SHA:           "merge-sha-gl-801",
+				Name:          "deploy / main",
+				WebURL:        "https://gitlab.com/example-org/checkout-service/-/pipelines/6002",
+				Duration:      520,
+				FinishedAt:    "2026-04-08T15:00:00Z",
+				FailureReason: "failure",
+			}},
+		},
+		Issues: []Issue{
+			{ID: "200", IID: "200", State: "opened"},
+			{ID: "201", IID: "201", State: "opened"},
+			{ID: "202", IID: "202", State: "opened"},
+		},
+		CodeownersText:         "* @example-org/checkout-team\nsrc/cart/*",
+		UnownedPathsByMergeIID: map[string][]string{"803": {"src/cart/*"}},
+		FetchedAt:              "2026-04-09T16:00:00Z",
+	}
+}

--- a/stacks/go/net-http/rest/bff/flow/gitlab/types.go
+++ b/stacks/go/net-http/rest/bff/flow/gitlab/types.go
@@ -1,0 +1,130 @@
+package gitlab
+
+type User struct {
+	ID       string   `json:"id" yaml:"id"`
+	Username string   `json:"username" yaml:"username"`
+	Name     string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Groups   []string `json:"groups,omitempty" yaml:"groups,omitempty"`
+}
+
+type Group struct {
+	ID       string `json:"id,omitempty" yaml:"id,omitempty"`
+	FullPath string `json:"full_path,omitempty" yaml:"full_path,omitempty"`
+	Name     string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type Project struct {
+	ID                string `json:"id" yaml:"id"`
+	PathWithNamespace string `json:"path_with_namespace" yaml:"path_with_namespace"`
+	DefaultBranch     string `json:"default_branch" yaml:"default_branch"`
+	Visibility        string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+	Archived          bool   `json:"archived,omitempty" yaml:"archived,omitempty"`
+}
+
+type MergeRequest struct {
+	ID             string `json:"id" yaml:"id"`
+	IID            string `json:"iid" yaml:"iid"`
+	Title          string `json:"title" yaml:"title"`
+	Description    string `json:"description,omitempty" yaml:"description,omitempty"`
+	State          string `json:"state" yaml:"state"`
+	Draft          bool   `json:"draft,omitempty" yaml:"draft,omitempty"`
+	WorkInProgress bool   `json:"work_in_progress,omitempty" yaml:"work_in_progress,omitempty"`
+	MergedAt       string `json:"merged_at,omitempty" yaml:"merged_at,omitempty"`
+	ClosedAt       string `json:"closed_at,omitempty" yaml:"closed_at,omitempty"`
+	MergeCommitSHA string `json:"merge_commit_sha,omitempty" yaml:"merge_commit_sha,omitempty"`
+	SourceBranch   string `json:"source_branch" yaml:"source_branch"`
+	TargetBranch   string `json:"target_branch" yaml:"target_branch"`
+	Author         User   `json:"author" yaml:"author"`
+	Reviewers      []User `json:"reviewers,omitempty" yaml:"reviewers,omitempty"`
+	CreatedAt      string `json:"created_at" yaml:"created_at"`
+	UpdatedAt      string `json:"updated_at" yaml:"updated_at"`
+	SHA            string `json:"sha,omitempty" yaml:"sha,omitempty"`
+	MergedBy       *User  `json:"merged_by,omitempty" yaml:"merged_by,omitempty"`
+}
+
+type ApprovalEntry struct {
+	User       User   `json:"user" yaml:"user"`
+	ApprovedAt string `json:"approved_at,omitempty" yaml:"approved_at,omitempty"`
+}
+
+type ApprovalRule struct {
+	Name              string          `json:"name,omitempty" yaml:"name,omitempty"`
+	ApprovalsRequired int             `json:"approvals_required,omitempty" yaml:"approvals_required,omitempty"`
+	ApprovedBy        []ApprovalEntry `json:"approved_by,omitempty" yaml:"approved_by,omitempty"`
+	Users             []User          `json:"users,omitempty" yaml:"users,omitempty"`
+	Groups            []Group         `json:"groups,omitempty" yaml:"groups,omitempty"`
+}
+
+type ApprovalState struct {
+	ApprovalsRequired  int             `json:"approvals_required,omitempty" yaml:"approvals_required,omitempty"`
+	ApprovalsLeft      *int            `json:"approvals_left,omitempty" yaml:"approvals_left,omitempty"`
+	ApprovedBy         []ApprovalEntry `json:"approved_by,omitempty" yaml:"approved_by,omitempty"`
+	SuggestedApprovers []User          `json:"suggested_approvers,omitempty" yaml:"suggested_approvers,omitempty"`
+	Rules              []ApprovalRule  `json:"rules,omitempty" yaml:"rules,omitempty"`
+	LastActivityAt     string          `json:"last_activity_at,omitempty" yaml:"last_activity_at,omitempty"`
+	AsOf               string          `json:"as_of,omitempty" yaml:"as_of,omitempty"`
+}
+
+type Pipeline struct {
+	ID             string `json:"id" yaml:"id"`
+	Status         string `json:"status" yaml:"status"`
+	Ref            string `json:"ref,omitempty" yaml:"ref,omitempty"`
+	WebURL         string `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+	Duration       int    `json:"duration,omitempty" yaml:"duration,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	FinishedAt     string `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	StartedAt      string `json:"started_at,omitempty" yaml:"started_at,omitempty"`
+	SHA            string `json:"sha,omitempty" yaml:"sha,omitempty"`
+	Name           string `json:"name,omitempty" yaml:"name,omitempty"`
+	FailureReason  string `json:"failure_reason,omitempty" yaml:"failure_reason,omitempty"`
+	PipelineType   string `json:"pipeline_type,omitempty" yaml:"pipeline_type,omitempty"`
+}
+
+type CommitStatus struct {
+	ID        string `json:"id" yaml:"id"`
+	Name      string `json:"name" yaml:"name"`
+	Status    string `json:"status" yaml:"status"`
+	TargetURL string `json:"target_url,omitempty" yaml:"target_url,omitempty"`
+	Ref       string `json:"ref,omitempty" yaml:"ref,omitempty"`
+	CreatedAt string `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+type Issue struct {
+	ID     string `json:"id" yaml:"id"`
+	IID    string `json:"iid,omitempty" yaml:"iid,omitempty"`
+	Title  string `json:"title,omitempty" yaml:"title,omitempty"`
+	State  string `json:"state,omitempty" yaml:"state,omitempty"`
+	WebURL string `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+}
+
+type EvidenceState struct {
+	State         string   `json:"state" yaml:"state"`
+	AsOf          string   `json:"as_of" yaml:"as_of"`
+	RequiredTypes []string `json:"required_types,omitempty" yaml:"required_types,omitempty"`
+	Owner         *User    `json:"owner,omitempty" yaml:"owner,omitempty"`
+	FreshnessAt   string   `json:"freshness_at,omitempty" yaml:"freshness_at,omitempty"`
+	IsPartial     bool     `json:"is_partial,omitempty" yaml:"is_partial,omitempty"`
+}
+
+type GitLabAdapterSource struct {
+	Project                       Project
+	MergeRequests                 []MergeRequest
+	ApprovalsByMergeIID           map[string]ApprovalState
+	PipelinesByMergeIID           map[string][]Pipeline
+	TrunkPipelinesByBranch        map[string][]Pipeline
+	CommitStatusesBySHA           map[string][]CommitStatus
+	EvidenceStatesByMergeIID      map[string][]EvidenceState
+	UnownedPathsByMergeIID        map[string][]string
+	GroupOwners                   []string
+	CodeownersText                string
+	Issues                        []Issue
+	BaseURL                       string
+	SelfManaged                   bool
+	AddTrunkValidationPlaceholder bool
+	AdditionalActors              []User
+	FetchedAt                     string
+}
+
+// AdapterSource is kept as a compatibility alias.
+type AdapterSource = GitLabAdapterSource


### PR DESCRIPTION
### Motivation

- Provide Go implementations of provider adapters to normalize GitHub and GitLab inputs into the shared `flow.ProviderAdapterInput` contract so stacks can share the same flow model and enable cross-stack equivalence testing.
- Mirror existing NodeJS adapter behavior and the shared fixture catalog to ensure semantic equivalence across provider stacks.
- Add parsers and helpers (for codeowners, actor/repo IDs, work item extraction, review & validation mapping, ownership hints, evidence) required to compute the normalized model.

### Description

- Added a GitHub adapter under `stacks/go/net-http/rest/bff/flow/github/` implementing `BuildProviderInput`, supporting normalization of repositories, pull requests, reviews, checks, statuses, workflows, ownership hints and merge events, plus `ParseCodeowners` helper in `codeowners.go` and domain types in `types.go`.
- Added a GitLab adapter under `stacks/go/net-http/rest/bff/flow/gitlab/` implementing `BuildProviderInput`, supporting normalization of projects, merge requests, approvals, pipelines, commit statuses, evidence states, ownership hints and merge events, plus domain types in `types.go` and reuse of the codeowners parser.
- Added fixture helper sources and unit tests for both providers (`*_fixtures_test.go` and `*_adapter_test.go`) that load the shared YAML fixtures from `schema/fixtures/provider-adapter-input/` and assert deep equality with the adapter output; also added sorting/normalization helpers for deterministic comparisons.
- Updated the ADR `docs/content/architecture/decisions/0014-mvp-flow-observation-technical-foundations.md` to explicitly reference the shared flow insight contract tests and fixture locations (`tests/features/flow-insights.feature`, `tests/src/profiles/flow-insights.ts`, and `schema/fixtures/provider-adapter-input/`).

### Testing

- Ran the new Go unit tests for the adapters with `go test ./stacks/go/net-http/rest/bff/flow/...` and all added tests (`TestGitHubAdapterBlockedOnReview`, `TestGitHubAdapterChangesRequested`, `TestGitHubAdapterReviewNotRequired`, `TestGitHubAdapterTrunkIntegrationFailure`, `TestGitHubAdapterPartialEvidence`, and the corresponding GitLab tests such as `TestGitLabAdapterBlockedOnReview`, `TestGitLabAdapterTrunkIntegrationFailure`, etc.) passed.
- The adapter tests load and compare against the canonical YAML fixtures under `schema/fixtures/provider-adapter-input/` and succeeded, verifying parity with the fixture catalog.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e189f42c948332b09bd587550f3133)