### PR TITLE
fix(bff): add explicit rootDir to tsconfig for TypeScript 6.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,10 @@ target/
 
 # Local stack artifacts
 stacks/go/net-http/rest/.bin/
+stacks/nodejs/react-fastify/rest/bff/dist/
 stacks/nodejs/react-fastify/rest/web/dist/
 src/stacks/go/net-http/rest/.bin/
+src/stacks/nodejs/react-fastify/rest/bff/dist/
 src/stacks/nodejs/react-fastify/rest/web/dist/
 web.log
 bff.log

--- a/stacks/nodejs/react-fastify/rest/bff/tsconfig.json
+++ b/stacks/nodejs/react-fastify/rest/bff/tsconfig.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "types": ["node"],
+    "rootDir": "src",
     "outDir": "dist"
   },
   "include": ["src"]


### PR DESCRIPTION
TypeScript 6.0 (TS5011) now requires rootDir to be explicitly set when
outDir is configured, even when the common source dir is unambiguous.
Fixes the BFF Docker build failure from the typescript 6.0.3 bump (PR #268).

https://claude.ai/code/session_01CTj8oxE8VWr13yKDgruErR