### PR TITLE
fix(nodejs-bff): start gracefully when flow fixture dir is missing

### DIFF
--- a/stacks/nodejs/react-fastify/rest/bff/src/flow/insightsCatalog.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/flow/insightsCatalog.ts
@@ -79,18 +79,23 @@ export interface InsightFilters {
   audience?: InsightAudience;
 }
 
-const FIXTURE_DIR = path.resolve(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "schema/fixtures/provider-adapter-input",
-);
+// __dirname is 7 segments deep below the repo root:
+//   <repo>/stacks/nodejs/react-fastify/rest/bff/{src,dist}/flow
+// Allow OUR_IDP_FLOW_FIXTURE_DIR to override, e.g. when fixtures are mounted
+// into a container at a non-default location.
+const FIXTURE_DIR =
+  process.env.OUR_IDP_FLOW_FIXTURE_DIR ??
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+    "..",
+    "..",
+    "..",
+    "schema/fixtures/provider-adapter-input",
+  );
 
 function loadFixtureFile(fileName: string): AdapterFixture | null {
   const raw = fs.readFileSync(path.join(FIXTURE_DIR, fileName), "utf-8");
@@ -169,7 +174,19 @@ function summarizeForAudience(signal: FlowSignal, audience?: InsightAudience): s
 }
 
 function buildCatalog(): FlowInsightRecord[] {
-  const files = fs.readdirSync(FIXTURE_DIR).filter((file) => file.endsWith(".yaml"));
+  // The fixture directory is optional: container images and some deployment
+  // contexts do not ship the schema fixtures. Mirror the Go BFF behaviour
+  // and treat a missing directory as an empty catalog rather than crashing
+  // the server at startup.
+  let files: string[];
+  try {
+    files = fs.readdirSync(FIXTURE_DIR).filter((file) => file.endsWith(".yaml"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
   const records: FlowInsightRecord[] = [];
 
   for (const file of files) {


### PR DESCRIPTION
## Summary

PR #317's status checks surfaced three failures that pre-date that PR and trace back to the flow insights catalog landed in #294:

- **Check Container Build** — `Smoke Node.js BFF container` got HTTP 000 because the BFF crashed at startup.
- **Check Auth Integration** — `Run Node.js auth integration contract tests` exited 2 because the BFF never came up.
- **Check Flow Insights Equivalence** — `Run cross-stack flow insights equivalence` exited 2 because the Node.js BFF readiness probe never returned 200.

### Root cause

`stacks/nodejs/react-fastify/rest/bff/src/flow/insightsCatalog.ts` resolved the fixture directory using eight `..` segments. The file lives 7 segments below the repo root (`stacks/nodejs/react-fastify/rest/bff/{src,dist}/flow`), so the path resolved to a directory *above* the repo root (`/home/user/schema/...` instead of `/home/user/idp/schema/...`). `fs.readdirSync` ran at module load and threw `ENOENT`, taking the whole BFF down before it could listen.

In containers the directory simply isn't present, so even with the right segment count startup would have failed.

### Fix

- Use the correct segment count.
- Catch `ENOENT` in `buildCatalog` and return an empty catalog. The Go BFF already does this at runtime, so the two stacks now behave consistently.
- Allow `OUR_IDP_FLOW_FIXTURE_DIR` to override the path for callers that bundle fixtures into containers.

The POST `/api/flow/insights` endpoint that the equivalence runner exercises does not depend on the catalog — it runs the inference engine on the request body — so an empty catalog at startup does not affect equivalence.

## Test plan

- [x] `npm run typecheck:bff` passes.
- [x] `npm run test:bff` — all 24 BFF unit tests pass.
- [x] Local `node bff/dist/server.js` boot with default path: `/readiness` returns 200, `/api/flow/insights` returns `total: 27`.
- [x] Local boot with `OUR_IDP_FLOW_FIXTURE_DIR=/nonexistent`: `/readiness` returns 200, `/api/flow/insights` returns `total: 0` (no crash).
- [ ] CI `Check Container Build`, `Check Auth Integration`, `Check Flow Insights Equivalence` succeed on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LCYgdYPLQjwSqWurCWfjnw)_