### PR TITLE
feat(flow-insights): enforce cross-stack equivalence via fixture-based PR check

### DIFF
--- a/.github/workflows/gitlab-harness-e2e.yml
+++ b/.github/workflows/gitlab-harness-e2e.yml
@@ -24,8 +24,28 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Setup toolchain
+        uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
+        with:
+          proto-version: "0.55.4"
+          auto-install: true
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Install Node.js BFF dependencies
+        run: npm install --prefix stacks/nodejs/react-fastify/rest
+
       - name: Run GitLab harness e2e
         env:
           GITLAB_HARNESS: "1"
         run: |
           bash scripts/e2e/run-gitlab-harness.sh
+
+      - name: Upload equivalence artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitlab-harness-e2e-flow-insights-equivalence
+          path: .tmp/flow-insights-equivalence
+          if-no-files-found: ignore

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -33,6 +33,7 @@ jobs:
       run_mock_oauth_build: ${{ steps.detect.outputs.run_mock_oauth_build }}
       run_mock_oauth_containers: ${{ steps.detect.outputs.run_mock_oauth_containers }}
       run_auth_integration: ${{ steps.detect.outputs.run_auth_integration }}
+      run_flow_insights_equivalence: ${{ steps.detect.outputs.run_flow_insights_equivalence }}
       run_backstage_tools: ${{ steps.detect.outputs.run_backstage_tools }}
     steps:
       - name: Checkout
@@ -93,6 +94,7 @@ jobs:
           echo "run_mock_oauth_build=${{ steps.detect.outputs.run_mock_oauth_build }}"
           echo "run_mock_oauth_containers=${{ steps.detect.outputs.run_mock_oauth_containers }}"
           echo "run_auth_integration=${{ steps.detect.outputs.run_auth_integration }}"
+          echo "run_flow_insights_equivalence=${{ steps.detect.outputs.run_flow_insights_equivalence }}"
           echo "run_backstage_tools=${{ steps.detect.outputs.run_backstage_tools }}"
 
       - name: Save proto and moon cache
@@ -629,6 +631,73 @@ jobs:
             ~/.cache/go-build
           key: go-${{ runner.os }}-${{ hashFiles('.prototools', 'stacks/go/net-http/rest/go.mod', 'stacks/go/net-http/rest/go.sum') }}
 
+  check-flow-insights-equivalence:
+    name: Check Flow Insights Equivalence
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_flow_insights_equivalence == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup toolchain
+        uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
+        with:
+          proto-version: ${{ env.PROTO_VERSION }}
+          auto-install: true
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Install Node.js BFF dependencies
+        run: npm install --prefix stacks/nodejs/react-fastify/rest
+
+      - name: Run cross-stack flow insights equivalence
+        run: make check-flow-insights-equivalence
+
+      - name: Upload equivalence artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-insights-equivalence
+          path: .tmp/flow-insights-equivalence
+          if-no-files-found: ignore
+
+      - name: Save proto and moon cache
+        if: always()
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        continue-on-error: true
+        with:
+          path: |
+            ~/.proto
+            ~/.cache/proto
+            ~/.cache/moon
+            ~/.moon/cache
+            .moon/cache
+          key: proto-moon-${{ runner.os }}-${{ hashFiles('.prototools') }}
+
+      - name: Save npm cache
+        if: always()
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        continue-on-error: true
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json', 'docs/package-lock.json', 'tools/mcp/package-lock.json', 'stacks/nodejs/react-fastify/rest/package-lock.json') }}
+
+      - name: Save Go cache
+        if: always()
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        continue-on-error: true
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ hashFiles('.prototools', 'stacks/go/net-http/rest/go.mod', 'stacks/go/net-http/rest/go.sum') }}
+
   pr-validation-result:
     name: PR Validation Result
     runs-on: ubuntu-latest
@@ -643,6 +712,7 @@ jobs:
       - check-container-build
       - check-mock-oauth-build
       - check-auth-integration
+      - check-flow-insights-equivalence
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -657,4 +727,5 @@ jobs:
           RESULT_CONTAINERS: ${{ needs.check-container-build.result }}
           RESULT_MOCK_OAUTH: ${{ needs.check-mock-oauth-build.result }}
           RESULT_AUTH_INTEGRATION: ${{ needs.check-auth-integration.result }}
+          RESULT_FLOW_INSIGHTS: ${{ needs.check-flow-insights-equivalence.result }}
         run: bash scripts/ci/check-pr-validation-result.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all ci install build clean reset lint check-lint-md check-lint-workflows check-privacy check-stack check-team-membership check-pr-title check-pr-changes issue-number issue-triage issue-signal-ready issue-setup-labels worktree-path worktree-ensure worktree-cleanup audit-worktrees check-lint check-test check-contract check test test-contract dev docs-site build-containers build-container-dev-tools gitlab-harness-up gitlab-harness-down gitlab-harness-seed gitlab-harness-reset gitlab-harness-wait-healthy gitlab-harness-token gitlab-harness-logs
+.PHONY: help all ci install build clean reset lint check-lint-md check-lint-workflows check-privacy check-flow-insights-equivalence check-stack check-team-membership check-pr-title check-pr-changes issue-number issue-triage issue-signal-ready issue-setup-labels worktree-path worktree-ensure worktree-cleanup audit-worktrees check-lint check-test check-contract check test test-contract dev docs-site build-containers build-container-dev-tools gitlab-harness-up gitlab-harness-down gitlab-harness-seed gitlab-harness-reset gitlab-harness-wait-healthy gitlab-harness-token gitlab-harness-logs
 
 DEFAULT_STACK := stacks/go/net-http/rest
 STACK ?= $(DEFAULT_STACK)
@@ -20,6 +20,7 @@ help:
 	@printf "  check-lint-md Lint all Markdown files\n"
 	@printf "  check-lint-workflows Lint GitHub workflow definitions\n"
 	@printf "  check-privacy Run privacy and secret scanning\n"
+	@printf "  check-flow-insights-equivalence Run cross-stack equivalence check for /api/flow/insights\n"
 	@printf "  check-stack   Run full checks for STACK\n"
 	@printf "  check-team-membership Check org team authorization\n"
 	@printf "  check-pr-title Validate PR title policy\n"
@@ -110,6 +111,9 @@ check-privacy:
 	else \
 		"bash" "./$(CI_SCRIPTS_DIR)/check-privacy.sh"; \
 	fi
+
+check-flow-insights-equivalence:
+	@"bash" "./$(CI_SCRIPTS_DIR)/run-flow-insights-equivalence.sh"
 
 check-stack:
 	@"$(MAKE)" -C "$(STACK)" all

--- a/docs/content/flow/cross-stack-equivalence.md
+++ b/docs/content/flow/cross-stack-equivalence.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 10
+---
+
+# Cross-Stack Equivalence
+
+Cross-stack equivalence is the guarantee that every flow insight signal is semantically identical across every stack that ships the flow insight MVP. The [capability contract](./implementation-strategy) describes the rule; this page describes how the rule is continuously enforced against shared fixtures and what counts as a permissible difference.
+
+## What "equivalent" means
+
+The equivalence rules come from [ADR-0014: MVP Flow Observation Technical Foundations](../architecture/decisions/mvp-flow-observation-technical-foundations). They apply to every fixture in `schema/fixtures/provider-adapter-input/` when exercised through each stack's `/api/flow/insights` route.
+
+Across any two stacks, for a given fixture, the following must be equal:
+
+- **Set of signal identifiers.** Each stack must produce the same signal identifiers for the same input fixture. Missing a signal on one stack but not another is a divergence.
+- **Severity intent.** For each matching signal, the severity value (`low`, `medium`, `high`) must match. Severity drives downstream UX and triage; divergence changes product behavior.
+- **Confidence band.** For each matching signal, the confidence band (`low`, `medium`, `high`) must match.
+- **Explanation and action presence.** If one stack provides an explanation, the other must also provide one. The same holds for recommended next action. Presence is part of the contract; wording is not.
+
+The following are **allowed to differ**:
+
+- **Exact wording of explanations and recommended actions.** Each stack may phrase human-readable text naturally. The contract enforces presence and intent, not text similarity.
+- **Ordering of signals in the response array.** The harness compares signals by identifier, not by position.
+- **Diagnostic metadata fields** (for example, generated identifiers, per-stack counters, debug fields) that are not part of the product contract.
+
+Any other difference — a signal missing from one stack, a severity mismatch, a confidence mismatch, an explanation present on one stack but missing from the other — is classified as **divergent** and fails the check.
+
+## How the harness runs
+
+The harness lives at `tests/src/tools/flow-insights-equivalence.ts` and is invoked from `scripts/ci/run-flow-insights-equivalence.sh` (`make check-flow-insights-equivalence`). It runs in three phases:
+
+1. **Boot both BFFs.** The Go BFF is started on a loopback port; the Node.js BFF is started on a disjoint loopback port. The script polls each `/readiness` endpoint until both report ready or the timeout expires.
+2. **Capture signal summaries.** The harness calls `/api/flow/insights` on each BFF with the shared provider adapter fixtures as input. For each response, it extracts a `SignalSummary` per signal — identifier, severity, confidence, and booleans for explanation presence and recommended-next-action presence — and writes a stable JSON artifact per stack.
+3. **Diff the captures.** The harness compares the two captures fixture-by-fixture and signal-by-signal under the rules above. Every fixture gets a verdict of `equal`, `allowed-difference`, or `divergent`. The run exits non-zero if any fixture is `divergent`, which fails the PR check.
+
+Artifacts are written to `.tmp/flow-insights-equivalence/`:
+
+- `go.json` — Go BFF signal summary capture
+- `node.json` — Node.js BFF signal summary capture
+- `diff.json` — structured diff with per-fixture verdict
+- `diff.md` — human-readable summary used in CI logs
+
+## When the check runs
+
+The PR validation workflow gates the equivalence job on path-based change detection. The job runs when a PR modifies any of:
+
+- Provider adapter input fixtures under `schema/fixtures/provider-adapter-input/`.
+- The flow insights BFF route or inference engine in either stack (Go: `stacks/go/net-http/rest/bff/flow/*`; Node.js: `stacks/nodejs/react-fastify/rest/bff/src/routes/flow-insights*`, `stacks/nodejs/react-fastify/rest/bff/src/flow/*`).
+- The harness itself (`tests/src/tools/flow-insights-equivalence.ts`) or the profile module (`tests/src/profiles/flow-insights.ts`).
+- Anything that also triggers the broad `run_reference_all` bucket (for example, `Makefile` or cross-cutting test tooling).
+
+PRs that only touch documentation or a single stack's unrelated code skip the check, keeping the PR lane fast while preserving the guarantee on every change that could move equivalence.
+
+## Allowed-difference exceptions
+
+The harness supports an explicit allow list for differences that the team has consciously accepted — for example, a confidence band that one stack legitimately raises or lowers based on richer local data, provided the signal is still produced on both sides. The allow list lives in the `ALLOWED_DIFFERENCES` constant in the harness source and must cite a rationale for every entry.
+
+Adding an entry to the allow list is a contract change: it moves a previously `divergent` case to `allowed-difference`. Every entry must be justified against the equivalence rules above and reviewed on the PR that introduces it.
+
+## Reading a failed run
+
+When the harness reports a divergence:
+
+1. Open `.tmp/flow-insights-equivalence/diff.md` from the failed CI run's artifacts. It lists each divergent fixture, the signal identifier in play, and which fields differ.
+2. Consult `.tmp/flow-insights-equivalence/go.json` and `.tmp/flow-insights-equivalence/node.json` to see the full per-stack signal summary for context.
+3. Decide the verdict:
+   - If the divergence is a bug in one stack's inference, fix the stack so it emits the same intent as the other.
+   - If the divergence reflects a new, defensible difference (different confidence signal available in one stack, for example), add an entry to `ALLOWED_DIFFERENCES` with a clear rationale.
+   - If the fixture itself is incomplete and drives ambiguous behavior, update the fixture and note the change.
+
+The check stays as a required PR gate so every contract-relevant change either preserves equivalence or explicitly renegotiates it.

--- a/docs/content/testing/profiles/flow-insights.md
+++ b/docs/content/testing/profiles/flow-insights.md
@@ -140,8 +140,20 @@ and the capability flag in `stack.json`:
 }
 ```
 
+## Cross-stack equivalence harness
+
+The `flow-insights` profile pairs with a cross-stack equivalence harness that
+boots both BFFs together, captures `/api/flow/insights` signal summaries for
+every fixture against each stack, and diffs the two captures under the
+equivalence rules above. The harness is invoked as
+`make check-flow-insights-equivalence` and is gated as a required PR check.
+
+See [Cross-Stack Equivalence](../../flow/cross-stack-equivalence) for the full
+methodology, allow-list policy, and guidance for reading a failed run.
+
 ## Related
 
+- [Cross-Stack Equivalence](../../flow/cross-stack-equivalence) — Harness methodology and allow-list policy
 - [Contract Test Harness](../contract-harness) — Full harness guide
 - [Flow Intent Scenarios](../../flow/intent-scenarios) — Layer 1 source
 - [Signal Catalog](../../flow/signals) — Canonical signal definitions

--- a/scripts/ci/check-pr-validation-result.sh
+++ b/scripts/ci/check-pr-validation-result.sh
@@ -13,6 +13,7 @@
 #   RESULT_CONTAINERS      — check-container-build job result
 #   RESULT_MOCK_OAUTH      — check-mock-oauth-build job result
 #   RESULT_AUTH_INTEGRATION — check-auth-integration job result
+#   RESULT_FLOW_INSIGHTS   — check-flow-insights-equivalence job result
 #
 # Exit codes:
 #   0 — All required checks passed or were skipped
@@ -28,6 +29,7 @@ set -euo pipefail
 : "${RESULT_CONTAINERS:?RESULT_CONTAINERS is required}"
 : "${RESULT_MOCK_OAUTH:?RESULT_MOCK_OAUTH is required}"
 : "${RESULT_AUTH_INTEGRATION:?RESULT_AUTH_INTEGRATION is required}"
+: "${RESULT_FLOW_INSIGHTS:?RESULT_FLOW_INSIGHTS is required}"
 
 failed=false
 
@@ -58,6 +60,7 @@ _check "check-docs-site"          "${RESULT_DOCS}"
 _check "check-container-build"    "${RESULT_CONTAINERS}"
 _check "check-mock-oauth-build"   "${RESULT_MOCK_OAUTH}"
 _check "check-auth-integration"   "${RESULT_AUTH_INTEGRATION}"
+_check "check-flow-insights-equivalence" "${RESULT_FLOW_INSIGHTS}"
 
 if [[ "${failed}" == "true" ]]; then
   exit 1

--- a/scripts/ci/detect-pr-changes.sh
+++ b/scripts/ci/detect-pr-changes.sh
@@ -46,6 +46,7 @@ run_mock_oauth_build="false"
 run_mock_oauth_containers="false"
 run_dev_tools_container="false"
 run_auth_integration="false"
+run_flow_insights_equivalence="false"
 
 container_detection_output="$({
   BASE_SHA="${BASE_SHA}" \
@@ -94,12 +95,20 @@ for file in "${changed_files[@]}"; do
     .github/workflows/*)
       run_workflow_lint="true"
       ;;
+    scripts/ci/run-flow-insights-equivalence.sh)
+      run_workflow_lint="true"
+      run_flow_insights_equivalence="true"
+      ;;
     scripts/ci/*)
       run_workflow_lint="true"
       ;;
     stacks/go/net-http/rest/bff/auth*)
       run_go_stack="true"
       run_auth_integration="true"
+      ;;
+    stacks/go/net-http/rest/bff/flow/*)
+      run_go_stack="true"
+      run_flow_insights_equivalence="true"
       ;;
     stacks/go/net-http/rest/*)
       run_go_stack="true"
@@ -108,12 +117,27 @@ for file in "${changed_files[@]}"; do
       run_node_stack="true"
       run_auth_integration="true"
       ;;
+    stacks/nodejs/react-fastify/rest/bff/src/routes/flow-insights*)
+      run_node_stack="true"
+      run_flow_insights_equivalence="true"
+      ;;
     stacks/nodejs/react-fastify/rest/bff/src/auth/*)
       run_node_stack="true"
       run_auth_integration="true"
       ;;
+    stacks/nodejs/react-fastify/rest/bff/src/flow/*)
+      run_node_stack="true"
+      run_flow_insights_equivalence="true"
+      ;;
     stacks/nodejs/react-fastify/rest/*)
       run_node_stack="true"
+      ;;
+    schema/fixtures/provider-adapter-input/*)
+      run_flow_insights_equivalence="true"
+      ;;
+    tests/src/tools/flow-insights-equivalence.ts|tests/src/profiles/flow-insights.ts|tests/features/flow-insights.feature)
+      run_flow_insights_equivalence="true"
+      run_reference_all="true"
       ;;
     tools/mock-oauth/*)
       run_mock_oauth_build="true"
@@ -142,7 +166,7 @@ for file in "${changed_files[@]}"; do
     Makefile|package.json|package-lock.json|tests/*)
       run_reference_all="true"
       ;;
-    *.md|.github/*|scripts/ci/*)
+    *.md|.github/*)
       ;;
     *)
       run_reference_all="true"
@@ -176,6 +200,7 @@ if [[ "${run_reference_all}" == "true" ]]; then
   run_mock_oauth_containers="true"
   run_dev_tools_container="true"
   run_auth_integration="true"
+  run_flow_insights_equivalence="true"
 fi
 
 run_stack_validation="false"
@@ -193,6 +218,7 @@ if [[ "${markdown_only}" == "true" ]]; then
   run_mock_oauth_containers="false"
   run_dev_tools_container="false"
   run_auth_integration="false"
+  run_flow_insights_equivalence="false"
 fi
 
 run_any_containers="false"
@@ -247,6 +273,7 @@ echo "run_mock_oauth_build=${run_mock_oauth_build}"
 echo "run_mock_oauth_containers=${run_mock_oauth_containers}"
 echo "run_dev_tools_container=${run_dev_tools_container}"
 echo "run_auth_integration=${run_auth_integration}"
+echo "run_flow_insights_equivalence=${run_flow_insights_equivalence}"
 echo "run_vscode_extension=${run_vscode_extension}"
 echo "run_backstage_tools=${run_backstage_tools}"
 
@@ -268,6 +295,7 @@ if [[ -n "${OUTPUT_FILE}" ]]; then
     printf "run_mock_oauth_containers=%s\n" "${run_mock_oauth_containers}"
     printf "run_dev_tools_container=%s\n" "${run_dev_tools_container}"
     printf "run_auth_integration=%s\n" "${run_auth_integration}"
+    printf "run_flow_insights_equivalence=%s\n" "${run_flow_insights_equivalence}"
     printf "run_vscode_extension=%s\n" "${run_vscode_extension}"
     printf "run_backstage_tools=%s\n" "${run_backstage_tools}"
   } >> "${OUTPUT_FILE}"

--- a/scripts/ci/run-flow-insights-equivalence.sh
+++ b/scripts/ci/run-flow-insights-equivalence.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# run-flow-insights-equivalence.sh — Cross-stack equivalence runner.
+#
+# Starts the Go BFF and the Node.js BFF on disjoint loopback ports, waits
+# for both to become ready, captures the canonical /api/flow/insights
+# response for every shared fixture against each BFF, and diffs the two
+# captures under ADR-0014's equivalence rules.
+#
+# Exit code is 0 when every fixture is `equal` or `allowed-difference`,
+# and non-zero when any fixture is `divergent`.
+#
+# Usage:
+#   bash scripts/ci/run-flow-insights-equivalence.sh
+#
+# Optional environment variables:
+#   OUR_IDP_GO_BFF_HOST   Go BFF host (default: 127.0.0.1)
+#   OUR_IDP_GO_BFF_PORT   Go BFF port (default: 8301)
+#   OUR_IDP_NODE_BFF_HOST Node.js BFF host (default: 127.0.0.1)
+#   OUR_IDP_NODE_BFF_PORT Node.js BFF port (default: 8401)
+#   OUR_IDP_READY_TIMEOUT Seconds to wait for readiness (default: 120)
+#   OUR_IDP_RESULTS_DIR   Directory for captured JSON and diff output
+#                         (default: .tmp/flow-insights-equivalence)
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "${ROOT_DIR}"
+
+GO_BFF_HOST="${OUR_IDP_GO_BFF_HOST:-127.0.0.1}"
+GO_BFF_PORT="${OUR_IDP_GO_BFF_PORT:-8301}"
+NODE_BFF_HOST="${OUR_IDP_NODE_BFF_HOST:-127.0.0.1}"
+NODE_BFF_PORT="${OUR_IDP_NODE_BFF_PORT:-8401}"
+READY_TIMEOUT="${OUR_IDP_READY_TIMEOUT:-120}"
+READY_INTERVAL="${OUR_IDP_READY_INTERVAL:-1}"
+RESULTS_DIR="${OUR_IDP_RESULTS_DIR:-.tmp/flow-insights-equivalence}"
+
+GO_BFF_URL="http://${GO_BFF_HOST}:${GO_BFF_PORT}"
+NODE_BFF_URL="http://${NODE_BFF_HOST}:${NODE_BFF_PORT}"
+
+mkdir -p "${RESULTS_DIR}"
+
+GO_BFF_PID=""
+NODE_BFF_PID=""
+
+log() {
+  printf "[flow-insights-equivalence] %s\n" "$*"
+}
+
+cleanup() {
+  log "Stopping BFFs"
+  if [[ -n "${GO_BFF_PID}" ]]; then
+    kill "${GO_BFF_PID}" >/dev/null 2>&1 || true
+    wait "${GO_BFF_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${NODE_BFF_PID}" ]]; then
+    kill "${NODE_BFF_PID}" >/dev/null 2>&1 || true
+    wait "${NODE_BFF_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_ready() {
+  local label="$1"
+  local url="$2"
+  local deadline=$(( $(date +%s) + READY_TIMEOUT ))
+  while (( $(date +%s) < deadline )); do
+    if curl --silent --fail --max-time 5 "${url}/readiness" >/dev/null 2>&1; then
+      log "${label} ready at ${url}"
+      return 0
+    fi
+    sleep "${READY_INTERVAL}"
+  done
+  log "${label} failed to become ready at ${url}"
+  return 1
+}
+
+log "Starting Go BFF on ${GO_BFF_URL}"
+(
+  export OUR_IDP_API_HOST="${GO_BFF_HOST}"
+  export OUR_IDP_API_PORT="${GO_BFF_PORT}"
+  export OUR_IDP_STATUS_WEB_URL="http://${GO_BFF_HOST}:3300"
+  cd stacks/go/net-http/rest
+  exec go run ./bff/...
+) >"${RESULTS_DIR}/go-bff.log" 2>&1 &
+GO_BFF_PID=$!
+
+log "Starting Node.js BFF on ${NODE_BFF_URL}"
+(
+  export OUR_IDP_API_HOST="${NODE_BFF_HOST}"
+  export OUR_IDP_API_PORT="${NODE_BFF_PORT}"
+  export OUR_IDP_STATUS_WEB_URL="http://${NODE_BFF_HOST}:3400"
+  cd stacks/nodejs/react-fastify/rest
+  exec npm run --silent start:bff
+) >"${RESULTS_DIR}/node-bff.log" 2>&1 &
+NODE_BFF_PID=$!
+
+wait_for_ready "Go BFF" "${GO_BFF_URL}"
+wait_for_ready "Node.js BFF" "${NODE_BFF_URL}"
+
+log "Capturing Go BFF signal summary"
+npx --no-install tsx tests/src/tools/flow-insights-equivalence.ts \
+  capture "${GO_BFF_URL}" "${RESULTS_DIR}/go.json"
+
+log "Capturing Node.js BFF signal summary"
+npx --no-install tsx tests/src/tools/flow-insights-equivalence.ts \
+  capture "${NODE_BFF_URL}" "${RESULTS_DIR}/node.json"
+
+log "Running cross-stack diff"
+set +e
+npx --no-install tsx tests/src/tools/flow-insights-equivalence.ts \
+  diff "${RESULTS_DIR}/go.json" "${RESULTS_DIR}/node.json" \
+  --out-json "${RESULTS_DIR}/diff.json" \
+  --out-md "${RESULTS_DIR}/diff.md"
+DIFF_EXIT=$?
+set -e
+
+if [[ "${DIFF_EXIT}" -ne 0 ]]; then
+  log "Cross-stack diff failed: unacceptable divergence detected"
+  log "See ${RESULTS_DIR}/diff.md for details"
+  exit "${DIFF_EXIT}"
+fi
+
+log "Cross-stack equivalence check passed"
+exit 0

--- a/scripts/e2e/run-gitlab-harness.sh
+++ b/scripts/e2e/run-gitlab-harness.sh
@@ -14,4 +14,12 @@ make gitlab-harness-wait-healthy
 make gitlab-harness-token
 make gitlab-harness-seed
 
-echo "GitLab harness is up and seeded. Add live adapter test commands here (GITLAB_HARNESS=1)."
+echo "GitLab harness is up and seeded."
+
+# Run the cross-stack flow insights equivalence check in the full-env
+# nightly context. The check boots both BFFs and diffs /api/flow/insights
+# signal summaries for every shared fixture under the ADR-0014 rules.
+# When live GitLab routing gets wired into the BFFs, the same harness will
+# exercise it against the seeded scenarios without further workflow changes.
+echo "Running cross-stack flow insights equivalence"
+make check-flow-insights-equivalence

--- a/tests/src/tools/flow-insights-equivalence.ts
+++ b/tests/src/tools/flow-insights-equivalence.ts
@@ -1,0 +1,413 @@
+// Cross-stack semantic equivalence runner for the flow-insights profile.
+//
+// Two subcommands:
+//
+//   capture <bff-url> <out-file>
+//     POST every fixture under schema/fixtures/provider-adapter-input/ to
+//     the target BFF's /api/flow/insights endpoint and write a canonical
+//     JSON summary. The summary keeps only the fields that ADR-0014 treats
+//     as contract surface (signal id, severity, confidence, presence of
+//     explanation and recommended next action).
+//
+//   diff <stack-a.json> <stack-b.json> [--out-json <path>] [--out-md <path>]
+//     Compare two summaries under ADR-0014's equivalence rules and report:
+//       required to match   — signal id set, severity per signal,
+//                             confidence per signal
+//       allowed to differ   — wording of explanation / recommendedNextAction,
+//                             ordering, incidental metadata
+//     Exit 0 if every per-fixture comparison is either `equal` or an
+//     explicitly allowed difference; exit 1 otherwise.
+//
+// The summary schema is intentionally narrow so this tool does not drift
+// with incidental BFF response changes. The authoritative equivalence rules
+// live in docs/content/architecture/decisions/0014-mvp-flow-observation-technical-foundations.md.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { post } from "../http";
+
+// js-yaml is a runtime dep of the tests workspace; no bundled types.
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any
+const yaml = require("js-yaml") as { load: (input: string) => unknown };
+
+const FIXTURE_DIR = path.resolve(
+  __dirname,
+  "../../../schema/fixtures/provider-adapter-input",
+);
+
+const FLOW_INSIGHTS_ENDPOINT = "/api/flow/insights";
+
+type SignalSummary = {
+  id: string;
+  severity: string | null;
+  confidence: string | null;
+  hasExplanation: boolean;
+  hasRecommendedNextAction: boolean;
+};
+
+type FixtureSummary = {
+  fixture: string;
+  status: number;
+  signals: SignalSummary[];
+};
+
+type CaptureReport = {
+  bffUrl: string;
+  capturedAt: string;
+  fixtures: FixtureSummary[];
+};
+
+type FlowSignal = {
+  id?: unknown;
+  severity?: unknown;
+  confidence?: unknown;
+  explanation?: unknown;
+  recommendedNextAction?: unknown;
+};
+
+function listFixtureIds(): string[] {
+  return fs
+    .readdirSync(FIXTURE_DIR)
+    .filter((name) => name.endsWith(".yaml"))
+    .map((name) => name.replace(/\.yaml$/, ""))
+    .sort();
+}
+
+function loadFixture(fixtureId: string): unknown {
+  const filePath = path.join(FIXTURE_DIR, `${fixtureId}.yaml`);
+  return yaml.load(fs.readFileSync(filePath, "utf-8"));
+}
+
+function normalizeSignal(raw: unknown): SignalSummary {
+  const s = raw as FlowSignal;
+  const id = typeof s.id === "string" ? s.id : "";
+  const severity = typeof s.severity === "string" ? s.severity : null;
+  const confidence = typeof s.confidence === "string" ? s.confidence : null;
+  const explanation = typeof s.explanation === "string" ? s.explanation : "";
+  const action =
+    typeof s.recommendedNextAction === "string" ? s.recommendedNextAction : "";
+  return {
+    id,
+    severity,
+    confidence,
+    hasExplanation: explanation.trim().length > 0,
+    hasRecommendedNextAction: action.trim().length > 0,
+  };
+}
+
+function sortSignals(signals: SignalSummary[]): SignalSummary[] {
+  return [...signals].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+async function captureFixture(
+  bffBaseUrl: URL,
+  fixtureId: string,
+): Promise<FixtureSummary> {
+  const fixture = loadFixture(fixtureId);
+  const endpoint = new URL(FLOW_INSIGHTS_ENDPOINT, bffBaseUrl);
+  const response = await post(endpoint, fixture);
+
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      fixture: fixtureId,
+      status: response.status,
+      signals: [],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response.body);
+  } catch {
+    return {
+      fixture: fixtureId,
+      status: response.status,
+      signals: [],
+    };
+  }
+
+  const rawSignals =
+    typeof parsed === "object" &&
+    parsed !== null &&
+    Array.isArray((parsed as { signals?: unknown }).signals)
+      ? ((parsed as { signals: unknown[] }).signals as unknown[])
+      : [];
+
+  return {
+    fixture: fixtureId,
+    status: response.status,
+    signals: sortSignals(rawSignals.map(normalizeSignal)),
+  };
+}
+
+async function runCapture(bffUrl: string, outFile: string): Promise<void> {
+  const bffBaseUrl = new URL(bffUrl);
+  const fixtureIds = listFixtureIds();
+  const report: CaptureReport = {
+    bffUrl: bffBaseUrl.toString(),
+    capturedAt: new Date().toISOString(),
+    fixtures: [],
+  };
+
+  for (const fixtureId of fixtureIds) {
+    // eslint-disable-next-line no-await-in-loop
+    const summary = await captureFixture(bffBaseUrl, fixtureId);
+    report.fixtures.push(summary);
+  }
+
+  fs.mkdirSync(path.dirname(outFile), { recursive: true });
+  fs.writeFileSync(outFile, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  process.stdout.write(
+    `captured ${report.fixtures.length} fixtures → ${outFile}\n`,
+  );
+}
+
+// ─── diff ─────────────────────────────────────────────────────────────────
+
+type Verdict = "equal" | "allowed-difference" | "divergent";
+
+type FixtureVerdict = {
+  fixture: string;
+  verdict: Verdict;
+  reasons: string[];
+};
+
+type DiffReport = {
+  stackA: string;
+  stackB: string;
+  verdicts: FixtureVerdict[];
+  divergentCount: number;
+  allowedDifferenceCount: number;
+  equalCount: number;
+};
+
+// Allowed differences declared up-front per ADR-0014. Any entry here MUST be
+// documented in docs/content/flow/cross-stack-equivalence.md with rationale.
+// The list is intentionally empty by default — any divergence must be
+// explicitly added here AND to the findings doc before it counts as allowed.
+const ALLOWED_DIFFERENCES: Array<{
+  fixture: string;
+  signalId: string;
+  field: "severity" | "confidence" | "presence";
+  rationale: string;
+}> = [];
+
+function loadReport(filePath: string): CaptureReport {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return JSON.parse(raw) as CaptureReport;
+}
+
+function compareFixture(
+  fixture: string,
+  a: FixtureSummary | undefined,
+  b: FixtureSummary | undefined,
+): FixtureVerdict {
+  const reasons: string[] = [];
+
+  if (!a || !b) {
+    reasons.push(
+      `fixture missing from one stack (a=${!!a}, b=${!!b})`,
+    );
+    return { fixture, verdict: "divergent", reasons };
+  }
+
+  if (a.status !== b.status) {
+    reasons.push(`http status differs: a=${a.status}, b=${b.status}`);
+  }
+
+  const aIds = new Set(a.signals.map((s) => s.id));
+  const bIds = new Set(b.signals.map((s) => s.id));
+  const onlyInA = [...aIds].filter((id) => !bIds.has(id));
+  const onlyInB = [...bIds].filter((id) => !aIds.has(id));
+
+  if (onlyInA.length > 0) {
+    reasons.push(`only in A: ${onlyInA.join(", ")}`);
+  }
+  if (onlyInB.length > 0) {
+    reasons.push(`only in B: ${onlyInB.join(", ")}`);
+  }
+
+  const commonIds = [...aIds].filter((id) => bIds.has(id));
+  let hasAllowedOnly = reasons.length === 0;
+
+  for (const id of commonIds) {
+    const sa = a.signals.find((s) => s.id === id)!;
+    const sb = b.signals.find((s) => s.id === id)!;
+
+    if (sa.severity !== sb.severity) {
+      const allowed = ALLOWED_DIFFERENCES.some(
+        (d) =>
+          d.fixture === fixture && d.signalId === id && d.field === "severity",
+      );
+      if (allowed) {
+        hasAllowedOnly = true;
+      } else {
+        reasons.push(
+          `signal ${id}: severity differs (a=${sa.severity}, b=${sb.severity})`,
+        );
+      }
+    }
+    if (sa.confidence !== sb.confidence) {
+      const allowed = ALLOWED_DIFFERENCES.some(
+        (d) =>
+          d.fixture === fixture &&
+          d.signalId === id &&
+          d.field === "confidence",
+      );
+      if (allowed) {
+        hasAllowedOnly = true;
+      } else {
+        reasons.push(
+          `signal ${id}: confidence differs (a=${sa.confidence}, b=${sb.confidence})`,
+        );
+      }
+    }
+    if (sa.hasExplanation !== sb.hasExplanation) {
+      reasons.push(
+        `signal ${id}: explanation presence differs (a=${sa.hasExplanation}, b=${sb.hasExplanation})`,
+      );
+    }
+    if (sa.hasRecommendedNextAction !== sb.hasRecommendedNextAction) {
+      reasons.push(
+        `signal ${id}: recommendedNextAction presence differs (a=${sa.hasRecommendedNextAction}, b=${sb.hasRecommendedNextAction})`,
+      );
+    }
+  }
+
+  if (reasons.length === 0) {
+    return { fixture, verdict: "equal", reasons };
+  }
+  if (hasAllowedOnly && onlyInA.length === 0 && onlyInB.length === 0) {
+    return { fixture, verdict: "allowed-difference", reasons };
+  }
+  return { fixture, verdict: "divergent", reasons };
+}
+
+function buildDiff(a: CaptureReport, b: CaptureReport): DiffReport {
+  const fixtures = new Set<string>([
+    ...a.fixtures.map((f) => f.fixture),
+    ...b.fixtures.map((f) => f.fixture),
+  ]);
+
+  const verdicts: FixtureVerdict[] = [];
+  for (const fixture of [...fixtures].sort()) {
+    const fa = a.fixtures.find((f) => f.fixture === fixture);
+    const fb = b.fixtures.find((f) => f.fixture === fixture);
+    verdicts.push(compareFixture(fixture, fa, fb));
+  }
+
+  return {
+    stackA: a.bffUrl,
+    stackB: b.bffUrl,
+    verdicts,
+    divergentCount: verdicts.filter((v) => v.verdict === "divergent").length,
+    allowedDifferenceCount: verdicts.filter(
+      (v) => v.verdict === "allowed-difference",
+    ).length,
+    equalCount: verdicts.filter((v) => v.verdict === "equal").length,
+  };
+}
+
+function renderMarkdown(report: DiffReport): string {
+  const lines: string[] = [];
+  lines.push("# Cross-stack equivalence diff");
+  lines.push("");
+  lines.push(`- Stack A: \`${report.stackA}\``);
+  lines.push(`- Stack B: \`${report.stackB}\``);
+  lines.push(`- Equal: ${report.equalCount}`);
+  lines.push(`- Allowed differences: ${report.allowedDifferenceCount}`);
+  lines.push(`- Divergent: ${report.divergentCount}`);
+  lines.push("");
+  lines.push("| Fixture | Verdict | Reasons |");
+  lines.push("| --- | --- | --- |");
+  for (const v of report.verdicts) {
+    const reasons = v.reasons.length === 0 ? "—" : v.reasons.join("; ");
+    lines.push(`| \`${v.fixture}\` | ${v.verdict} | ${reasons} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function runDiff(
+  stackAFile: string,
+  stackBFile: string,
+  outJson: string | undefined,
+  outMd: string | undefined,
+): number {
+  const a = loadReport(stackAFile);
+  const b = loadReport(stackBFile);
+  const report = buildDiff(a, b);
+
+  if (outJson) {
+    fs.mkdirSync(path.dirname(outJson), { recursive: true });
+    fs.writeFileSync(outJson, `${JSON.stringify(report, null, 2)}\n`, "utf-8");
+  }
+  if (outMd) {
+    fs.mkdirSync(path.dirname(outMd), { recursive: true });
+    fs.writeFileSync(outMd, renderMarkdown(report), "utf-8");
+  }
+
+  process.stdout.write(renderMarkdown(report));
+  return report.divergentCount === 0 ? 0 : 1;
+}
+
+// ─── argv dispatch ─────────────────────────────────────────────────────────
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  tsx tests/src/tools/flow-insights-equivalence.ts capture <bff-url> <out-file>",
+    "  tsx tests/src/tools/flow-insights-equivalence.ts diff <stack-a.json> <stack-b.json> [--out-json <path>] [--out-md <path>]",
+  ].join("\n");
+}
+
+async function main(): Promise<number> {
+  const [subcommand, ...rest] = process.argv.slice(2);
+
+  if (subcommand === "capture") {
+    const [bffUrl, outFile] = rest;
+    if (!bffUrl || !outFile) {
+      process.stderr.write(`${usage()}\n`);
+      return 2;
+    }
+    await runCapture(bffUrl, outFile);
+    return 0;
+  }
+
+  if (subcommand === "diff") {
+    const positional: string[] = [];
+    let outJson: string | undefined;
+    let outMd: string | undefined;
+    for (let i = 0; i < rest.length; i += 1) {
+      const value = rest[i];
+      if (value === "--out-json") {
+        outJson = rest[i + 1];
+        i += 1;
+      } else if (value === "--out-md") {
+        outMd = rest[i + 1];
+        i += 1;
+      } else {
+        positional.push(value);
+      }
+    }
+    const [stackA, stackB] = positional;
+    if (!stackA || !stackB) {
+      process.stderr.write(`${usage()}\n`);
+      return 2;
+    }
+    return runDiff(stackA, stackB, outJson, outMd);
+  }
+
+  process.stderr.write(`${usage()}\n`);
+  return 2;
+}
+
+main()
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`flow-insights-equivalence error: ${message}\n`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Adds a cross-stack flow insights equivalence harness (`tests/src/tools/flow-insights-equivalence.ts`) that captures `/api/flow/insights` signal summaries from both BFFs and diffs them under the ADR-0014 rules.
- Wires the harness into PR validation as a new required check (`check-flow-insights-equivalence`), gated on fixture, BFF route, or harness changes so PRs that don't touch the equivalence surface aren't slowed down.
- Extends the nightly `gitlab-harness-e2e` job to run the same harness after seeding the GitLab harness, so future live adapter routing lands against an already-green cross-stack check.
- Adds a long-lived findings doc (`docs/content/flow/cross-stack-equivalence.md`) that covers the equivalence rules, allow-list policy, and how to read a failed run; cross-links from the flow-insights profile page per the sync rule.

## Test plan

- [x] `moon run repo:check-lint-md`
- [x] `moon run repo:check-lint-workflows`
- [x] `tsc --noEmit` against `tests/tsconfig.json`
- [ ] PR-validate workflow: `Check Flow Insights Equivalence` job passes on this PR
- [ ] Remaining PR-validate required checks pass

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)