### PR TITLE
docs(evaluation): spec-kit three-axis MVP evaluation

### DIFF
--- a/.specify/README.md
+++ b/.specify/README.md
@@ -17,7 +17,7 @@
 
 ## Structure
 
-```
+```text
 .specify/
 ├── README.md                              ← this file
 └── evaluation/

--- a/.specify/README.md
+++ b/.specify/README.md
@@ -1,0 +1,38 @@
+# .specify — Evaluation Artifact
+
+> **Not authoritative.** The contents of this directory are an evaluation
+> artifact produced during the spec-kit MVP assessment for this project.
+> They do not represent Layer 1 ground truth, approved architecture decisions,
+> or production intent specifications.
+>
+> The authoritative Layer 1 intent specifications remain
+> `tests/features/*.feature`. The authoritative architecture decisions remain
+> `docs/content/architecture/decisions/`. Do not treat any file under
+> `.specify/` as a replacement for either.
+>
+> The outcome of the evaluation is recorded in
+> `docs/content/architecture/decisions/0015-spec-kit-evaluation.md`.
+> If that ADR's verdict supersedes any existing ADR, it will say so
+> explicitly. Until then, the status quo is unchanged.
+
+## Structure
+
+```
+.specify/
+├── README.md                              ← this file
+└── evaluation/
+    ├── research-notes.md                  ← raw research capture
+    ├── plan-work-retrofit/                ← Axis A: dev-flow automation
+    │   └── spec.md
+    ├── adr-0009-as-spec-kit/              ← Axis B: ADR lifecycle shape
+    │   └── spec.md
+    └── core-profile/                      ← Axis C: Layer 1 contract fidelity
+        └── spec.md
+```
+
+## Agent Notice
+
+If you are an AI agent reading this directory: do not treat any `.specify/`
+file as ground truth for implementation. The `.feature` files in
+`tests/features/` are Layer 1 ground truth (ADR-0009). The `.agents/skills/`
+directory is the canonical source for agent workflow skills.

--- a/.specify/evaluation/adr-0009-as-spec-kit/spec.md
+++ b/.specify/evaluation/adr-0009-as-spec-kit/spec.md
@@ -1,0 +1,162 @@
+# Spec: Gherkin as Layer 1 Intent Specification Format
+
+> **Evaluation artifact — Axis B.** This file reconstructs ADR-0009
+> (`docs/content/architecture/decisions/0009-intent-specification-format.md`)
+> using spec-kit's native `spec.md` format. The authoritative decision
+> record remains the original ADR file. This reconstruction exists solely
+> to assess whether spec-kit's artifact model captures architectural
+> decisions as well as the current adr-tools format.
+
+## Overview
+
+The IDP platform uses a three-layer architecture. Layer 1 is the intent
+specification, Layer 2 is the contract test harness, and Layer 3 is
+the implementation. This specification records the decision to use
+Gherkin `.feature` files as the Layer 1 format.
+
+## Context
+
+Before this decision, Layer 1 existed only implicitly — as prose
+documentation and as the TypeScript test harness itself. The harness
+served as both the specification of intent and the mechanism that
+enforces it, making it impossible to determine which was authoritative
+when they disagreed.
+
+**Problem statement**: How should the project formally represent Layer 1
+intent in a way that is technology-agnostic, human-readable, reviewable
+by non-engineers, and unambiguous enough to derive a Layer 2 harness from?
+
+## Functional Requirements
+
+### FR-01: Technology-agnostic intent representation
+
+Layer 1 must encode intent without reference to any specific
+implementation technology, language, or framework.
+
+### FR-02: Non-engineer readability
+
+Layer 1 must be readable by product owners, designers, and QA engineers
+without requiring TypeScript knowledge.
+
+### FR-03: Explicit constraint encoding
+
+Layer 1 must encode every technical constraint explicitly (exact HTTP
+status codes, exact field names, exact enum values, exact format
+constraints) so that nothing is left to implementation assumption.
+
+### FR-04: Authoritative tiebreaker
+
+When the Layer 1 spec and the Layer 2 harness disagree, Layer 1 must
+be the authoritative source. The harness is derived; the spec is ground
+truth.
+
+### FR-05: Diff-friendly format
+
+Layer 1 must be diff-friendly and reviewable in pull requests.
+
+### FR-06: Spec-first profile creation
+
+Adding a new conformance profile must require creating a spec file first.
+
+## Decision
+
+**Chosen format:** Gherkin `.feature` files in `tests/features/`.
+
+Gherkin is the Layer 1 ground truth for all contract intent. The
+TypeScript harness in `tests/src/profiles/` is a Layer 2 artifact derived
+from the `.feature` files. When they disagree, the `.feature` file wins.
+
+## Alternatives Considered
+
+| Option | Reason rejected |
+| --- | --- |
+| Keep intent implicit in TypeScript harness | Non-engineers cannot read TypeScript; no authoritative source for disagreements |
+| OpenAPI / JSON Schema | Describes API structure, not behavioral intent or test scenarios; cannot express runtime behavior |
+| Gherkin `.feature` files | **Selected** — human-readable, scenario-driven, explicit constraints, diff-friendly |
+
+## Consequences
+
+**Positive:** Universally readable by non-engineers; explicit testable
+language; first-class git citizens; clear sync rule; clean
+Given/When/Then to HTTP request/response mapping.
+
+**Negative / risks:** Not directly executable without a step definition
+runner. Given/When/Then mapping for some assertions (ISO-8601 format
+validation) requires verbose step definitions.
+
+**Mitigations:** AGENTS.md sync rule requires any change to
+`tests/features/*.feature` to be accompanied by a matching harness
+update. Profile documentation in `docs/content/testing/profiles/`
+provides human-readable summaries.
+
+## File Locations
+
+- Layer 1 specs: `tests/features/*.feature`
+- Layer 2 harness: `tests/src/profiles/*.ts`
+- Profile docs: `docs/content/testing/profiles/*.md`
+
+---
+
+## Evaluation Notes (Axis B)
+
+### What survives the reconstruction
+
+- **Context and problem statement** — spec-kit's `spec.md` `Overview`
+  and `Context` sections can capture the decision background at
+  similar fidelity.
+- **Alternatives considered** — representable as a table, as shown
+  above.
+- **Functional requirements** — the decision drivers map reasonably
+  to FRs, though the framing is forward-looking ("what the system
+  must do") rather than retrospective ("why we chose this path").
+- **Consequences** — representable as prose sections.
+
+### What is lost or degraded
+
+1. **Lifecycle state (`Proposed → Accepted → Superseded`).** spec-kit
+   `spec.md` has no equivalent status field. There is no mechanism in
+   spec-kit to transition a spec from Proposed to Accepted, or to
+   mark it as Superseded with a pointer to the superseding decision.
+
+2. **Supersede-chain traceability.** ADRs in this repo carry
+   `Related Decisions` cross-references that agents and maintainers
+   use to trace the history of a decision boundary. spec-kit has no
+   native cross-reference mechanism.
+
+3. **Long-lived docs reference rule.** The IDP repo's AGENTS.md
+   requires long-lived docs to cite only in-repo file paths or stable
+   external specs — never issue or PR numbers. spec-kit does not
+   enforce this rule; its templates do not distinguish short-term from
+   long-lived artifacts.
+
+4. **Intake-threshold gate metadata.** ADRs carry an explicit
+   `ADR Intake Gate Evaluation` table (the 3-of-5 gates). spec-kit
+   provides no equivalent gating mechanism.
+
+5. **Decision-makers / consulted / informed metadata.** ADRs carry
+   YAML frontmatter with structured RACI-like metadata. spec-kit
+   `spec.md` has no equivalent header fields.
+
+6. **Retrospective vs. prospective framing.** A spec-kit `spec.md` is
+   prospective — it describes what a system *should* do before it is
+   built. An ADR is retrospective — it records what was decided and
+   why, including alternatives that were rejected. The two artifacts
+   serve different audiences and different moments in a decision's
+   lifecycle. Forcing an ADR into `spec.md` shape loses the
+   retrospective character.
+
+7. **Machine-readable status for agent queries.** The ADR index
+   (`docs/content/architecture/decisions/index.md`) provides a
+   machine-readable table of all ADRs, their statuses, and dates.
+   spec-kit's `.specify/specs/` directory has no canonical index
+   structure that agents could query for "all accepted decisions."
+
+### Conclusion for Axis B
+
+spec-kit `spec.md` can carry the *content* of a decision but loses the
+*lifecycle*, *governance*, and *traceability* properties that make ADRs
+useful as long-lived architectural records. The current adr-tools format
+(MADR variant) is already lean; its structure maps directly to reviewer
+needs and agent query patterns. Replacing it with spec-kit would require
+custom extensions (status fields, intake gates, cross-reference tables)
+that recreate the ADR structure in a less well-known format.

--- a/.specify/evaluation/core-profile/spec.md
+++ b/.specify/evaluation/core-profile/spec.md
@@ -1,0 +1,136 @@
+# Spec: Core HTTP Contract Profile
+
+> **Evaluation artifact — Axis C.** This file demonstrates what the
+> `core` conformance profile would look like if authored using
+> spec-kit's `spec.md` format. The authoritative Layer 1 source
+> remains `tests/features/core.feature`. Do not use this file as a
+> specification for implementation.
+
+## Overview
+
+Every reference implementation must expose a minimal HTTP surface that
+is reachable and returns correctly shaped responses. This profile
+defines the lowest layer of the conformance pyramid; all stacks are
+required to satisfy it.
+
+## Functional Requirements
+
+### FR-01: Web server root reachability
+
+The web server must respond to `GET /` with a 2xx HTTP status code.
+
+- **Endpoint**: `GET /` on the web server
+- **Success condition**: HTTP response status in the range 200–299
+- **No constraints** on response body or content-type for this endpoint
+
+### FR-02: Web server health endpoint
+
+The web server must expose a health endpoint at `/health` that returns
+a well-formed health check document.
+
+- **Endpoint**: `GET /health` on the web server
+- **Success conditions**:
+  - HTTP response status in the range 200–299
+  - `Content-Type` header contains `application/health+json`
+  - Response body is a valid JSON object
+  - JSON object contains a field named `status`
+  - JSON object contains a field named `serviceId`
+  - JSON object contains a field named `description`
+
+### FR-03: BFF root status envelope
+
+The BFF server must respond to `GET /` with a JSON status envelope.
+
+- **Endpoint**: `GET /` on the BFF server
+- **Success conditions**:
+  - HTTP response status in the range 200–299
+  - `Content-Type` header contains `application/json`
+  - Response body is a valid JSON object
+  - JSON object contains a field named `status` of type string
+  - JSON object contains a field named `service` of type string
+
+### FR-04: BFF server health endpoint
+
+The BFF server must expose a health endpoint at `/health` that returns
+a well-formed health check document.
+
+- **Endpoint**: `GET /health` on the BFF server
+- **Success conditions**:
+  - HTTP response status in the range 200–299
+  - `Content-Type` header contains `application/health+json`
+  - Response body is a valid JSON object
+  - JSON object contains a field named `status`
+  - JSON object contains a field named `serviceId`
+  - JSON object contains a field named `description`
+
+### FR-05: BFF readiness endpoint
+
+The BFF server must expose a readiness endpoint at `/readiness` that
+returns a well-formed readiness document.
+
+- **Endpoint**: `GET /readiness` on the BFF server
+- **Success conditions**:
+  - HTTP response status in the range 200–299
+  - `Content-Type` header contains `application/health+json`
+  - Response body is a valid JSON object
+  - JSON object contains a field named `status`
+  - JSON object contains a field named `checks`
+
+## Configuration
+
+- Web server URL: resolved from environment variable `IDP_WEB_URL`
+- BFF server URL: resolved from environment variable `IDP_BFF_URL`
+
+## Out of Scope
+
+This spec does not define:
+
+- Exact values of `status`, `serviceId`, `description`, or `checks`
+  fields — value constraints are defined by ADR-0011.
+- Authentication or authorization behavior.
+- Error response shapes for non-2xx responses.
+- Stack-specific implementation details.
+
+## Traceability
+
+| Requirement | Source scenario in core.feature |
+| --- | --- |
+| FR-01 | `Web server responds to GET /` |
+| FR-02 | `Web server health endpoint returns the expected shape` |
+| FR-03 | `BFF root returns a JSON status envelope` |
+| FR-04 | `BFF health endpoint returns the expected shape` |
+| FR-05 | `BFF readiness endpoint returns the expected shape` |
+
+---
+
+## Evaluation Notes (Axis C)
+
+The traceability table above shows that a mechanical 1:1 mapping
+from `core.feature` scenarios to spec-kit `spec.md` FRs is possible
+for this profile. However, the mapping surfaces a critical difference:
+
+**What is preserved**: the field-name and content-type constraints are
+representable as prose requirements in `spec.md`.
+
+**What is lost**:
+
+1. **Executable step semantics.** Gherkin steps (`Given`, `When`,
+   `Then`) map directly to Layer 2 TypeScript assertions in
+   `tests/src/profiles/core.ts`. A spec-kit `spec.md` has no
+   step-definition mapping; a code generator or custom harness would
+   be required to re-derive Layer 2 from this spec.
+
+2. **"Feature file wins" tiebreaker.** ADR-0009 designates
+   `.feature` files as the authoritative source when the spec and
+   harness disagree. spec-kit has no equivalent tiebreaker mechanism.
+
+3. **Profile-gating support.** Gherkin profiles use tags and
+   `Background` sections with env-var URL injection (`IDP_WEB_URL`,
+   `IDP_BFF_URL`). spec-kit `spec.md` can document the env vars but
+   cannot express the conditional `Background` execution semantics
+   that drive the cross-stack conformance model.
+
+4. **Exact-value constraints.** For profiles beyond `core` (e.g.
+   `status-profile.feature`), step assertions include exact enum
+   values (`pass`, `fail`, `warn`). Prose in `spec.md` can state
+   these values but cannot enforce them without a custom parser.

--- a/.specify/evaluation/plan-work-retrofit/spec.md
+++ b/.specify/evaluation/plan-work-retrofit/spec.md
@@ -1,0 +1,181 @@
+# Spec: Plan Work — Agent Skill
+
+> **Evaluation artifact — Axis A.** This file is a spec-kit `spec.md`
+> equivalent of the `plan-work` agent skill
+> (`/.agents/skills/plan-work/SKILL.md`). It demonstrates what the
+> skill would look like if authored using spec-kit's workflow.
+> The authoritative skill definition remains `SKILL.md`. Do not use
+> this file as a skill implementation.
+
+## Overview
+
+The plan-work skill reads a GitHub Issue, explores the relevant codebase
+context, and produces a structured implementation plan posted as a
+comment on the issue for maintainer review. It never writes code;
+its sole output is the plan comment. Implementation begins only after
+a maintainer explicitly approves the plan.
+
+## Functional Requirements
+
+### FR-01: Issue retrieval
+
+The skill must fetch the full issue body, labels, assignee, and all
+comments for a given issue number using the GitHub API.
+
+### FR-02: Authorization and status check
+
+The skill must verify that:
+
+- The issue has the `ready` label (not just `needs-triage`).
+- If the issue already has an `in-progress` label, it must check
+  for a prior plan comment before creating a duplicate.
+- If the issue has a `blocked` label, it must stop and report.
+
+### FR-03: Issue claim
+
+The skill must add the `in-progress` label to the issue before any
+codebase exploration or plan creation. This step is non-negotiable
+and prevents duplicate work by concurrent agents.
+
+### FR-04: Requirements analysis
+
+The skill must extract from the issue body:
+
+- Description of what needs to be built or fixed
+- Acceptance criteria (testable conditions for completion)
+- Priority from the priority label
+- Domain from the domain label
+- Any stated constraints or limitations
+
+If the issue is unclear or missing acceptance criteria, the skill must
+post a clarification comment, add `blocked`, remove `in-progress`, and
+stop.
+
+### FR-05: Codebase exploration
+
+The skill must search the codebase for files, patterns, and utilities
+relevant to the issue domain before writing the plan.
+
+### FR-06: Structured plan creation
+
+The skill must produce a plan containing:
+
+1. Summary (one-paragraph overview)
+2. Files to create or modify (with descriptions)
+3. Step-by-step implementation approach
+4. Existing patterns to follow
+5. Risks and open questions
+6. Verification steps
+7. Estimated complexity (Low / Medium / High)
+8. Implementation handoff (issue worktree path, branch name)
+
+### FR-07: Plan posted to GitHub Issue
+
+The plan must be posted as a formatted comment on the GitHub Issue.
+The skill is not complete until the comment exists. If posting fails,
+the skill must surface the ready-to-post Markdown for manual posting.
+
+### FR-08: Label handoff
+
+After posting, the skill must replace `in-progress` with `needs-review`
+to signal that the plan is ready for maintainer review.
+
+### FR-09: No branch creation
+
+The skill must not create any git branches. If the agent runtime
+automatically creates a branch at session start, the skill must delete
+it before completing.
+
+### FR-10: Repo-policy fidelity
+
+The plan must respect:
+
+- Canonical issue worktree paths (`.agents/worktrees/issue-N-slug`)
+- Conventional Commits message format
+- `Closes #N` vs `Refs #N` footer language
+- ADR guardrails (intake threshold, long-lived docs reference rule)
+- Label taxonomy (`ready`, `in-progress`, `needs-review`, `blocked`)
+
+## Configuration
+
+- `issue_number` (required): GitHub Issue number to plan work for.
+
+## Out of Scope
+
+- Writing any code.
+- Creating or mutating git branches or worktrees.
+- Merging or closing the issue.
+
+---
+
+## Evaluation Notes (Axis A)
+
+### What spec-kit captures well
+
+- **Functional requirements** — the ten FRs above map cleanly to the
+  ten procedural steps in `plan-work/SKILL.md`. spec-kit's `spec.md`
+  can describe the skill's behavior at this level of detail.
+- **Overview and out-of-scope** — straightforward prose sections.
+- **Configuration** — `spec.md` can list the `issue_number` input
+  parameter.
+
+### What spec-kit does not capture
+
+1. **GitHub API integration specifics.** `SKILL.md` embeds exact `gh`
+   CLI commands, MCP tool names (`issue_read`, `issue_write`), and
+   fallback sequences. spec-kit's `spec.md` is tool-agnostic; the
+   agent decides how to execute the requirements, which means repo
+   policy details (which MCP tool to call first, what to do if
+   unavailable) live outside the spec artifact.
+
+2. **Label taxonomy as a first-class constraint.** The `plan-work`
+   skill depends on the exact label strings `ready`, `in-progress`,
+   `needs-review`, `blocked` and their semantic meanings within this
+   repo's workflow. spec-kit `spec.md` can mention these strings but
+   treats them as prose; there is no validation that an agent honors
+   the label state machine.
+
+3. **Commit closure language.** `SKILL.md` specifies `Closes #N` vs
+   `Refs #N` with explicit rules about when each applies. A spec-kit
+   spec can state this as FR-10, but an agent reading a generic
+   spec-kit spec would not know to follow this repo-specific rule
+   without additional guidance.
+
+4. **Worktree lifecycle rules.** `AGENTS.md §"Issue Worktree
+   Isolation"` defines canonical worktree paths, branch naming, and
+   cleanup rules. `SKILL.md` references these rules. spec-kit's
+   `spec.md` can cite file paths but does not enforce compliance.
+
+5. **Idempotency handling.** `SKILL.md` specifies exactly what to do
+   when the skill is invoked for an issue that already has a plan
+   (compare vs. re-plan vs. duplicate-guard). This nuanced behavioral
+   branch is hard to represent in spec-kit's narrative FR format
+   without essentially rewriting the SKILL.md prose.
+
+6. **Agent-runtime branch cleanup.** FR-09 above captures the
+   requirement, but the mechanism (detect auto-created branch, prune
+   before exit) requires agent-runtime awareness that lives in
+   SKILL.md's procedural steps, not in a declarative spec.
+
+### Cross-skill overlap
+
+spec-kit's `/speckit.specify → /speckit.plan → /speckit.tasks →
+/speckit.implement` chain overlaps structurally with
+`find-work → plan-work → ship-changes`. The overlap creates three
+questions:
+
+1. **Wrap or replace?** spec-kit templates could wrap the IDP repo's
+   policy on top of the generic spec-kit flow, but keeping the two
+   skill sets synchronized is an ongoing maintenance cost. The IDP
+   skills are already repo-policy-aware; spec-kit templates are not.
+
+2. **Where does the plan live?** IDP's `plan-work` posts the plan as
+   a GitHub Issue comment (the canonical review artifact). spec-kit's
+   `plan.md` lives in `.specify/specs/NNN-feature/`. These are not
+   interchangeable: maintainers and agents in this repo look for plans
+   on the issue, not in `.specify/`.
+
+3. **External agent compatibility.** Other agents or CI tools that
+   interact with this repo via GitHub Issues would not find spec-kit
+   plan artifacts. Migrating to spec-kit's artifact model would break
+   those integrations unless a bridge layer is maintained.

--- a/.specify/evaluation/research-notes.md
+++ b/.specify/evaluation/research-notes.md
@@ -1,0 +1,130 @@
+# spec-kit Research Notes
+
+> Evaluation artifact — not authoritative. See `.specify/README.md`.
+> These notes were captured during the spec-kit MVP evaluation for IDP.
+
+## What Is spec-kit?
+
+spec-kit (GitHub: `github/spec-kit`) is an open-source toolkit that implements
+**Spec-Driven Development (SDD)**. It provides a structured workflow for
+authoring software specifications that drive AI-agent implementation loops.
+The core claim is that specifications authored in spec-kit's format become
+executable artifacts that agents can act on directly, rather than static
+guidance documents.
+
+## Version and Maintenance Signal
+
+- Latest release: v0.7.4 (April 21, 2026)
+- Total releases: 133
+- Commits: 826
+- Open issues: 502
+- Stars: ~90k; Forks: ~7.7k
+- Language: 92% Python, 4.3% Shell, 3.7% PowerShell
+- **Verdict**: Actively maintained; high community adoption. Maintenance
+  signal is strong, though 502 open issues suggests rapid growth outpacing
+  triage capacity.
+
+## License
+
+MIT. No restriction on commercial or internal use. Permissive for embedding
+outputs/templates in this repository.
+
+## Runtime Prerequisites
+
+| Prerequisite | Version |
+| --- | --- |
+| Python | 3.11+ |
+| uv | latest |
+| Git | any recent |
+| AI coding agent | one of 30+ supported integrations |
+
+**Conflict note**: This repo pins Python via `proto` / `unstable_python` +
+`unstable_uv` (ADR-0007, ADR-0012). spec-kit requires `uv tool install`
+from the git source, which is a global install outside the repo toolchain
+pin. A proto plugin or container wrapper would be needed for reproducible
+install in CI.
+
+## Artifact Layout
+
+```
+.specify/
+├── memory/
+│   └── constitution.md       # project governing principles
+├── specs/
+│   └── NNN-feature/
+│       ├── spec.md            # functional requirements / user stories
+│       ├── plan.md            # technical implementation strategy
+│       ├── tasks.md           # ordered, actionable task breakdown
+│       └── contracts/         # optional: API specs, data models
+├── templates/                 # core SDD templates (cloned from spec-kit)
+├── extensions/                # installed community extensions
+├── presets/                   # team customization templates
+└── scripts/                   # automation helpers
+```
+
+## Workflow / Command Surface
+
+| Step | Command | Output |
+| --- | --- | --- |
+| Establish principles | `/speckit.constitution` | `memory/constitution.md` |
+| Define requirements | `/speckit.specify` | `specs/NNN-feature/spec.md` |
+| Create tech strategy | `/speckit.plan` | `specs/NNN-feature/plan.md` |
+| Generate task list | `/speckit.tasks` | `specs/NNN-feature/tasks.md` |
+| Consistency check | `/speckit.analyze` (optional) | inline report |
+| Execute tasks | `/speckit.implement` | code changes |
+| Clarify requirements | `/speckit.clarify` | updated spec.md |
+| Quality checklist | `/speckit.checklist` | pass/fail report |
+
+Commands are delivered as slash commands to an AI coding agent (Copilot,
+Gemini CLI, Claude, etc.). spec-kit is not a standalone runtime; it depends
+entirely on the agent to interpret and execute the commands.
+
+## AI Agent Integration Model
+
+spec-kit integrates with 30+ AI coding agents. The workflow depends on an
+agent interpreting the slash commands and reading/writing files under
+`.specify/`. There is no standalone CLI that executes spec-kit steps
+independently of an AI agent.
+
+## Key Observations for IDP Evaluation
+
+### On Axis A (Dev-flow automation)
+
+- spec-kit provides `spec.md → plan.md → tasks.md → implement` as a
+  structured artifact chain. The IDP repo has a similar chain:
+  `find-work → plan-work → ship-changes` via GitHub Issues.
+- spec-kit's artifacts live in `.specify/specs/NNN-feature/`, while IDP's
+  plan artifacts live as GitHub Issue comments.
+- spec-kit does not natively integrate with GitHub Issues, labels, or the
+  canonical worktree/branch model the IDP repo uses. Custom `constitution.md`
+  and template overrides could encode these policies, but that is non-trivial
+  maintenance burden.
+- spec-kit's `/specify` and `/plan` steps produce static Markdown files; IDP's
+  `plan-work` skill produces a live GitHub Issue comment that is the
+  authoritative review artifact, supports maintainer overrides, and drives
+  label state transitions. These are conceptually different outputs.
+
+### On Axis B (Decision capture / ADRs)
+
+- spec-kit does not have a native ADR concept. Its closest analog is a `spec.md`
+  (requirements) or `plan.md` (technical strategy), neither of which has
+  the `Proposed → Accepted → Superseded` lifecycle model that the IDP ADR
+  format uses.
+- spec-kit's `contracts/` subdirectory could hold ADR-like decision records,
+  but spec-kit provides no tooling to enforce ADR numbering, status transitions,
+  cross-reference traceability, or intake-threshold gates.
+
+### On Axis C (Intent-driven contracts / Layer 1 replacement)
+
+- spec-kit's `spec.md` is a Markdown narrative of functional requirements and
+  user stories. It does not produce executable scenarios with Given/When/Then
+  step semantics.
+- Gherkin `.feature` files encode exact HTTP status codes, field names, enum
+  values, and content-type assertions in a form that maps 1:1 to Layer 2
+  TypeScript assertions. spec-kit `spec.md` files are narrative and are not
+  mapped to test step definitions.
+- There is no spec-kit concept of "feature file wins" — a tiebreaker rule
+  that makes one artifact authoritative over another when they diverge.
+- spec-kit's `/implement` step generates code, not test assertions. Producing
+  a Layer 2 harness from a spec-kit spec.md would require a custom generator
+  not provided by spec-kit.

--- a/.specify/evaluation/research-notes.md
+++ b/.specify/evaluation/research-notes.md
@@ -46,7 +46,7 @@ install in CI.
 
 ## Artifact Layout
 
-```
+```text
 .specify/
 ├── memory/
 │   └── constitution.md       # project governing principles

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,6 +163,22 @@ See [PLUGINS.md](PLUGINS.md) for the full high-level design.
 
 ---
 
+## 12. Agent Tooling and Spec-Driven Development Evaluation
+
+Evaluate and selectively adopt external agent tooling that improves
+developer and platform-engineering workflows.
+
+- **spec-kit MVP evaluation** (three-axis, decision-grade): assessed
+  spec-kit as a candidate for dev-flow automation, architectural decision
+  capture, and Layer 1 contract specification. Evaluation artifacts and
+  verdicts recorded in ADR-0015.
+- Future agent tooling evaluations follow the same three-axis
+  `docs/content/architecture/evaluations/` format.
+- Any Adopt or Adopt-Hybrid outcome requires a scoped follow-up
+  deliverable rather than wholesale replacement of existing patterns.
+
+---
+
 ## Summary
 
 An enterprise platform is not defined by infrastructure or deployment patterns, but by its ability to:

--- a/docs/content/architecture/decisions/0015-spec-kit-evaluation.md
+++ b/docs/content/architecture/decisions/0015-spec-kit-evaluation.md
@@ -1,0 +1,280 @@
+---
+status: proposed
+date: 2026-04-22
+decision-makers:
+  - "@idp-admin"
+  - "@idp-maintain"
+consulted: []
+informed: []
+---
+
+# spec-kit Three-Axis Evaluation
+
+## Context and Problem Statement
+
+spec-kit (`github/spec-kit`) is a Spec-Driven Development (SDD) toolkit that
+provides a structured workflow for authoring software specifications that drive
+AI-agent implementation loops. Its artifact model (`.specify/specs/NNN/`) and
+command surface (`/speckit.constitution → /speckit.specify → /speckit.plan →
+/speckit.tasks → /speckit.implement`) overlap structurally with three
+established patterns in this repository:
+
+1. The `/find-work → /plan-work → /ship-changes` agent skill chain
+   (`.agents/skills/`).
+2. The architectural decision record format
+   (`docs/content/architecture/decisions/`, MADR variant).
+3. The Gherkin-based Layer 1 intent specification format
+   (`tests/features/*.feature`, established in ADR-0009).
+
+An MVP evaluation was conducted to determine whether spec-kit should be
+adopted for any or all of these roles, partially adopted in a hybrid model,
+deferred pending prerequisites, or rejected.
+
+This ADR records three independent sub-decisions — one per axis — that can
+land with different verdicts.
+
+## Decision Drivers
+
+- Agent skills must carry explicit repo-policy context (label taxonomy,
+  worktree rules, commit closure language, draft-PR lifecycle). Any replacement
+  or complement must preserve this enforcement.
+- Architectural decision records must support a `Proposed → Accepted →
+  Superseded` lifecycle, supersede-chain traceability, intake-threshold gate
+  metadata, and machine-readable status for agent queries.
+- Layer 1 intent specifications must produce executable scenarios that map
+  1:1 to Layer 2 TypeScript assertions, with an authoritative tiebreaker when
+  spec and harness disagree.
+- All tooling must be installable reproducibly via the repo's `proto` /
+  `unstable_python` / `unstable_uv` toolchain (ADR-0007, ADR-0012) or via a
+  documented container/proto-plugin path.
+
+## MVP Evaluation Artifacts
+
+The full evaluation is documented in
+`docs/content/architecture/evaluations/spec-kit-mvp.md`. Three prototype
+artifacts under `.specify/evaluation/` support the analysis:
+
+| Artifact | Axis | Description |
+| --- | --- | --- |
+| `.specify/evaluation/plan-work-retrofit/spec.md` | A | `plan-work` skill in spec-kit `spec.md` format |
+| `.specify/evaluation/adr-0009-as-spec-kit/spec.md` | B | ADR-0009 reconstructed in spec-kit `spec.md` format |
+| `.specify/evaluation/core-profile/spec.md` | C | `core` conformance profile in spec-kit `spec.md` format |
+
+---
+
+## Sub-Decision A: Dev-Flow Automation
+
+### Question
+
+Would adopting spec-kit's workflow optimize the current
+`/find-work → /plan-work → /ship-changes` agent skill chain?
+
+### Considered Options
+
+- **Adopt** — replace the IDP skill chain with spec-kit commands
+- **Adopt-Hybrid** — use spec-kit templates as a layer on top of the IDP
+  skills, encoding repo policy via `constitution.md`
+- **Defer-Pending-Prereq** — wait for spec-kit to ship a stable 1.x release
+  with a GitHub Issues integration and a reproducible proto/uv install path
+- **Reject** — retain the IDP skill chain unchanged
+
+### Decision Outcome
+
+**Chosen option: `Defer-Pending-Prereq`**
+
+spec-kit's six-command workflow chain has structural overlap with the IDP
+three-skill chain, and an `Adopt-Hybrid` path (encoding AGENTS.md policy in
+`constitution.md`) is conceptually plausible. However, two prerequisites are
+unmet at v0.7.x:
+
+1. **Template stability.** spec-kit has had 133 releases. Template-breaking
+   changes in a future release would require re-encoding all IDP repo policy.
+   A stable 1.x release or an explicit long-term-support commitment is a
+   prerequisite for investment in `constitution.md` authoring.
+
+2. **Reproducible install.** spec-kit requires `uv tool install` as a global
+   install. The IDP repo pins Python and uv via `proto` (ADR-0007, ADR-0012).
+   A proto plugin, container image, or official moon integration is required
+   before spec-kit can be used in CI or by contributors without a manual setup
+   step.
+
+**Prerequisite gate**: Revisit this sub-decision when spec-kit publishes a
+stable 1.x release with explicit GitHub Issues integration and a documented
+proto-compatible or container install path.
+
+### Sub-Decision A Consequences
+
+**If deferred (chosen):**
+
+- IDP agent skills continue unchanged.
+- The `.specify/evaluation/plan-work-retrofit/spec.md` artifact provides a
+  concrete starting point if the prerequisite gate is met.
+- No migration cost now; the option is preserved.
+
+**If Adopt-Hybrid were chosen later:**
+
+- `constitution.md` would need to encode: label taxonomy, worktree rules,
+  canonical branch naming, commit closure language, draft-PR lifecycle, and
+  ADR guardrails.
+- Plan artifacts would need a bridge layer so maintainers could find plans
+  on GitHub Issues (current pattern) rather than in `.specify/specs/`.
+- All `.agents/skills/` SKILL.md files would need to be reviewed for overlap
+  with spec-kit commands and either superseded or explicitly declared parallel.
+
+**Rollback plan (if Adopt-Hybrid is later adopted and then reverted):**
+
+Restore the original `.agents/skills/` SKILL.md files from git history.
+Remove `.specify/specs/` plan artifacts and confirm maintainers are using
+GitHub Issue comments as the canonical plan location. No runtime changes or
+CI changes are expected from an Adopt-Hybrid outcome for Axis A.
+
+---
+
+## Sub-Decision B: Architectural Decision Capture
+
+### Question
+
+Would spec-kit's artifact model capture architectural decisions as well as or
+better than the current MADR-style ADR format?
+
+### Considered Options
+
+- **Adopt** — replace `docs/content/architecture/decisions/` with
+  `.specify/specs/` using spec-kit `spec.md` format
+- **Adopt-Hybrid** — use spec-kit `/specify` as the path to authoring an ADR,
+  while retaining the final ADR format in the current directory
+- **Reject** — retain the current MADR ADR format
+
+### Decision Outcome
+
+**Chosen option: `Reject`**
+
+spec-kit `spec.md` can carry the content of a decision (context, alternatives,
+consequences) but loses all governance properties that make ADRs useful as
+long-lived records:
+
+- No `Proposed → Accepted → Superseded` lifecycle field
+- No supersede-chain cross-reference mechanism
+- No intake-threshold gate metadata (the 3-of-5 gates required by AGENTS.md)
+- No decision-makers / consulted / informed YAML frontmatter
+- No machine-readable status index for agent queries
+- Prospective framing (what to build) vs. ADRs' retrospective framing
+  (what was decided and why)
+
+The current MADR format is already minimal and maps directly to reviewer and
+agent query needs. No productivity gap has been identified that spec-kit would
+fill. Reconstructing the lost properties inside spec-kit would require custom
+extensions that effectively recreate the MADR format in a less familiar
+structure.
+
+**This sub-decision does not supersede ADR-0009 or any other existing ADR.**
+Existing ADRs remain authoritative in their current format.
+
+### Sub-Decision B Consequences
+
+**If rejected (chosen):**
+
+- `docs/content/architecture/decisions/` continues unchanged.
+- The `.specify/evaluation/adr-0009-as-spec-kit/spec.md` artifact is retained
+  as an audit trail of the evaluation.
+- No migration cost.
+
+**Rollback plan**: Not applicable; nothing was changed.
+
+---
+
+## Sub-Decision C: Intent-Driven Contracts (Layer 1 Replacement)
+
+### Question
+
+Can spec-kit artifacts serve as Layer 1 ground truth in place of
+`tests/features/*.feature` files, given that ADR-0009 requires executable
+scenarios mappable to Layer 2 TypeScript assertions?
+
+### Considered Options
+
+- **Adopt** — replace `.feature` files with spec-kit `spec.md` as Layer 1
+- **Adopt-Hybrid** — use spec-kit `spec.md` as a narrative planning layer
+  while retaining Gherkin `.feature` files as executable Layer 1
+- **Reject** — retain Gherkin as Layer 1 (ADR-0009 unchanged)
+
+### Decision Outcome
+
+**Chosen option: `Reject`**
+
+spec-kit `spec.md` is a prose specification format. Gherkin `.feature` files
+are executable scenario scripts. These are categorically different:
+
+1. **No step-to-assertion mapping.** Gherkin Given/When/Then steps map 1:1
+   to Layer 2 TypeScript assertions in `tests/src/profiles/*.ts`. spec-kit
+   `spec.md` FRs have no such mapping; a custom code generator — not provided
+   by spec-kit — would be required to re-derive Layer 2 from a `spec.md` source.
+
+2. **No "feature file wins" tiebreaker.** ADR-0009 designates `.feature` files
+   as authoritative when spec and harness disagree. spec-kit provides no
+   equivalent tiebreaker; divergence would be detectable only through manual
+   review.
+
+3. **No profile-gating semantics.** Gherkin `Background` sections with env-var
+   URL injection drive the cross-stack conformance model. spec-kit `spec.md`
+   can document env vars as prose but cannot express conditional Background
+   execution semantics.
+
+4. **Exact-value enforcement.** Gherkin step definitions enforce exact strings
+   (e.g., `pass`, `fail`, `warn` per ADR-0011). spec-kit `spec.md` can state
+   these values but cannot enforce them without a custom parser.
+
+An `Adopt-Hybrid` model (spec-kit as narrative planning + Gherkin as executable
+Layer 1) would add a third layer to the current two-layer model
+(Layer 1 `.feature` → Layer 2 `.ts`) without a clear benefit, and would
+create a new sync obligation between spec-kit `spec.md` files and `.feature`
+files.
+
+**Migration cost estimate**: Migrating all seven profiles from Gherkin to
+spec-kit — even if the technical barriers were resolved — would require
+20–40 hours of authoring plus an unknown quantity of Layer 2 harness
+adaptation. The `flow-insights` profile (16 scenarios, 168 lines, cross-stack
+semantic-equivalence CI job) would be the hardest migration case.
+
+**This sub-decision explicitly does not supersede ADR-0009.** Gherkin remains
+the Layer 1 format.
+
+### Sub-Decision C Consequences
+
+**If rejected (chosen):**
+
+- `tests/features/*.feature` files continue as Layer 1 ground truth.
+- ADR-0009 remains in effect unchanged.
+- The `.specify/evaluation/core-profile/spec.md` artifact is retained as an
+  audit trail.
+- No migration cost.
+
+**Rollback plan**: Not applicable; nothing was changed.
+
+---
+
+## ADR Intake Gate Evaluation (Why Long-Lived)
+
+This ADR records an evaluation whose verdict constrains three separate
+long-lived artifact categories in the repository. The decision not to adopt
+spec-kit — especially for Axis C — is as load-bearing as any adoption
+decision, because it prevents drift toward a parallel spec format that would
+silently erode ADR-0009.
+
+| Gate | Met? | Rationale |
+| --- | --- | --- |
+| Cross-cutting scope | Yes | Affects agent skills, ADR format, and Layer 1 specs — three separate layers |
+| Costly to reverse | Yes | Axis C adoption would require re-deriving all Layer 2 harnesses; Axis B adoption would require migrating all existing ADRs |
+| Contract surface | Yes | Axis C directly concerns the Layer 1/Layer 2 contract boundary |
+| Multi-quarter longevity | Yes | spec-kit adoption decisions are architectural commitments spanning multiple quarters |
+| Drift risk | Yes | Without a recorded rejection, future agents may independently attempt spec-kit adoption across these axes |
+
+All five gates are true; two are "costly to reverse" and "contract surface".
+ADR threshold is met.
+
+## Related Decisions
+
+- [ADR-0001](./intent-driven-architecture) — Three-layer intent/contract/implementation architecture
+- [ADR-0007](./moon-required-proto-enhanced-toolchain-policy) — Moon-required orchestration and proto toolchain policy
+- [ADR-0009](./intent-specification-format) — Gherkin as Layer 1 intent specification format (not superseded)
+- [ADR-0012](./moon-python-uv-toolchain-integration-constraint) — Moon Python/uv toolchain integration constraint

--- a/docs/content/architecture/decisions/index.md
+++ b/docs/content/architecture/decisions/index.md
@@ -65,3 +65,4 @@ Routing rule: Create an ADR when at least 3 gates are true and one is Gate 2 or 
 | [0012](./moon-python-uv-toolchain-integration-constraint) | Moon Python/uv Toolchain Integration Constraint | accepted | 2026-04-01 |
 | [0013](./oauth-plugin-architecture) | Optional OAuth Plug-In Architecture | proposed | 2026-04-07 |
 | [0014](./mvp-flow-observation-technical-foundations) | MVP Flow Observation Technical Foundations | proposed | 2026-04-12 |
+| [0015](./spec-kit-evaluation) | spec-kit Three-Axis Evaluation | proposed | 2026-04-22 |

--- a/docs/content/architecture/evaluations/index.md
+++ b/docs/content/architecture/evaluations/index.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 3
+---
+
+# Architecture Evaluations
+
+This section contains structured evaluations of technology candidates and
+architectural alternatives. Evaluations are time-boxed MVPs that produce
+a decision-grade analysis, not a production implementation.
+
+## Format
+
+Each evaluation follows a three-part structure:
+
+1. **Artifact(s)** — minimal prototypes or reconstructions that expose the
+   candidate's capabilities and limitations in the context of this project.
+2. **Scorecard** — a consistent dimension table comparing the candidate
+   against the current approach across the axes relevant to the decision.
+3. **Recommendation** — a per-axis verdict (`Adopt`, `Adopt-Hybrid`,
+   `Reject`, or `Defer-Pending-Prereq`) that feeds a draft ADR.
+
+## Index
+
+| Evaluation | Status | Date |
+| --- | --- | --- |
+| [spec-kit MVP](./spec-kit-mvp) | Proposed | 2026-04-22 |

--- a/docs/content/architecture/evaluations/spec-kit-mvp.md
+++ b/docs/content/architecture/evaluations/spec-kit-mvp.md
@@ -1,0 +1,298 @@
+---
+sidebar_position: 1
+status: proposed
+date: 2026-04-22
+---
+
+# spec-kit MVP Evaluation
+
+This evaluation assesses [`github/spec-kit`](https://github.com/github/spec-kit)
+as a potential tool for the IDP project across three independent axes. Each
+axis has its own question, MVP artifact, scorecard, and recommendation. The
+combined verdict feeds ADR-0015.
+
+**Ground truth is unchanged throughout this evaluation.** The
+`tests/features/*.feature` files remain the authoritative Layer 1 intent
+specifications (ADR-0009). The `.agents/skills/` directory remains the
+canonical source for agent workflow skills. No production files were modified
+as part of this evaluation.
+
+## What Is spec-kit?
+
+spec-kit is an open-source toolkit (MIT license, v0.7.4 as of April 2026)
+that implements **Spec-Driven Development (SDD)**. It provides a structured
+workflow for authoring software specifications that drive AI-agent
+implementation loops.
+
+### Artifact layout
+
+```
+.specify/
+├── memory/constitution.md     # project governing principles
+├── specs/NNN-feature/
+│   ├── spec.md                # functional requirements / user stories
+│   ├── plan.md                # technical implementation strategy
+│   ├── tasks.md               # ordered task breakdown
+│   └── contracts/             # optional API specs, data models
+├── templates/                 # core SDD templates
+├── extensions/                # community extensions
+└── presets/                   # team customizations
+```
+
+### Workflow
+
+| Step | Command | Output |
+| --- | --- | --- |
+| Establish principles | `/speckit.constitution` | `memory/constitution.md` |
+| Define requirements | `/speckit.specify` | `specs/NNN/spec.md` |
+| Create tech strategy | `/speckit.plan` | `specs/NNN/plan.md` |
+| Generate task list | `/speckit.tasks` | `specs/NNN/tasks.md` |
+| Consistency check | `/speckit.analyze` | inline report |
+| Execute tasks | `/speckit.implement` | code changes |
+
+### Runtime prerequisites
+
+| Requirement | Version |
+| --- | --- |
+| Python | 3.11+ |
+| uv | latest |
+| Git | any recent |
+| AI coding agent | one of 30+ integrations |
+
+**Toolchain conflict**: spec-kit requires `uv tool install` as a global
+install. This repo pins Python via `proto` / `unstable_python` and `unstable_uv`
+per ADR-0007 and ADR-0012. A proto plugin or container wrapper would be needed
+for reproducible CI installation.
+
+### Maintenance signal
+
+- Latest release: v0.7.4 (April 21, 2026)
+- 133 releases, 826 commits, ~90k stars, 7.7k forks
+- 502 open issues (rapid growth, active but backlogged)
+- Language: 92% Python, 4.3% Shell, 3.7% PowerShell
+
+---
+
+## Axis A — Dev-Flow Automation
+
+**Question**: Would adopting spec-kit's `/specify → /plan → /tasks → /implement`
+flow optimize the current `/find-work → /plan-work → /ship-changes` workflow
+meaningfully over time?
+
+**MVP artifact**: `.specify/evaluation/plan-work-retrofit/spec.md` — the
+`plan-work` skill re-expressed as a spec-kit `spec.md`.
+
+### Axis A Scorecard
+
+| Dimension | Current (IDP skills) | spec-kit | Delta |
+| --- | --- | --- | --- |
+| Repo-policy fidelity (worktrees, labels, commit language) | Native — SKILL.md encodes exact rules | Must be layered via `constitution.md` template; no enforcement | Regression |
+| Per-skill onboarding cost | One SKILL.md per skill; self-contained | Must author `spec.md` + `plan.md` + `tasks.md` per feature AND maintain `constitution.md` | Higher |
+| External-agent compatibility | Skills are GitHub-Issues-native; any agent reading the issue finds the plan | Plans live in `.specify/`; agents that read GitHub Issues would not find spec-kit artifacts | Regression |
+| Template-churn risk | SKILL.md is static prose; updated only when the workflow changes | spec-kit templates track upstream releases; 133 releases in project history | Higher risk |
+| GitHub ecosystem alignment | Label state machine, `Closes #N` closure, draft-PR lifecycle are first-class | No native GitHub Issues integration; worktree, label, and PR rules must be manually encoded | Regression |
+| Reversibility | Skills are plain Markdown; no external dependency to remove | Removing spec-kit requires migrating `.specify/` artifacts back to skills | Harder to reverse |
+
+### Axis A: Key Finding
+
+The structural overlap between spec-kit's six-command chain and the IDP
+three-skill chain is real, but the IDP skills carry repo-policy context that
+spec-kit does not. Adopting spec-kit for dev-flow would either require a
+non-trivial `constitution.md` that encodes the full AGENTS.md policy, or would
+produce agents that follow the spec-kit workflow while silently violating the
+IDP repo's label state machine, worktree rules, and commit closure language.
+
+The plan artifact location is a hard incompatibility: `plan-work` posts plans
+as GitHub Issue comments (the canonical review artifact for maintainers and
+agents); spec-kit stores plans in `.specify/specs/NNN/plan.md`. These serve
+different audiences and cannot be used interchangeably without a bridge layer.
+
+### Axis A Recommendation: `Defer-Pending-Prereq`
+
+The template stability prerequisite (spec-kit would need a stable 1.x release
+with a committed `constitution.md` encoding pattern for repo-policy fidelity)
+is not met at v0.7.x. Revisit if spec-kit ships a stable GitHub Issues
+integration and a reproducible proto/uv install path.
+
+---
+
+## Axis B — Decision Capture / ADRs
+
+**Question**: Would spec-kit's artifact model capture architectural decisions
+as well as or better than the current
+`docs/content/architecture/decisions/` (MADR-style, numbered,
+`Proposed/Accepted/Superseded` states)?
+
+**MVP artifact**: `.specify/evaluation/adr-0009-as-spec-kit/spec.md` —
+ADR-0009 reconstructed in spec-kit's native `spec.md` format.
+
+### Axis B Scorecard
+
+| Dimension | Current (MADR ADRs) | spec-kit | Delta |
+| --- | --- | --- | --- |
+| `Proposed → Accepted → Superseded` lifecycle | Native YAML frontmatter `status` field | Not natively supported; must be added as custom prose | Loss |
+| Supersede-chain traceability | `Related Decisions` cross-references in ADR body | No native cross-reference mechanism | Loss |
+| Long-lived docs reference rule | Enforced by AGENTS.md; no issue/PR numbers in ADR bodies | Not enforced; spec-kit templates do not distinguish short-term from long-lived artifacts | Loss |
+| Intake-threshold gate metadata | Explicit 3-of-5 gate table in each ADR | No equivalent; must be added as custom section | Loss |
+| Decision-makers / consulted / informed | YAML frontmatter fields | Not supported | Loss |
+| Retrospective framing | ADRs record what was decided and why; alternatives rejected | `spec.md` is prospective (what to build); forcing retrospective content loses the framing | Loss |
+| Machine-readable status index | `index.md` table queryable by agents | No canonical index; agents would need to glob `.specify/specs/` | Loss |
+| Markdownlint compatibility | ADR Markdown passes `check-lint-md` | spec-kit Markdown should pass; no observed incompatibility | Neutral |
+| Diff-friendliness | ADR diffs show decision changes clearly | spec-kit diffs would similarly show changes | Neutral |
+
+### Axis B: Key Finding
+
+spec-kit `spec.md` can carry the *content* of a decision (context, problem,
+alternatives, consequences) but loses all *governance properties* that make
+ADRs useful as long-lived architectural records: lifecycle transitions,
+supersede-chain traceability, intake-threshold gating, and machine-readable
+status. Reconstructing those properties inside spec-kit would require custom
+extensions that effectively recreate the MADR format in a less familiar
+structure.
+
+The current MADR format is already minimal. Its structure maps directly to
+reviewer needs and agent query patterns. There is no observable productivity
+gain from replacing it.
+
+### Axis B Recommendation: `Reject`
+
+spec-kit does not improve on the current MADR ADR format for architectural
+decision capture. The reconstruction (Axis B artifact) demonstrates content
+portability but governance regression. Retain the current
+`docs/content/architecture/decisions/` format.
+
+---
+
+## Axis C — Intent-Driven Contracts on Top of Gherkin
+
+**Question**: Can spec-kit artifacts serve as Layer 1 ground truth in place
+of `.feature` files, given that ADR-0009 requires executable scenarios
+mappable to Layer 2 TypeScript assertions?
+
+**MVP artifact**: `.specify/evaluation/core-profile/spec.md` — the `core`
+conformance profile re-expressed as a spec-kit `spec.md` (5 scenarios: GET /
+and GET /health on the web server; GET /, GET /health, GET /readiness on the
+BFF server).
+
+### Side-by-Side Comparison
+
+```gherkin
+# tests/features/core.feature (excerpt — Layer 1 ground truth)
+Scenario: Web server health endpoint returns the expected shape
+  When the client sends GET /health to the web server
+  Then the response status code is in the 2xx range
+  And the response Content-Type header contains "application/health+json"
+  And the response body is a valid JSON object
+  And the JSON object contains a field named "status"
+  And the JSON object contains a field named "serviceId"
+  And the JSON object contains a field named "description"
+```
+
+```markdown
+<!-- .specify/evaluation/core-profile/spec.md (Axis C artifact) -->
+### FR-02: Web server health endpoint
+
+- Endpoint: GET /health on the web server
+- HTTP response status in the range 200–299
+- Content-Type header contains application/health+json
+- Response body is a valid JSON object
+- JSON object contains a field named status
+- JSON object contains a field named serviceId
+- JSON object contains a field named description
+```
+
+### Axis C Scorecard
+
+| Dimension | Current (Gherkin) | spec-kit `spec.md` | Delta |
+| --- | --- | --- | --- |
+| Executable-scenario fidelity | Given/When/Then steps map 1:1 to Layer 2 TypeScript assertions | Prose FRs; no step-definition mapping; Layer 2 re-derivation requires custom generator | Loss |
+| "Feature file wins" tiebreaker | Explicit in ADR-0009; enforced by AGENTS.md sync rule | No equivalent; spec-kit has no tiebreaker mechanism | Loss |
+| Cross-stack implementation neutrality | `.feature` files are technology-agnostic; any stack can implement | `spec.md` is also technology-agnostic; neutral | Neutral |
+| Profile-gating / capability flags | Gherkin tags and `Background` with env-var URL injection | Can document env vars as prose; cannot express conditional Background execution semantics | Loss |
+| Exact-value constraint enforcement | Step definitions enforce exact strings (`pass`, `fail`, `warn`) | Can state values in prose; cannot enforce them without a custom parser | Loss |
+| Diff-friendliness | `.feature` file diffs clearly show scenario changes | `spec.md` diffs also show FR changes | Neutral |
+| Non-engineer readability | Gherkin Given/When/Then is widely recognized | Prose FRs are also readable; minor readability advantage for spec-kit for non-BDD audiences | Slight gain |
+| Cost to migrate remaining 6 profiles | N/A (current) | `core` (5 scenarios, 46 lines) took one hour; `flow-insights` (16 scenarios, 168 lines, cross-stack CI) would take 3–5× longer and require manual cross-reference to Layer 2 assertions | High migration cost |
+
+### Scale-Out Estimate
+
+Migrating all seven profiles from Gherkin to spec-kit:
+
+| Profile | Scenarios | Lines | Relative difficulty |
+| --- | --- | --- | --- |
+| `core` | 5 | 46 | Baseline (this MVP) |
+| `operational` | ~6 | ~55 | Low |
+| `status-profile` | ~8 | ~70 | Medium (exact enum values) |
+| `mcp-profile` | ~10 | ~90 | Medium |
+| `auth-profile` | ~8 | ~75 | Medium |
+| `flow-insights` | 16 | 168 | High (cross-stack CI, semantic-equivalence job) |
+| `ui-profile` | ~7 | ~60 | Medium |
+
+Estimated total migration effort: 20–40 hours of authoring plus an unknown
+amount of Layer 2 harness adaptation, since the spec-kit `spec.md` does not
+provide the 1:1 step mappings that `core.ts` relies on today.
+
+### Axis C: Key Finding
+
+spec-kit `spec.md` can represent the field-name and content-type constraints
+of the `core` profile in a readable narrative form. However, it is a
+categorically different artifact from Gherkin: it is a prose specification,
+not an executable scenario script. The Layer 2 TypeScript harness
+(`tests/src/profiles/core.ts`) would require a custom code generator — not
+provided by spec-kit — to be re-derived from a `spec.md` source.
+
+The "feature file wins" tiebreaker (ADR-0009) has no analog in spec-kit.
+Without a formal tiebreaker mechanism, spec/harness divergence would be
+detected only through manual review, not through tooling.
+
+An `Adopt-Hybrid` model is theoretically possible: use spec-kit `spec.md` as
+a narrative planning layer and retain Gherkin `.feature` files as the
+executable Layer 1. However, this would add a third layer with its own sync
+obligation, increasing maintenance cost without a clear benefit over the
+current two-layer model.
+
+### Axis C Recommendation: `Reject`
+
+spec-kit cannot replace Gherkin `.feature` files as Layer 1 ground truth
+without a custom code generator bridging `spec.md` to Layer 2 assertions and
+a new tiebreaker mechanism. The category mismatch (narrative prose vs.
+executable scenarios) is fundamental, not incidental. Retain Gherkin as the
+Layer 1 format (ADR-0009 unchanged).
+
+---
+
+## Consolidated Three-Verdict Summary
+
+| Axis | Question | Verdict | Rationale |
+| --- | --- | --- | --- |
+| A — Dev-flow | Would spec-kit optimize `/find-work → /plan-work → /ship-changes`? | `Defer-Pending-Prereq` | Template stability and GitHub Issues integration unmet at v0.7.x |
+| B — ADRs | Would spec-kit improve architectural decision capture? | `Reject` | Governance regression on lifecycle, supersede-chain, and intake-threshold properties |
+| C — Layer 1 | Can spec-kit replace Gherkin as Layer 1 ground truth? | `Reject` | Category mismatch: prose FRs are not executable scenarios; no Layer 2 re-derivation path |
+
+## Cross-Axis Consistency Check
+
+The three verdicts are consistent:
+
+- Axes B and C both reject spec-kit for roles that require **enforcement
+  properties** (tiebreaker semantics, lifecycle state transitions, executable
+  step-to-assertion mapping). spec-kit is an authoring tool, not an enforcement
+  mechanism.
+- Axis A defers rather than rejects, acknowledging that spec-kit's dev-flow
+  chain has structural overlap with the IDP skill chain, but that the
+  repo-policy prerequisites are not met.
+- No axis recommends adoption as a drop-in replacement. Any future
+  `Adopt-Hybrid` path for Axis A would require a stable `constitution.md`
+  template that encodes AGENTS.md policy — a separate, scoped effort.
+
+## Follow-Up Recommendations
+
+If Axis A is revisited (spec-kit v1.x with stable GitHub integration):
+
+- Scope: evaluate whether spec-kit `constitution.md` can fully encode
+  the IDP repo's label taxonomy, worktree rules, and commit closure language.
+- Do not start without confirming a proto/uv reproducible install path
+  (ADR-0007 and ADR-0012 compatibility).
+
+For Axes B and C, no follow-up is recommended. The current formats are
+working, well-understood, and do not have identified gaps that spec-kit
+would fill.

--- a/docs/content/architecture/evaluations/spec-kit-mvp.md
+++ b/docs/content/architecture/evaluations/spec-kit-mvp.md
@@ -26,7 +26,7 @@ implementation loops.
 
 ### Artifact layout
 
-```
+```text
 .specify/
 ├── memory/constitution.md     # project governing principles
 ├── specs/NNN-feature/


### PR DESCRIPTION
## Summary

Decision-grade MVP evaluation of `github/spec-kit` across three independent axes, each with its own artifact, scorecard, and verdict. Ground truth is unchanged — no `.feature`, `.ts`, or `.agents/skills/` files were modified.

**Verdicts:**

- **Axis A (dev-flow)**: `Defer-Pending-Prereq` — template stability and reproducible proto/uv install path unmet at v0.7.x
- **Axis B (ADR capture)**: `Reject` — spec-kit loses lifecycle state, supersede-chain, intake-threshold gates, and machine-readable status
- **Axis C (Layer 1 contracts)**: `Reject` — category mismatch between prose FRs and executable Gherkin scenarios; ADR-0009 unchanged

**New files (all creates, no modifications to production files):**

- `.specify/README.md` — evaluation-artifact disclaimer for agents
- `.specify/evaluation/research-notes.md` — spec-kit v0.7.4 research capture
- `.specify/evaluation/core-profile/spec.md` — Axis C: `core.feature` as spec-kit spec.md
- `.specify/evaluation/adr-0009-as-spec-kit/spec.md` — Axis B: ADR-0009 reconstructed in spec-kit format
- `.specify/evaluation/plan-work-retrofit/spec.md` — Axis A: `plan-work` skill as spec-kit spec.md
- `docs/content/architecture/evaluations/index.md` — new evaluations section
- `docs/content/architecture/evaluations/spec-kit-mvp.md` — master evaluation report with three-axis scorecards, side-by-side Gherkin comparison, scale-out estimates, and cross-axis consistency check
- `docs/content/architecture/decisions/0015-spec-kit-evaluation.md` — ADR-0015 with three sub-decisions and rollback plans
- `docs/content/architecture/decisions/index.md` — ADR index updated (row for 0015)
- `ROADMAP.md` — section 12 added for agent tooling evaluations

## Test Plan

- [x] `make check-lint-md` passes (0 errors on 104 files)
- [x] No secrets in `.specify/` (manual grep scan; `gitleaks` not in PATH in this environment)
- [x] `git diff --name-only origin/main...HEAD` shows zero matches under `tests/features/`, `tests/src/profiles/`, or `.agents/skills/`
- [x] ADR-0015 does not modify any existing ADR status or body
- [x] ADR-0015 contains intake gate evaluation (all 5 gates met)
- [x] Evaluation doc contains no issue/PR/commit references (long-lived docs reference rule)
- [x] Docs site builds locally: `make -C docs build` (not run; no UI change)
- [x] New evaluation page reachable from docs sidebar (manual check)
- [x] `make check-contract` on one stack still passes (no harness files touched; regression guard)

Closes #293