### PR TITLE
fix(ci): quote $GITHUB_ENV to satisfy shellcheck SC2086

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -478,7 +478,7 @@ jobs:
           auto-install: true
 
       - name: Set JAVA_HOME from proto openjdk
-        run: echo "JAVA_HOME=$(java -XshowSettings:property -version 2>&1 | grep 'java.home' | awk -F' = ' '{print $2}')" >> $GITHUB_ENV
+        run: echo "JAVA_HOME=$(java -XshowSettings:property -version 2>&1 | grep 'java.home' | awk -F' = ' '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Build and test mock OAuth
         run: moon run mock-oauth:check-ci
@@ -534,7 +534,7 @@ jobs:
           auto-install: true
 
       - name: Set JAVA_HOME from proto openjdk
-        run: echo "JAVA_HOME=$(java -XshowSettings:property -version 2>&1 | grep 'java.home' | awk -F' = ' '{print $2}')" >> $GITHUB_ENV
+        run: echo "JAVA_HOME=$(java -XshowSettings:property -version 2>&1 | grep 'java.home' | awk -F' = ' '{print $2}')" >> "$GITHUB_ENV"
 
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Quotes `$GITHUB_ENV` in two `Set JAVA_HOME from proto openjdk` steps in `pr-validate.yml`
- Fixes `Check Workflow Files` CI failure (shellcheck SC2086: double quote to prevent globbing and word splitting)
- Affects the `check-mock-oauth-build` and `check-auth-integration` jobs

The fix is purely cosmetic for shell safety — `$GITHUB_ENV` is a path written by the Actions runner and won't undergo splitting in practice, but quoting it is the correct shell hygiene and silences the lint warning.

## Test plan

- [x] `Check Workflow Files` should now pass (shellcheck SC2086 resolved)
- [x] No functional change to the JAVA_HOME derivation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)