### PR TITLE
feat: add fixture-backed agent work insight

### DIFF
--- a/.agents/docs/autonomous-task-experiment.md
+++ b/.agents/docs/autonomous-task-experiment.md
@@ -37,7 +37,7 @@ pnpm pi
 
 ### Example invocation inputs
 
-```
+```text
 task_description: "Add a CONTRIBUTING.md with project setup and PR guidelines"
 task_type: docs
 model_profile: fast
@@ -96,10 +96,10 @@ required for fully offline parallel runs.
 
 Each agent writes two files inside its worktree:
 
-| File | Content |
-|------|---------|
-| `.agent-lock` | Session ID, start time, task slug, PID |
-| `.agent-heartbeat` | Last completed step name + ISO timestamp |
+| File                 | Content                                         |
+| -------------------- | ----------------------------------------------- |
+| `.agent-lock`        | Session ID, start time, task slug, PID          |
+| `.agent-heartbeat`   | Last completed step name + ISO timestamp        |
 
 Check status of all running agents at any time:
 
@@ -113,6 +113,7 @@ make audit-worktrees
 ```
 
 If a session disappears silently:
+
 1. Its lock file remains; `audit-work-integrity` will flag it as a Medium finding.
 2. Manually release: `rm .agents/worktrees/<slug>/.agent-lock`
 3. Resume: re-invoke `autonomous-task` with the same `task_description` and
@@ -120,11 +121,11 @@ If a session disappears silently:
 
 ## Tool selection rationale
 
-| Tool | Role in experiment | Key capability used |
-|------|-------------------|---------------------|
-| OpenCode v1.14.x | Primary harness | First-party git worktree support; 75+ LLM providers; native `.agents/skills/` discovery |
-| Pi v0.74.x | Speed comparison | Minimal system prompt (~1K tokens); same skill discovery path |
-| Goose | Excluded (v1) | Worktree support in-progress ([aaif-goose/goose#3557](https://github.com/aaif-goose/goose/issues/3557)); revisit when GA |
+| Tool             | Role in experiment | Key capability used                                                                                                          |
+| ---------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| OpenCode v1.14.x | Primary harness    | First-party git worktree support; 75+ LLM providers; native `.agents/skills/` discovery                                      |
+| Pi v0.74.x       | Speed comparison   | Minimal system prompt (~1K tokens); same skill discovery path                                                                |
+| Goose            | Excluded (v1)      | Worktree support in-progress ([aaif-goose/goose#3557](https://github.com/aaif-goose/goose/issues/3557)); revisit when GA     |
 
 ## Known limitations
 

--- a/.agents/skills/audit-work-integrity/SKILL.md
+++ b/.agents/skills/audit-work-integrity/SKILL.md
@@ -104,6 +104,7 @@ For each path under `.agents/worktrees/`:
      worktree branch has no PR and no recent commit within `stale_days`.
 
 Report each stale or abandoned worktree with:
+
 - Path, lock session ID and start time (if available)
 - Last heartbeat step and timestamp (if available)
 - Recommended action: investigate the session, manually release the lock

--- a/.agents/skills/autonomous-task/SKILL.md
+++ b/.agents/skills/autonomous-task/SKILL.md
@@ -106,11 +106,11 @@ task/issue. Two mechanisms make this safe:
 
 **Recommended launchers for parallel sessions:**
 
-| Tool | How |
-|------|-----|
-| OpenCode Ensemble | `opencode-ensemble` plugin — each agent automatically gets its own worktree |
-| Pi side-agents | `@pasky/pi-side-agents` — one tmux window per agent, each in an isolated worktree |
-| Manual tmux | Split panes; run `pnpm oc` or `pnpm pi` in each; provide a different `task_description` per pane |
+| Tool              | How                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------- |
+| OpenCode Ensemble | `opencode-ensemble` plugin — each agent automatically gets its own worktree                       |
+| Pi side-agents    | `@pasky/pi-side-agents` — one tmux window per agent, each in an isolated worktree                 |
+| Manual tmux       | Split panes; run `pnpm oc` or `pnpm pi` in each; provide a different `task_description` per pane  |
 
 All three approaches are compatible with `local_only=true` for fully offline
 multi-agent runs.
@@ -123,13 +123,16 @@ If `skip_to=implement`, jump directly to step 3 (skip lock/heartbeat
 initialisation; they should already exist from the original run).
 
 Derive `TASK_SLUG` for use in worktree paths, lock files, and docker namespacing:
+
 - If `issue_number` provided: `issue-<number>-<title-slug>` (title words lowercased, spaces → hyphens, max 40 chars total).
 - If `task_description` only: first 8 words of description, lowercased, spaces → hyphens.
 
 **From issue:**
+
 ```bash
 gh issue view <issue_number> --json number,title,body,labels,assignees,state
 ```
+
 If closed, stop and report. If `blocked`, stop and surface the blocker.
 Derive `task_description` from the issue body and acceptance criteria.
 
@@ -137,9 +140,11 @@ Derive `task_description` from the issue body and acceptance criteria.
 for worktree naming: lowercase, spaces → hyphens, max 40 chars.
 
 Claim the issue if `issue_number` is provided:
+
 ```bash
 gh issue edit <issue_number> --add-label "in-progress"
 ```
+
 If labeling fails, stop and report.
 
 ---
@@ -158,6 +163,7 @@ git worktree add .agents/worktrees/<TASK_SLUG> -b task/<TASK_SLUG>
 ```
 
 Resolve the absolute worktree path:
+
 ```bash
 make worktree-path ISSUE_NUMBER=<issue_number>   # or derive manually
 ```
@@ -176,7 +182,8 @@ the developer confirms the previous session has ended (or the heartbeat shows
 it is stale).
 
 Write the lock file with a session identifier:
-```
+
+```text
 session: <random 8-char hex or tool-provided session ID>
 started: <ISO 8601 timestamp>
 task: <TASK_SLUG>
@@ -186,7 +193,8 @@ pid: <process ID if available>
 ### Heartbeat — initial
 
 Write `<worktree_path>/.agent-heartbeat`:
-```
+
+```text
 step: worktree-claimed
 timestamp: <ISO 8601>
 ```
@@ -203,6 +211,7 @@ role in the active profile (see [../../agent-models.yml](../../agent-models.yml)
 ### 2a. Explore (inside worktree)
 
 From `worktree_path`:
+
 1. Read files relevant to the task — check existing patterns, tests, docs.
 2. Identify files to create or modify.
 3. Note reusable utilities and patterns.
@@ -217,20 +226,26 @@ Structure: **Summary** (1 paragraph) · **Files to create/modify** ·
 ### 2c. Review gate
 
 **`review_mode=human`:**
+
 - If `issue_number` provided: post plan as issue comment starting with
   `## Implementation Plan` and a note that approval is required.
+
   ```bash
   gh issue comment <issue_number> --body "<plan markdown>"
   ```
+
   Set `plan_comment_url` output. Replace `in-progress` with `needs-review`:
+
   ```bash
   gh issue edit <issue_number> --remove-label "in-progress" --add-label "needs-review"
   ```
+
 - If no issue: print the plan to stdout.
 - **Halt.** Inform the developer to re-invoke with `skip_to=implement` after
   approving the plan. Do not proceed.
 
 **`review_mode=auto`:**
+
 - Invoke a second agent instance (review role model from the active profile).
   Provide: original task requirements + the plan. Ask: does the plan
   completely and safely satisfy the requirements? Respond APPROVED or
@@ -253,6 +268,7 @@ role in the active profile.
 ### 3a. Implement (inside worktree)
 
 Working strictly inside `worktree_path`:
+
 1. Follow the approved plan step by step.
 2. Stage and commit each logical slice — never `git add .`.
    See [../../docs/shared/iterative-commits.md](../../docs/shared/iterative-commits.md).
@@ -277,6 +293,7 @@ If checks pass, update the heartbeat (`step: impl-validated`) and proceed to
 step 4.
 
 If checks fail:
+
 - Capture the full error output.
 - Update heartbeat (`step: impl-validation-failed`).
 - Increment iteration counter.
@@ -291,6 +308,7 @@ If checks fail:
 Load the model defined for the `validate` role in the active profile.
 
 The validation agent reviews the final state of the worktree:
+
 1. Does the implementation satisfy all acceptance criteria from the task?
 2. Are tests added or updated?
 3. Are docs updated (if user-facing behavior changed)?
@@ -308,6 +326,7 @@ Update heartbeat: `step: ship`.
 ### If `local_only=true`
 
 Stop here. Do **not** invoke `ship-changes`. Print a completion summary:
+
 - Worktree path
 - Branch name
 - Last commit SHA and message
@@ -328,14 +347,19 @@ worktree cleanup.
 Set `pr_url` output from the result of `ship-changes`.
 
 After successful merge:
+
 - Remove `in-progress` label (if present):
+
   ```bash
   gh issue edit <issue_number> --remove-label "in-progress"
   ```
+
 - Confirm worktree cleanup:
+
   ```bash
   make worktree-cleanup ISSUE_NUMBER=<issue_number>
   ```
+
 - Release the lock file: `rm <worktree_path>/.agent-lock`
 
 ---
@@ -343,13 +367,16 @@ After successful merge:
 ## On any unrecoverable failure
 
 Before exiting on error at any step:
+
 1. Update heartbeat: `step: failed — <step-name>`.
 2. Release the lock file: `rm <worktree_path>/.agent-lock`.
 3. If `issue_number` provided, remove `in-progress` and add `blocked`:
+
    ```bash
    gh issue edit <issue_number> \
      --remove-label "in-progress" --add-label "blocked"
    ```
+
 4. Report the failure with the last heartbeat step and full error context so a
    developer or a future agent session can resume from the right point.
 
@@ -358,6 +385,7 @@ Before exiting on error at any step:
 ## Definition of done
 
 **`local_only=false`:**
+
 1. Implementation passes `make check` without errors.
 2. All acceptance criteria from the task/issue are met.
 3. PR is squash-merged to `main`.
@@ -365,6 +393,7 @@ Before exiting on error at any step:
 5. Lock file is removed. `in-progress` label is removed (if issue-backed).
 
 **`local_only=true`:**
+
 1. Implementation passes `make check` without errors.
 2. All acceptance criteria from the task/issue are met.
 3. Worktree is left clean and ready for developer review.

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -474,6 +474,9 @@ jobs:
           proto-version: ${{ env.PROTO_VERSION }}
           auto-install: true
 
+      - name: Set JAVA_HOME from proto openjdk
+        run: echo "JAVA_HOME=$(java -XshowSettings:property -version 2>&1 | grep 'java.home' | awk -F' = ' '{print $2}')" >> $GITHUB_ENV
+
       - name: Build and test mock OAuth
         run: moon run mock-oauth:check-ci
 
@@ -526,6 +529,9 @@ jobs:
         with:
           proto-version: ${{ env.PROTO_VERSION }}
           auto-install: true
+
+      - name: Set JAVA_HOME from proto openjdk
+        run: echo "JAVA_HOME=$(java -XshowSettings:property -version 2>&1 | grep 'java.home' | awk -F' = ' '{print $2}')" >> $GITHUB_ENV
 
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,10 @@ manually. No PR is created.
 
 ### Review modes
 
-| `review_mode` | Behaviour |
-|---------------|-----------|
-| `human` (default) | Agent posts the plan and halts. Re-invoke with `skip_to=implement` to proceed after you approve. |
-| `auto` | A second agent instance reviews the plan automatically. Enables fully unattended runs. |
+| `review_mode`     | Behaviour                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| `human` (default) | Agent posts the plan and halts. Re-invoke with `skip_to=implement` to proceed after you approve.       |
+| `auto`            | A second agent instance reviews the plan automatically. Enables fully unattended runs.                 |
 
 ### Model profiles
 
@@ -169,11 +169,11 @@ roles (`plan`, `implement`, `validate`, `review`) to a provider and model.
 Each session operates in its own worktree, so you can run N sessions
 concurrently on a single machine. Three launchers work out of the box:
 
-| Launcher | Command |
-|----------|---------|
-| OpenCode Ensemble | `pnpm opencode-ensemble "task A" "task B" "task C"` |
-| Pi side-agents (tmux) | `pnpm pi --extension @pasky/pi-side-agents` |
-| Manual tmux splits | Split panes; run `pnpm oc` or `pnpm pi` in each with a different `task_description` |
+| Launcher              | Command                                                                                       |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| OpenCode Ensemble     | `pnpm opencode-ensemble "task A" "task B" "task C"`                                           |
+| Pi side-agents (tmux) | `pnpm pi --extension @pasky/pi-side-agents`                                                   |
+| Manual tmux splits    | Split panes; run `pnpm oc` or `pnpm pi` in each with a different `task_description`           |
 
 All three are compatible with `local_only=true`.
 

--- a/docs/content/flow/agent-work-dogfood.md
+++ b/docs/content/flow/agent-work-dogfood.md
@@ -1,0 +1,116 @@
+---
+sidebar_position: 11
+---
+
+# Agent Work — Local Dogfood Path
+
+This page documents a deliberately manual, fixture-backed path for
+observing goose autonomous task work in the IDP portal. It exists as the
+first useful slice while a real goose launcher (e.g.
+`make agent-goose-task`) is still being designed.
+
+## What this is
+
+A local-first, fixture-backed view that lets a human read an agent task
+snapshot and decide what to do next. The flow:
+
+1. A goose autonomous task writes (or simulates) a snapshot file named
+   `.agent-task.json` describing what it observed, why it matters, and a
+   recommended next action.
+2. The Node.js BFF reads those snapshots at startup from
+   `schema/fixtures/agent-tasks/` (seed fixtures) and from
+   `.agents/worktrees/<slug>/.agent-task.json` (live snapshots).
+3. The BFF exposes them at `GET /api/agent-work/tasks` and
+   `GET /api/agent-work/tasks/:taskId`.
+4. The web app's `/agent-work` route renders an `AgentTaskCard` per task,
+   surfacing **Observation**, **Why it matters**, and **What to do**.
+
+## What this is not
+
+- Not a goose launcher. There is no `make agent-goose-task` target yet.
+- Not a telemetry pipeline. No OpenTelemetry ingestion, no database, no
+  push-based events. The BFF only reads local files.
+- Not a remote agent runner. There is no network call to start, observe,
+  or modify an agent run.
+
+## Snapshot shape
+
+`.agent-task.json` files are plain JSON. The required fields are:
+
+```json
+{
+  "task_id": "goose-001",
+  "issue_number": 371,
+  "state": "impl-validation-failed",
+  "slug": "issue-371-agent-work-insights",
+  "worktree_path": ".agents/worktrees/issue-371-agent-work-insights",
+  "heartbeat": {
+    "state": "impl-validation-failed",
+    "updated_at": "2026-05-16T10:00:00Z"
+  },
+  "model": null,
+  "tokens": null,
+  "cost": null,
+  "observation": "make check failed on iteration 2 of 3. ...",
+  "why_it_matters": "The autonomous task exhausted its retries. ...",
+  "what_to_do": "Open the worktree at ..., fix Y, re-invoke with ..."
+}
+```
+
+`state` and `heartbeat.state` are constrained to the heartbeat vocabulary
+defined in `.agents/skills/autonomous-task/SKILL.md`: `worktree-claimed`,
+`planning`, `planning-review`, `implementing`, `impl-validation-failed`,
+`impl-validated`, `validating`, `ship`, `complete-local`, `failed`,
+`blocked`.
+
+`model`, `tokens`, and `cost` are intentionally nullable. When a snapshot
+does not carry a known value, set it to `null` and the UI will display
+"unavailable" — values are never guessed or backfilled.
+
+## Adding a snapshot manually
+
+The dogfood path requires no special tooling. Drop a file with the shape
+above into one of two locations:
+
+- `schema/fixtures/agent-tasks/<name>.agent-task.json` — seed fixture
+  that lives with the repo. Good for demos and tests.
+- `.agents/worktrees/<slug>/.agent-task.json` — live snapshot for a real
+  worktree. The catalog reads this on BFF startup and shadows any
+  fixture with the same `task_id`.
+
+Restart the BFF to pick up the new file. The catalog loads at startup;
+there is no file watcher.
+
+## How to test locally
+
+```bash
+# Validate a fixture file is well-formed JSON
+node -e "JSON.parse(require('fs').readFileSync('schema/fixtures/agent-tasks/impl-validation-failed-goose-001.agent-task.json','utf8'))"
+
+# Start the BFF
+pnpm --dir stacks/nodejs/react-fastify/rest/bff dev
+
+# Probe the endpoints
+curl -s http://localhost:3000/api/agent-work/tasks | jq '.total, .tasks[0].state'
+curl -s http://localhost:3000/api/agent-work/tasks/goose-001 | jq '.task.what_to_do'
+
+# Start the web app and navigate to /agent-work
+pnpm --dir stacks/nodejs/react-fastify/rest/web dev
+```
+
+## Environment overrides
+
+The catalog resolves directories from the repo root by default. Override
+either with an environment variable if you need a non-default location
+(useful inside containers or for integration tests):
+
+- `OUR_IDP_AGENT_TASK_FIXTURE_DIR` — fixture directory
+- `OUR_IDP_AGENT_TASK_DIR` — live worktree root
+
+## Replacing this with a real launcher
+
+When a launcher exists, no code change is needed in the BFF or web. The
+launcher writes `.agent-task.json` to its worktree as part of the
+existing snapshot contract; the catalog reads it on the next BFF
+restart. This page becomes obsolete at that point and should be replaced
+with launcher documentation.

--- a/docs/content/flow/agent-work-dogfood.md
+++ b/docs/content/flow/agent-work-dogfood.md
@@ -88,14 +88,14 @@ there is no file watcher.
 node -e "JSON.parse(require('fs').readFileSync('schema/fixtures/agent-tasks/impl-validation-failed-goose-001.agent-task.json','utf8'))"
 
 # Start the BFF
-pnpm --dir stacks/nodejs/react-fastify/rest/bff dev
+pnpm --dir stacks/nodejs/react-fastify/rest run start:bff
 
 # Probe the endpoints
-curl -s http://localhost:3000/api/agent-work/tasks | jq '.total, .tasks[0].state'
-curl -s http://localhost:3000/api/agent-work/tasks/goose-001 | jq '.task.what_to_do'
+curl -s http://localhost:8000/api/agent-work/tasks | jq '.total, .tasks[0].state'
+curl -s http://localhost:8000/api/agent-work/tasks/goose-001 | jq '.task.what_to_do'
 
 # Start the web app and navigate to /agent-work
-pnpm --dir stacks/nodejs/react-fastify/rest/web dev
+pnpm --dir stacks/nodejs/react-fastify/rest run start:web
 ```
 
 ## Environment overrides

--- a/docs/package.json
+++ b/docs/package.json
@@ -30,10 +30,14 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.0",
+    "@docusaurus/theme-common": "3.10.0",
     "@docusaurus/tsconfig": "3.10.1",
     "@docusaurus/types": "3.10.0",
     "@mermaid-js/mermaid-cli": "11.14.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
     "markdownlint-cli2": "0.22.1",
+    "mermaid": "^11.0.0",
     "typescript": "~6.0.3"
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@docusaurus/module-type-aliases':
         specifier: 3.10.0
         version: 3.10.0(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@docusaurus/theme-common':
+        specifier: 3.10.0
+        version: 3.10.0(@docusaurus/plugin-content-docs@3.10.0(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@docusaurus/tsconfig':
         specifier: 3.10.1
         version: 3.10.1
@@ -85,9 +88,18 @@ importers:
       '@mermaid-js/mermaid-cli':
         specifier: 11.14.0
         version: 11.14.0(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.14)(puppeteer@24.43.1(typescript@6.0.3))(tsx@4.21.0)(yaml@2.9.0)
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.14)
       markdownlint-cli2:
         specifier: 0.22.1
         version: 0.22.1
+      mermaid:
+        specifier: ^11.0.0
+        version: 11.15.0
       typescript:
         specifier: ~6.0.3
         version: 6.0.3

--- a/schema/fixtures/agent-tasks/impl-validation-failed-goose-001.agent-task.json
+++ b/schema/fixtures/agent-tasks/impl-validation-failed-goose-001.agent-task.json
@@ -1,0 +1,17 @@
+{
+  "task_id": "goose-001",
+  "issue_number": 371,
+  "state": "impl-validation-failed",
+  "slug": "issue-371-agent-work-insights",
+  "worktree_path": ".agents/worktrees/issue-371-agent-work-insights",
+  "heartbeat": {
+    "state": "impl-validation-failed",
+    "updated_at": "2026-05-16T10:00:00Z"
+  },
+  "model": null,
+  "tokens": null,
+  "cost": null,
+  "observation": "make check failed on iteration 2 of 3. TypeScript compiler reported 2 errors in stacks/nodejs/react-fastify/rest/bff/src/routes/agent-work.ts: type mismatch on AgentTask.state field.",
+  "why_it_matters": "The autonomous task exhausted its implementation retries. Without a human resolving the type error, this work slice is stuck. The insight surfaces before the worktree goes stale.",
+  "what_to_do": "Open the worktree at .agents/worktrees/issue-371-agent-work-insights, inspect the TypeScript error, fix the type annotation, and re-invoke with skip_to=implement."
+}

--- a/stacks/nodejs/react-fastify/rest/bff/Dockerfile
+++ b/stacks/nodejs/react-fastify/rest/bff/Dockerfile
@@ -54,8 +54,12 @@ COPY tools/mock-providers/package.json ./tools/mock-providers/package.json
 COPY tools/vscode-extension/package.json ./tools/vscode-extension/package.json
 RUN pnpm install --prod --frozen-lockfile --filter nodejs-react-fastify-rest...
 
-# Copy compiled output from builder.
-COPY --from=builder /app/stacks/nodejs/react-fastify/rest/bff/dist/ ./bff/dist/
+# Copy compiled output from builder — must mirror the source tree so Node.js
+# module resolution can find node_modules at stacks/nodejs/react-fastify/rest/.
+COPY --from=builder /app/stacks/nodejs/react-fastify/rest/bff/dist/ ./stacks/nodejs/react-fastify/rest/bff/dist/
+
+# Copy agent-task fixture data (read by agentTaskCatalog at runtime).
+COPY schema/fixtures/agent-tasks/ ./schema/fixtures/agent-tasks/
 
 # Override loopback default (ADR-0006) for container context.
 ENV OUR_IDP_API_HOST=0.0.0.0
@@ -79,4 +83,4 @@ LABEL org.opencontainers.image.url="https://github.com/ourchitecture/idp"
 LABEL org.opencontainers.image.vendor="Ourchitecture"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.created-by="moon"
-CMD ["node", "bff/dist/server.js"]
+CMD ["node", "stacks/nodejs/react-fastify/rest/bff/dist/server.js"]

--- a/stacks/nodejs/react-fastify/rest/bff/src/agent-work/agentTaskCatalog.test.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/agent-work/agentTaskCatalog.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { findAgentTask, listAgentTasks } from "./agentTaskCatalog";
+import type { AgentTask } from "./types";
+
+function findRepoRoot(startDir: string): string {
+  let current = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(current, "schema"))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error("Repository root not found from agent task catalog tests");
+    }
+
+    current = parent;
+  }
+}
+
+const repoRoot = findRepoRoot(__dirname);
+const failedValidationFixturePath = path.join(
+  repoRoot,
+  "schema",
+  "fixtures",
+  "agent-tasks",
+  "impl-validation-failed-goose-001.agent-task.json",
+);
+
+test("loads the impl-validation-failed goose task fixture", () => {
+  const raw = fs.readFileSync(failedValidationFixturePath, "utf8");
+  const fixture = JSON.parse(raw) as AgentTask;
+
+  assert.equal(fixture.task_id, "goose-001");
+  assert.equal(fixture.state, "impl-validation-failed");
+  assert.equal(fixture.heartbeat.state, "impl-validation-failed");
+  assert.equal(fixture.model, null);
+  assert.equal(fixture.tokens, null);
+  assert.equal(fixture.cost, null);
+});
+
+test("maps failed validation state to a concrete human action", () => {
+  const task = findAgentTask("goose-001");
+
+  assert.ok(task, "expected goose-001 fixture to load into the catalog");
+  assert.equal(task.state, "impl-validation-failed");
+  assert.match(task.what_to_do, /Open the worktree/);
+  assert.match(task.what_to_do, /fix the type annotation/);
+  assert.match(task.what_to_do, /skip_to=implement/);
+});
+
+test("filters agent tasks by impl-validation-failed state", () => {
+  const tasks = listAgentTasks({ state: "impl-validation-failed" });
+  const task = tasks.find((candidate) => candidate.task_id === "goose-001");
+
+  assert.ok(task, "expected state filter to include goose-001");
+  assert.equal(task.state, "impl-validation-failed");
+  assert.ok(task.what_to_do.length > 0);
+});

--- a/stacks/nodejs/react-fastify/rest/bff/src/agent-work/agentTaskCatalog.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/agent-work/agentTaskCatalog.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+import type {
+  AgentTask,
+  AgentTaskFilters,
+  AgentTaskState,
+  AgentTaskSummary,
+} from "./types";
+
+const VALID_STATES: ReadonlySet<AgentTaskState> = new Set<AgentTaskState>([
+  "worktree-claimed",
+  "planning",
+  "planning-review",
+  "implementing",
+  "impl-validation-failed",
+  "impl-validated",
+  "validating",
+  "ship",
+  "complete-local",
+  "failed",
+  "blocked",
+]);
+
+// __dirname is 7 segments deep below the repo root:
+//   <repo>/stacks/nodejs/react-fastify/rest/bff/{src,dist}/agent-work
+// Mirrors the depth used by flow/insightsCatalog.ts.
+const REPO_ROOT_FROM_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+);
+
+const FIXTURE_DIR =
+  process.env.OUR_IDP_AGENT_TASK_FIXTURE_DIR ??
+  path.join(REPO_ROOT_FROM_DIR, "schema/fixtures/agent-tasks");
+
+const LIVE_TASK_DIR =
+  process.env.OUR_IDP_AGENT_TASK_DIR ??
+  path.join(REPO_ROOT_FROM_DIR, ".agents/worktrees");
+
+function isAgentTaskState(value: unknown): value is AgentTaskState {
+  return typeof value === "string" && VALID_STATES.has(value as AgentTaskState);
+}
+
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asNumberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function parseAgentTask(raw: unknown): AgentTask | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+
+  const task_id = typeof obj.task_id === "string" ? obj.task_id : null;
+  const slug = typeof obj.slug === "string" ? obj.slug : null;
+  const worktree_path =
+    typeof obj.worktree_path === "string" ? obj.worktree_path : null;
+  const observation =
+    typeof obj.observation === "string" ? obj.observation : null;
+  const why_it_matters =
+    typeof obj.why_it_matters === "string" ? obj.why_it_matters : null;
+  const what_to_do =
+    typeof obj.what_to_do === "string" ? obj.what_to_do : null;
+
+  if (
+    !task_id ||
+    !slug ||
+    !worktree_path ||
+    !observation ||
+    !why_it_matters ||
+    !what_to_do
+  ) {
+    return null;
+  }
+
+  if (!isAgentTaskState(obj.state)) return null;
+
+  const heartbeatRaw = obj.heartbeat;
+  if (heartbeatRaw === null || typeof heartbeatRaw !== "object") return null;
+  const heartbeatObj = heartbeatRaw as Record<string, unknown>;
+  if (!isAgentTaskState(heartbeatObj.state)) return null;
+  const heartbeatUpdatedAt =
+    typeof heartbeatObj.updated_at === "string" ? heartbeatObj.updated_at : null;
+  if (!heartbeatUpdatedAt) return null;
+
+  return {
+    task_id,
+    issue_number: asNumberOrNull(obj.issue_number),
+    state: obj.state,
+    slug,
+    worktree_path,
+    heartbeat: {
+      state: heartbeatObj.state,
+      updated_at: heartbeatUpdatedAt,
+    },
+    model: asStringOrNull(obj.model),
+    tokens: asNumberOrNull(obj.tokens),
+    cost: asNumberOrNull(obj.cost),
+    observation,
+    why_it_matters,
+    what_to_do,
+  };
+}
+
+function loadJsonFile(filePath: string): AgentTask | null {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    return parseAgentTask(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function readDirSafe(dir: string): string[] {
+  try {
+    return fs.readdirSync(dir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function buildCatalog(): AgentTask[] {
+  const byTaskId = new Map<string, AgentTask>();
+
+  // Fixtures first.
+  for (const file of readDirSafe(FIXTURE_DIR)) {
+    if (!file.endsWith(".agent-task.json")) continue;
+    const task = loadJsonFile(path.join(FIXTURE_DIR, file));
+    if (task) {
+      byTaskId.set(task.task_id, task);
+    }
+  }
+
+  // Live worktree snapshots shadow fixtures on task_id collision.
+  for (const entry of readDirSafe(LIVE_TASK_DIR)) {
+    const candidate = path.join(LIVE_TASK_DIR, entry, ".agent-task.json");
+    try {
+      if (!fs.statSync(candidate).isFile()) continue;
+    } catch {
+      continue;
+    }
+    const task = loadJsonFile(candidate);
+    if (task) {
+      byTaskId.set(task.task_id, task);
+    }
+  }
+
+  return Array.from(byTaskId.values());
+}
+
+const CATALOG = buildCatalog();
+
+function matchesFilter(value: string | undefined, filter?: string): boolean {
+  if (!filter) return true;
+  if (!value) return false;
+  return value.toLowerCase().includes(filter.toLowerCase());
+}
+
+function toSummary(task: AgentTask): AgentTaskSummary {
+  return {
+    task_id: task.task_id,
+    issue_number: task.issue_number,
+    state: task.state,
+    slug: task.slug,
+    observation: task.observation,
+    why_it_matters: task.why_it_matters,
+    what_to_do: task.what_to_do,
+    heartbeat: task.heartbeat,
+    model: task.model,
+    tokens: task.tokens,
+    cost: task.cost,
+  };
+}
+
+export function listAgentTasks(filters: AgentTaskFilters): AgentTaskSummary[] {
+  return CATALOG.filter((task) => {
+    if (!matchesFilter(task.state, filters.state)) return false;
+    if (!matchesFilter(task.slug, filters.slug)) return false;
+    return true;
+  }).map(toSummary);
+}
+
+export function findAgentTask(taskId: string): AgentTask | null {
+  return CATALOG.find((task) => task.task_id === taskId) ?? null;
+}

--- a/stacks/nodejs/react-fastify/rest/bff/src/agent-work/types.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/agent-work/types.ts
@@ -1,0 +1,51 @@
+export type AgentTaskState =
+  | "worktree-claimed"
+  | "planning"
+  | "planning-review"
+  | "implementing"
+  | "impl-validation-failed"
+  | "impl-validated"
+  | "validating"
+  | "ship"
+  | "complete-local"
+  | "failed"
+  | "blocked";
+
+export interface AgentTaskHeartbeat {
+  state: AgentTaskState;
+  updated_at: string;
+}
+
+export interface AgentTask {
+  task_id: string;
+  issue_number: number | null;
+  state: AgentTaskState;
+  slug: string;
+  worktree_path: string;
+  heartbeat: AgentTaskHeartbeat;
+  model: string | null;
+  tokens: number | null;
+  cost: number | null;
+  observation: string;
+  why_it_matters: string;
+  what_to_do: string;
+}
+
+export interface AgentTaskFilters {
+  state?: string;
+  slug?: string;
+}
+
+export interface AgentTaskSummary {
+  task_id: string;
+  issue_number: number | null;
+  state: AgentTaskState;
+  slug: string;
+  observation: string;
+  why_it_matters: string;
+  what_to_do: string;
+  heartbeat: AgentTaskHeartbeat;
+  model: string | null;
+  tokens: number | null;
+  cost: number | null;
+}

--- a/stacks/nodejs/react-fastify/rest/bff/src/app.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/app.ts
@@ -1,5 +1,6 @@
 import cors from "@fastify/cors";
 import Fastify, { type FastifyInstance } from "fastify";
+import { agentWorkRoutes } from "./routes/agent-work";
 import { authRoutes } from "./routes/auth";
 import { flowInsightsRoutes } from "./routes/flow-insights";
 import { healthRoutes } from "./routes/health";
@@ -26,6 +27,7 @@ export async function createApp(): Promise<FastifyInstance> {
   await app.register(readinessRoutes);
   await app.register(portalSummaryRoutes);
   await app.register(flowInsightsRoutes);
+  await app.register(agentWorkRoutes);
 
   return app;
 }

--- a/stacks/nodejs/react-fastify/rest/bff/src/routes/agent-work.ts
+++ b/stacks/nodejs/react-fastify/rest/bff/src/routes/agent-work.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { FastifyPluginAsync } from "fastify";
+import { findAgentTask, listAgentTasks } from "../agent-work/agentTaskCatalog";
+
+const listQuerySchema = z
+  .object({
+    state: z.string().optional(),
+    slug: z.string().optional(),
+  })
+  .strip();
+
+const detailParamsSchema = z.object({
+  taskId: z.string(),
+});
+
+export const agentWorkRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/api/agent-work/tasks", async (request) => {
+    const query = listQuerySchema.parse(request.query ?? {});
+    const tasks = listAgentTasks(query);
+
+    const appliedFilters = Object.fromEntries(
+      Object.entries(query).filter(
+        ([, value]) => value !== undefined && `${value}`.length > 0,
+      ),
+    );
+
+    return {
+      generatedAt: new Date().toISOString(),
+      filters: appliedFilters,
+      total: tasks.length,
+      tasks,
+    };
+  });
+
+  app.get("/api/agent-work/tasks/:taskId", async (request, reply) => {
+    const params = detailParamsSchema.parse(request.params ?? {});
+    const task = findAgentTask(params.taskId);
+
+    if (!task) {
+      return reply.status(404).send({
+        error: "agent_task_not_found",
+        message: `No agent task found for '${params.taskId}'.`,
+      });
+    }
+
+    return {
+      generatedAt: new Date().toISOString(),
+      task,
+    };
+  });
+};

--- a/stacks/nodejs/react-fastify/rest/web/src/components/agent-task-card.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/components/agent-task-card.tsx
@@ -1,0 +1,76 @@
+import type { AgentTask, AgentTaskState } from "../lib/api-client";
+
+type CardTone = "healthy" | "degraded" | "neutral";
+
+function stateToTone(state: AgentTaskState): CardTone {
+  switch (state) {
+    case "impl-validated":
+    case "ship":
+    case "complete-local":
+      return "healthy";
+    case "impl-validation-failed":
+    case "failed":
+    case "blocked":
+      return "degraded";
+    default:
+      return "neutral";
+  }
+}
+
+function renderMetric(label: string, value: string | number | null): string {
+  if (value === null) return `${label}: unavailable`;
+  return `${label}: ${value}`;
+}
+
+type AgentTaskCardProps = {
+  task: AgentTask;
+};
+
+export function AgentTaskCard({ task }: AgentTaskCardProps) {
+  const tone = stateToTone(task.state);
+  const issueLabel =
+    task.issue_number === null ? "no issue" : `#${task.issue_number}`;
+
+  return (
+    <article
+      className={`status-card agent-task-card agent-task-card--${tone}`}
+      aria-label={`Agent task ${task.slug} in state ${task.state}`}
+    >
+      <header className="status-card__header agent-task-card__header">
+        <h2>{task.slug}</h2>
+        <span
+          className={`portal-badge agent-task-card__badge agent-task-card__badge--${tone}`}
+        >
+          {task.state}
+        </span>
+      </header>
+
+      <p className="status-card__subtitle agent-task-card__issue">
+        Issue {issueLabel} · task <code>{task.task_id}</code>
+      </p>
+
+      <dl className="agent-task-card__insight">
+        <dt>Observation</dt>
+        <dd>{task.observation}</dd>
+        <dt>Why it matters</dt>
+        <dd>{task.why_it_matters}</dd>
+        <dt>What to do</dt>
+        <dd>{task.what_to_do}</dd>
+      </dl>
+
+      <footer className="agent-task-card__footer">
+        <p className="agent-task-card__worktree">
+          Worktree: <code>{task.worktree_path}</code>
+        </p>
+        <p className="agent-task-card__heartbeat">
+          Heartbeat {task.heartbeat.state} at {task.heartbeat.updated_at}
+        </p>
+        <p className="agent-task-card__metrics" aria-label="Run metrics">
+          <span>{renderMetric("Model", task.model)}</span>
+          <span>{renderMetric("Tokens", task.tokens)}</span>
+          <span>{renderMetric("Cost", task.cost)}</span>
+        </p>
+      </footer>
+    </article>
+  );
+}

--- a/stacks/nodejs/react-fastify/rest/web/src/lib/api-client.ts
+++ b/stacks/nodejs/react-fastify/rest/web/src/lib/api-client.ts
@@ -115,3 +115,76 @@ export function fetchPortalSummary(): Promise<PortalSummary> {
 export function fetchBffHealth(): Promise<BffHealth> {
   return fetchJson<BffHealth>("/health").then(assertHealthPayload);
 }
+
+export type AgentTaskState =
+  | "worktree-claimed"
+  | "planning"
+  | "planning-review"
+  | "implementing"
+  | "impl-validation-failed"
+  | "impl-validated"
+  | "validating"
+  | "ship"
+  | "complete-local"
+  | "failed"
+  | "blocked";
+
+export type AgentTaskHeartbeat = {
+  state: AgentTaskState;
+  updated_at: string;
+};
+
+export type AgentTask = {
+  task_id: string;
+  issue_number: number | null;
+  state: AgentTaskState;
+  slug: string;
+  worktree_path: string;
+  heartbeat: AgentTaskHeartbeat;
+  model: string | null;
+  tokens: number | null;
+  cost: number | null;
+  observation: string;
+  why_it_matters: string;
+  what_to_do: string;
+};
+
+export type AgentTaskList = {
+  generatedAt: string;
+  filters: Record<string, string>;
+  total: number;
+  tasks: AgentTask[];
+};
+
+export type AgentTaskDetail = {
+  generatedAt: string;
+  task: AgentTask;
+};
+
+export type AgentTaskFilters = {
+  state?: string;
+  slug?: string;
+};
+
+function buildAgentTaskQuery(filters?: AgentTaskFilters): string {
+  if (!filters) return "";
+  const params = new URLSearchParams();
+  if (filters.state) params.set("state", filters.state);
+  if (filters.slug) params.set("slug", filters.slug);
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : "";
+}
+
+export function fetchAgentTasks(
+  filters?: AgentTaskFilters,
+): Promise<AgentTaskList> {
+  return fetchJson<AgentTaskList>(
+    `/api/agent-work/tasks${buildAgentTaskQuery(filters)}`,
+  );
+}
+
+export function fetchAgentTask(taskId: string): Promise<AgentTaskDetail> {
+  return fetchJson<AgentTaskDetail>(
+    `/api/agent-work/tasks/${encodeURIComponent(taskId)}`,
+  );
+}

--- a/stacks/nodejs/react-fastify/rest/web/src/router.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/router.tsx
@@ -13,6 +13,11 @@ const StatusPage = lazy(async () => {
   return { default: module.StatusPage };
 });
 
+const AgentWorkPage = lazy(async () => {
+  const module = await import("./routes/agent-work-page");
+  return { default: module.AgentWorkPage };
+});
+
 function HomeRoute() {
   return (
     <Suspense fallback={<RouteLoading />}>
@@ -25,6 +30,14 @@ function StatusRoute() {
   return (
     <Suspense fallback={<RouteLoading />}>
       <StatusPage />
+    </Suspense>
+  );
+}
+
+function AgentWorkRoute() {
+  return (
+    <Suspense fallback={<RouteLoading />}>
+      <AgentWorkPage />
     </Suspense>
   );
 }
@@ -42,6 +55,11 @@ export const router = createBrowserRouter([
   {
     path: "/status",
     element: <StatusRoute />,
+    errorElement: <RootErrorBoundary />,
+  },
+  {
+    path: "/agent-work",
+    element: <AgentWorkRoute />,
     errorElement: <RootErrorBoundary />,
   },
 ]);

--- a/stacks/nodejs/react-fastify/rest/web/src/routes/agent-work-page.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/routes/agent-work-page.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { AgentTaskCard } from "../components/agent-task-card";
+import { fetchAgentTasks } from "../lib/api-client";
+
+export function AgentWorkPage() {
+  const agentTasksQuery = useQuery({
+    queryKey: ["agent-tasks"],
+    queryFn: () => fetchAgentTasks(),
+  });
+
+  return (
+    <main className="portal-shell">
+      <header className="portal-hero">
+        <p className="portal-kicker">
+          Stemix
+          <span className="portal-badge">Agent Work</span>
+        </p>
+        <h1>Agent work insights</h1>
+        <p className="portal-subtitle">
+          Local-first dogfood view of goose autonomous task snapshots. Each
+          card surfaces what the agent observed, why it matters, and the
+          concrete next action a human can take. Fixture-backed today; live
+          <code> .agent-task.json</code> snapshots from
+          <code> .agents/worktrees/</code> are read automatically on BFF
+          startup.
+        </p>
+        <div className="portal-actions">
+          <Link className="portal-action portal-action--secondary" to="/">
+            Back to home
+          </Link>
+        </div>
+      </header>
+
+      {agentTasksQuery.isLoading ? (
+        <section className="service-panel" aria-live="polite">
+          <p className="empty-state">Loading agent work snapshots...</p>
+        </section>
+      ) : null}
+
+      {agentTasksQuery.isError ? (
+        <section className="service-panel" aria-live="assertive">
+          <p className="empty-state empty-state--error">
+            Could not retrieve <code>/api/agent-work/tasks</code>. Confirm the
+            BFF is running and that the agent-task fixture directory is
+            reachable.
+          </p>
+        </section>
+      ) : null}
+
+      {agentTasksQuery.data !== undefined ? (
+        agentTasksQuery.data.total === 0 ? (
+          <section className="service-panel">
+            <p className="empty-state">
+              No agent tasks available yet. Drop a{" "}
+              <code>.agent-task.json</code> file into{" "}
+              <code>schema/fixtures/agent-tasks/</code> or{" "}
+              <code>.agents/worktrees/&lt;slug&gt;/</code> and restart the BFF.
+            </p>
+          </section>
+        ) : (
+          <section className="agent-task-grid" aria-label="Agent work tasks">
+            {agentTasksQuery.data.tasks.map((task) => (
+              <AgentTaskCard key={task.task_id} task={task} />
+            ))}
+          </section>
+        )
+      ) : null}
+    </main>
+  );
+}

--- a/stacks/nodejs/react-fastify/rest/web/src/routes/home-page.tsx
+++ b/stacks/nodejs/react-fastify/rest/web/src/routes/home-page.tsx
@@ -27,6 +27,9 @@ export function HomePage() {
           <Link className="portal-action" to="/status">
             View detailed status
           </Link>
+          <Link className="portal-action portal-action--secondary" to="/agent-work">
+            View agent work
+          </Link>
         </div>
       </header>
 

--- a/stacks/nodejs/react-fastify/rest/web/src/styles.css
+++ b/stacks/nodejs/react-fastify/rest/web/src/styles.css
@@ -387,6 +387,90 @@ body {
   }
 }
 
+.agent-task-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+.agent-task-card {
+  padding: 1.25rem;
+}
+
+.agent-task-card--degraded {
+  border-color: rgba(185, 87, 45, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(185, 87, 45, 0.15), var(--shadow);
+}
+
+.agent-task-card--healthy {
+  border-color: rgba(10, 123, 97, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(10, 123, 97, 0.15), var(--shadow);
+}
+
+.agent-task-card__header h2 {
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 1.05rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.agent-task-card__badge {
+  font-size: 0.62rem;
+}
+
+.agent-task-card__badge--degraded {
+  background: var(--warn);
+}
+
+.agent-task-card__badge--healthy {
+  background: var(--ok);
+}
+
+.agent-task-card__issue {
+  margin-top: 0.4rem;
+}
+
+.agent-task-card__insight {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.agent-task-card__insight dt {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.agent-task-card__insight dd {
+  margin: 0 0 0.5rem;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+.agent-task-card__footer {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(31, 42, 55, 0.08);
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.agent-task-card__footer code {
+  font-size: 0.78rem;
+}
+
+.agent-task-card__metrics {
+  margin: 0;
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
 @media (max-width: 700px) {
   .portal-shell {
     padding: 1rem 0.75rem 1.75rem;

--- a/tools/backstage/yarn.lock
+++ b/tools/backstage/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@acemir/cssom@npm:^0.9.31":
@@ -30345,11 +30345,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=cef18b"
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/6f7e53bf0d9702350deeb6f35e08b69cbc8b958c33e0ec77bdc0ad6a6c8e280f3959dcbfde6f5b0848bece57810696489deaaa53d75de3578ff255d168c1efbd
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds the fixture-backed Agent Work BFF surface and `/agent-work` UI for goose `impl-validation-failed` snapshots.
- Adds a catalog contract test for the `goose-001` failed-validation fixture and human action mapping.
- Fixes Markdown lint issues and corrects the local dogfood commands/ports in the docs.

## Validation
- `pnpm run test:bff` — 27 pass
- `pnpm run typecheck:bff` — pass
- `pnpm run typecheck:web` — pass
- `pnpm exec markdownlint-cli2` — pass

Closes #372