### PR TITLE
fix(flow-insights): anchor risk_aggregation window to latest observed signal

### DIFF
--- a/stacks/go/net-http/rest/bff/flow/inference/risk_by_scope.go
+++ b/stacks/go/net-http/rest/bff/flow/inference/risk_by_scope.go
@@ -7,14 +7,14 @@ import (
 )
 
 func InferRiskByScope(input flow.ProviderAdapterInput, signals []flow.FlowSignal, now time.Time) (*flow.FlowSignal, bool) {
-	windowStart := now.Add(-1 * RiskWindowHours * time.Hour)
-	contributing := make([]struct {
+	candidates := make([]struct {
 		signal     flow.FlowSignal
 		service    string
 		team       string
 		stage      flow.FlowSignalStage
 		observedAt time.Time
 	}, 0)
+	latestObserved := time.Time{}
 
 	for _, s := range signals {
 		if s.ID == "risk_aggregation" {
@@ -26,8 +26,8 @@ func InferRiskByScope(input flow.ProviderAdapterInput, signals []flow.FlowSignal
 				observed = parsed
 			}
 		}
-		if observed.Before(windowStart) {
-			continue
+		if observed.After(latestObserved) {
+			latestObserved = observed
 		}
 		service := ""
 		team := ""
@@ -43,7 +43,7 @@ func InferRiskByScope(input flow.ProviderAdapterInput, signals []flow.FlowSignal
 		if team == "" {
 			team = resolvePrimaryTeam(input.OwnershipHints)
 		}
-		contributing = append(contributing, struct {
+		candidates = append(candidates, struct {
 			signal     flow.FlowSignal
 			service    string
 			team       string
@@ -56,6 +56,24 @@ func InferRiskByScope(input flow.ProviderAdapterInput, signals []flow.FlowSignal
 			stage:      stage,
 			observedAt: observed,
 		})
+	}
+
+	if latestObserved.IsZero() {
+		latestObserved = now
+	}
+	windowStart := latestObserved.Add(-1 * RiskWindowHours * time.Hour)
+	contributing := make([]struct {
+		signal     flow.FlowSignal
+		service    string
+		team       string
+		stage      flow.FlowSignalStage
+		observedAt time.Time
+	}, 0)
+	for _, candidate := range candidates {
+		if candidate.observedAt.Before(windowStart) {
+			continue
+		}
+		contributing = append(contributing, candidate)
 	}
 
 	if len(contributing) < 3 {

--- a/stacks/nodejs/react-fastify/rest/bff/src/flow/inference/riskByScope.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/flow/inference/riskByScope.ts
@@ -8,9 +8,7 @@ export function inferRiskByScope(
   signals: FlowSignal[],
   now: Date,
 ): FlowSignal | null {
-  const windowStart = now.getTime() - RISK_WINDOW_HOURS * 60 * 60 * 1000;
-
-  const contributing = signals
+  const candidates = signals
     .filter((signal) => signal.id !== "risk_aggregation")
     .map((signal) => {
       const observedMs = signal.observedAt ? Date.parse(signal.observedAt) : Number.NaN;
@@ -23,7 +21,19 @@ export function inferRiskByScope(
         stage: signal.scope?.stage,
         observedMs,
       };
-    })
+    });
+
+  let latestObservedMs = Number.NaN;
+  for (const entry of candidates) {
+    if (Number.isNaN(entry.observedMs)) continue;
+    if (Number.isNaN(latestObservedMs) || entry.observedMs > latestObservedMs) {
+      latestObservedMs = entry.observedMs;
+    }
+  }
+  const anchorMs = Number.isNaN(latestObservedMs) ? now.getTime() : latestObservedMs;
+  const windowStart = anchorMs - RISK_WINDOW_HOURS * 60 * 60 * 1000;
+
+  const contributing = candidates
     .filter((entry) => Number.isNaN(entry.observedMs) || entry.observedMs >= windowStart);
 
   if (contributing.length < 3) {


### PR DESCRIPTION
Both stacks were anchoring the risk window to wall-clock runtime rather than
the latest observed signal timestamp in the fixture data. This caused
risk_aggregation to be suppressed when fixture signals are older than the
runtime window. Now the anchor is the latest observedAt across contributing
signals, falling back to now only when no timestamps are present.

Closes deprecated PR #261.

https://claude.ai/code/session_011DGE66ohS3VfDhtHKdvTFo