### PR TITLE
ci(workflows): add concurrency controls to all workflow files

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   cleanup-orphaned-branches:
     name: Remove orphaned zero-commit branches

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -32,6 +32,10 @@ permissions:
   actions: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   cleanup:
     name: Clean up Actions cache

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -31,6 +31,10 @@ permissions:
   id-token: write
   attestations: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/ourchitecture/idp

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   # Minimum number of versions to keep per image (floor threshold)
   KEEP_VERSIONS_GO_WEB: "5"

--- a/.github/workflows/container-latest-tag.yml
+++ b/.github/workflows/container-latest-tag.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/ourchitecture/idp

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -16,6 +16,10 @@ permissions:
   id-token: write
   attestations: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/ourchitecture/idp

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,6 +13,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/gitlab-harness-e2e.yml
+++ b/.github/workflows/gitlab-harness-e2e.yml
@@ -16,6 +16,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,6 +8,10 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/onboarding-check-weekly.yml
+++ b/.github/workflows/onboarding-check-weekly.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/privacy-scan-weekly.yml
+++ b/.github/workflows/privacy-scan-weekly.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   stale:
     name: Mark Stale Issues and PRs

--- a/.github/workflows/work-issue.yml
+++ b/.github/workflows/work-issue.yml
@@ -14,6 +14,10 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
+
 env:
   PROTO_VERSION: "0.55.4"
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3


### PR DESCRIPTION
Add top-level `concurrency:` blocks to all 16 workflows that were
missing them, ensuring only the latest run proceeds for any given
branch, PR, or issue.

**Strategy by trigger type:**

- PR/branch workflows (`container-build`, `pr-validate`,
  `copilot-setup-steps`, `gitlab-harness-e2e`): cancel previous
  runs on the same ref (`cancel-in-progress: true`).
- Scheduled maintenance (`branch-cleanup`, `container-cleanup`,
  `onboarding-check-weekly`, `privacy-scan-weekly`, `stale`): queue
  rather than cancel so in-progress runs are not interrupted
  (`cancel-in-progress: false`).
- Manual dispatch (`cache-cleanup`, `setup-labels`): cancel previous
  run when a newer dispatch arrives (`cancel-in-progress: true`).
- Issue-event workflows (`issue-triage`, `work-issue`): scope by
  issue number to prevent duplicate runs on the same issue
  (`cancel-in-progress: true`).
- Release/publish (`release-please`, `container-publish`): queue to
  avoid partial release state (`cancel-in-progress: false`).
- Workflow-run triggered (`container-latest-tag`): cancel stale runs
  since only the latest result matters (`cancel-in-progress: true`).

`docs-publish` already had correct concurrency and was left unchanged.

Closes #288