### PR TITLE
fix(gitlab-harness): use built-in GitLab healthcheck

### DIFF
--- a/tools/gitlab-harness/compose.yaml
+++ b/tools/gitlab-harness/compose.yaml
@@ -9,7 +9,8 @@ services:
       - "8929:8929"
       - "2424:22"
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8929/-/readiness"]
+      test: ["CMD", "/opt/gitlab/bin/gitlab-healthcheck", "--fail", "--max-time", "10"]
+      start_period: 5m
       interval: 15s
       timeout: 10s
       retries: 40


### PR DESCRIPTION
### Motivation
- The nightly CI reported `container gitlab-harness is unhealthy` during `make gitlab-harness-up`, indicating the existing readiness probe can return false negatives during Omnibus initialization. 
- Use the image-native healthcheck and tolerate the bootstrap window to improve startup reliability in CI.

### Description
- Replace the curl readiness probe in `tools/gitlab-harness/compose.yaml` with the vendor-provided check: `test: ["CMD", "/opt/gitlab/bin/gitlab-healthcheck", "--fail", "--max-time", "10"]`.
- Add `start_period: 5m` to the GitLab service healthcheck to avoid counting the Omnibus bootstrap time as failures.
- No other files were modified.

### Testing
- Attempted to validate the compose config with `docker compose -f tools/gitlab-harness/compose.yaml config`, but the command failed locally because `docker` is not available in this execution environment (validation did not run).
- No other automated tests were executed in this session; CI should be retried to verify the fix under actual container execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e371dc5adc8332b549bbdb94e5aa8f)