### PR TITLE
feat(#370): next slices — contract tests, goose launcher, impl-validated fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all ci install upgrade build clean reset lint check-lint-md check-lint-workflows check-privacy check-flow-insights-equivalence check-stack check-team-membership check-pr-changes issue-number issue-triage issue-signal-ready issue-setup-labels worktree-path worktree-ensure worktree-cleanup audit-worktrees check-lint check-test check-contract check test test-contract dev docs-site build-containers build-container-dev-tools gitlab-harness-up gitlab-harness-down gitlab-harness-seed gitlab-harness-reset gitlab-harness-wait-healthy gitlab-harness-wait-init gitlab-harness-token gitlab-harness-logs verify-tool-pins setup-hooks sync-skills check-skills-sync
+.PHONY: help all ci install upgrade build clean reset lint check-lint-md check-lint-workflows check-privacy check-flow-insights-equivalence check-stack check-team-membership check-pr-changes issue-number issue-triage issue-signal-ready issue-setup-labels worktree-path worktree-ensure worktree-cleanup audit-worktrees agent-goose-task check-lint check-test check-contract check test test-contract dev docs-site build-containers build-container-dev-tools gitlab-harness-up gitlab-harness-down gitlab-harness-seed gitlab-harness-reset gitlab-harness-wait-healthy gitlab-harness-wait-init gitlab-harness-token gitlab-harness-logs verify-tool-pins setup-hooks sync-skills check-skills-sync
 
 DEFAULT_STACK := stacks/go/net-http/rest
 STACK ?= $(DEFAULT_STACK)
@@ -35,6 +35,7 @@ help:
 	@printf "  worktree-ensure Create or reuse the canonical issue worktree\n"
 	@printf "  worktree-cleanup Remove a clean issue worktree after merge confirmation\n"
 	@printf "  audit-worktrees Report stale or orphaned issue worktrees\n"
+	@printf "  agent-goose-task Create worktree + snapshot for a goose dogfood run\n"
 	@printf "  check-lint    Run selected stack lint checks\n"
 	@printf "  check-test    Run selected stack tests\n"
 	@printf "  check-contract Run selected stack contract checks\n"
@@ -218,6 +219,9 @@ audit-worktrees:
 	else \
 		"bash" "./$(CI_SCRIPTS_DIR)/audit-worktrees.sh"; \
 	fi
+
+agent-goose-task:
+	@"bash" "./$(CI_SCRIPTS_DIR)/agent-goose-task.sh"
 
 install:
 	@"$(MAKE)" -C "$(STACK)" install

--- a/schema/fixtures/agent-tasks/impl-validated-goose-002.agent-task.json
+++ b/schema/fixtures/agent-tasks/impl-validated-goose-002.agent-task.json
@@ -1,0 +1,17 @@
+{
+  "task_id": "goose-002",
+  "issue_number": 370,
+  "state": "impl-validated",
+  "slug": "issue-370-agent-work-insights",
+  "worktree_path": ".agents/worktrees/issue-370-agent-work-insights",
+  "heartbeat": {
+    "state": "impl-validated",
+    "updated_at": "2026-05-16T11:30:00Z"
+  },
+  "model": null,
+  "tokens": null,
+  "cost": null,
+  "observation": "make check passed on iteration 1 of 3. All contract, unit, and type-check steps completed without errors.",
+  "why_it_matters": "The implementation is ready for the ship gate. No validation failures remain and no human retries are needed. Review the diff and approve the PR to close this slice.",
+  "what_to_do": "Review the changes in .agents/worktrees/issue-370-agent-work-insights, then push the branch and open a pull request. Run make worktree-cleanup ISSUE_NUMBER=370 after merge."
+}

--- a/scripts/ci/agent-goose-task.sh
+++ b/scripts/ci/agent-goose-task.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# agent-goose-task.sh — local dogfood launcher for goose autonomous tasks.
+#
+# Creates or reuses the canonical worktree for a task, writes an initial
+# .agent-task.json snapshot, and prints the goose invocation command.
+# Does NOT start goose automatically — early dogfooding uses manual
+# approval mode.
+#
+# Usage (via make):
+#   make agent-goose-task ISSUE_NUMBER=123
+#   make agent-goose-task TASK_DESCRIPTION="small docs update" LOCAL_ONLY=true
+#
+# Environment variables:
+#   ISSUE_NUMBER      GitHub issue number (optional; mutually exclusive with TASK_DESCRIPTION)
+#   ISSUE_TITLE       Issue title (optional; used to build the worktree slug)
+#   TASK_DESCRIPTION  Free-form task description (used when no issue number is given)
+#   LOCAL_ONLY        If "true", skip push/PR in the goose run (default: true)
+#   REMOTE            Git remote name (default: upstream)
+#   WORKTREE_ROOT     Root for worktrees (default: .agents/worktrees)
+
+set -euo pipefail
+
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+ISSUE_TITLE="${ISSUE_TITLE:-}"
+TASK_DESCRIPTION="${TASK_DESCRIPTION:-}"
+LOCAL_ONLY="${LOCAL_ONLY:-true}"
+REMOTE="${REMOTE:-upstream}"
+WORKTREE_ROOT="${WORKTREE_ROOT:-.agents/worktrees}"
+
+normalize_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+repo_root="$(normalize_path "${repo_root}")"
+
+# ---------------------------------------------------------------------------
+# Resolve task slug and description
+# ---------------------------------------------------------------------------
+
+if [[ -z "${ISSUE_NUMBER}" && -z "${TASK_DESCRIPTION}" ]]; then
+  printf "ERROR: ISSUE_NUMBER or TASK_DESCRIPTION is required.\n" >&2
+  printf "Usage:\n" >&2
+  printf "  make agent-goose-task ISSUE_NUMBER=123\n" >&2
+  printf "  make agent-goose-task TASK_DESCRIPTION=\"small docs update\"\n" >&2
+  exit 1
+fi
+
+task_id=""
+slug=""
+worktree_abs=""
+
+if [[ -n "${ISSUE_NUMBER}" ]]; then
+  # Fetch title if not provided
+  if [[ -z "${ISSUE_TITLE}" ]] && command -v gh >/dev/null 2>&1; then
+    ISSUE_TITLE="$(gh issue view "${ISSUE_NUMBER}" --json title --jq '.title' 2>/dev/null || true)"
+  fi
+
+  # Build slug: issue-<number>-<title-slug>, max 40 chars
+  title_slug=""
+  if [[ -n "${ISSUE_TITLE}" ]]; then
+    title_slug="$(printf '%s' "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')"
+  fi
+  raw_slug="issue-${ISSUE_NUMBER}-${title_slug}"
+  slug="${raw_slug:0:40}"
+  slug="${slug%-}"  # strip trailing hyphen if truncated mid-word
+
+  task_id="goose-issue-${ISSUE_NUMBER}"
+  worktree_abs="${repo_root}/${WORKTREE_ROOT}/${slug}"
+
+  # Ensure the worktree exists
+  ISSUE_NUMBER="${ISSUE_NUMBER}" ISSUE_TITLE="${ISSUE_TITLE}" \
+    bash "${repo_root}/scripts/ci/worktree-ensure.sh"
+else
+  # Free-form: first 8 words, lowercased, hyphenated, max 40 chars
+  slug="$(printf '%s' "${TASK_DESCRIPTION}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed 's/[^a-z0-9 ]//g' \
+    | awk '{for(i=1;i<=NF&&i<=8;i++) printf "%s%s",$i,(i<NF&&i<8?"-":""); print ""}' \
+    | sed 's/-\+/-/g')"
+  slug="${slug:0:40}"
+  slug="${slug%-}"
+  task_id="goose-${slug}"
+  worktree_abs="${repo_root}/${WORKTREE_ROOT}/${slug}"
+
+  if [[ ! -d "${worktree_abs}" ]]; then
+    branch="task/${slug}"
+    git -C "${repo_root}" worktree add "${worktree_abs}" -b "${branch}" "${REMOTE}/main"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Write initial .agent-task.json snapshot
+# ---------------------------------------------------------------------------
+
+iso_now="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || python3 -c 'import datetime; print(datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+worktree_rel="${WORKTREE_ROOT}/${slug}"
+
+issue_number_json="null"
+if [[ -n "${ISSUE_NUMBER}" ]]; then
+  issue_number_json="${ISSUE_NUMBER}"
+fi
+
+description_display="${TASK_DESCRIPTION:-issue ${ISSUE_NUMBER}}"
+
+cat > "${worktree_abs}/.agent-task.json" << SNAPSHOT
+{
+  "task_id": "${task_id}",
+  "issue_number": ${issue_number_json},
+  "state": "worktree-claimed",
+  "slug": "${slug}",
+  "worktree_path": "${worktree_rel}",
+  "heartbeat": {
+    "state": "worktree-claimed",
+    "updated_at": "${iso_now}"
+  },
+  "model": null,
+  "tokens": null,
+  "cost": null,
+  "observation": "Goose autonomous task started for: ${description_display}",
+  "why_it_matters": "The task is active. Monitor this card to track planning, implementation, and validation progress.",
+  "what_to_do": "Wait for goose to complete its work, then review the worktree at ${worktree_rel} and push the branch when ready."
+}
+SNAPSHOT
+
+printf "\n"
+printf "▶ Worktree ready: %s\n" "${worktree_abs}"
+printf "▶ Snapshot written: %s/.agent-task.json\n" "${worktree_abs}"
+printf "\n"
+printf "To start goose (run in the worktree directory):\n"
+printf "\n"
+if [[ -n "${ISSUE_NUMBER}" ]]; then
+  printf "  cd %s\n" "${worktree_abs}"
+  printf "  goose run \\\n"
+  printf "    --profile .agents/skills/autonomous-task/SKILL.md \\\n"
+  printf "    --input \"issue #%s\" \\\n" "${ISSUE_NUMBER}"
+  if [[ "${LOCAL_ONLY}" == "true" ]]; then
+    printf "    --input \"local_only=true\"\n"
+  fi
+else
+  printf "  cd %s\n" "${worktree_abs}"
+  printf "  goose run \\\n"
+  printf "    --profile .agents/skills/autonomous-task/SKILL.md \\\n"
+  printf "    --input \"%s\" \\\n" "${TASK_DESCRIPTION}"
+  if [[ "${LOCAL_ONLY}" == "true" ]]; then
+    printf "    --input \"local_only=true\"\n"
+  fi
+fi
+printf "\n"
+printf "The IDP portal (/agent-work) will show this task once the BFF is restarted.\n"
+printf "\n"

--- a/stacks/nodejs/react-fastify/rest/Makefile
+++ b/stacks/nodejs/react-fastify/rest/Makefile
@@ -114,7 +114,7 @@ check-contract:
 		OUR_IDP_MOCK_OAUTH_URL="http://127.0.0.1:$(OUR_IDP_OAUTH_MOCK_PORT)" \
 		OUR_IDP_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" \
 		OUR_IDP_BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" \
-		OUR_IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile" \
+		OUR_IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile,agent-work" \
 		OUR_IDP_ROOT_DIR="$(ROOT_DIR)" \
 		uv run python "$(ROOT_DIR)/scripts/ci/run-contract-check.py"; \
 	fi
@@ -130,7 +130,7 @@ e2e:
 		OUR_IDP_BFF_START_CMD='OUR_IDP_API_HOST="$(BFF_TEST_HOST)" OUR_IDP_API_PORT="$(BFF_TEST_PORT)" OUR_IDP_STATUS_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" pnpm run start:bff' \
 		OUR_IDP_WEB_URL="http://$(WEB_TEST_HOST):$(WEB_TEST_PORT)" \
 		OUR_IDP_BFF_URL="http://$(BFF_TEST_HOST):$(BFF_TEST_PORT)" \
-		OUR_IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile" \
+		OUR_IDP_CONTRACT_PROFILES="core,operational,status-profile,ui-profile,agent-work" \
 		OUR_IDP_ROOT_DIR="$(ROOT_DIR)" \
 		bash "$(ROOT_DIR)/scripts/e2e/run-stack-e2e.sh"; \
 	fi

--- a/stacks/nodejs/react-fastify/rest/moon.yml
+++ b/stacks/nodejs/react-fastify/rest/moon.yml
@@ -44,7 +44,7 @@ tasks:
       OUR_IDP_MOCK_OAUTH_URL: "http://127.0.0.1:9000"
       OUR_IDP_WEB_URL: "http://127.0.0.1:3400"
       OUR_IDP_BFF_URL: "http://127.0.0.1:8400"
-      OUR_IDP_CONTRACT_PROFILES: "core,operational,status-profile,ui-profile"
+      OUR_IDP_CONTRACT_PROFILES: "core,operational,status-profile,ui-profile,agent-work"
       OUR_IDP_ROOT_DIR: "../../../.."
   check-ci:
     command: ["bash", "-c", "true"]
@@ -68,7 +68,7 @@ tasks:
       OUR_IDP_BFF_START_CMD: "OUR_IDP_API_HOST=127.0.0.1 OUR_IDP_API_PORT=8400 OUR_IDP_STATUS_WEB_URL=http://127.0.0.1:3400 pnpm run start:bff"
       OUR_IDP_WEB_URL: "http://127.0.0.1:3400"
       OUR_IDP_BFF_URL: "http://127.0.0.1:8400"
-      OUR_IDP_CONTRACT_PROFILES: "core,operational,status-profile,ui-profile"
+      OUR_IDP_CONTRACT_PROFILES: "core,operational,status-profile,ui-profile,agent-work"
       OUR_IDP_ROOT_DIR: "../../../.."
   run-web:
     command: ["pnpm", "run", "start:web"]

--- a/stacks/nodejs/react-fastify/rest/stack.json
+++ b/stacks/nodejs/react-fastify/rest/stack.json
@@ -8,7 +8,8 @@
     "status-profile",
     "ui-profile",
     "auth-profile",
-    "flow-insights"
+    "flow-insights",
+    "agent-work"
   ],
   "capabilities": {
     "status": {
@@ -27,6 +28,9 @@
       ]
     },
     "flowInsights": {
+      "enabled": true
+    },
+    "agentWork": {
       "enabled": true
     }
   }

--- a/tests/src/index.ts
+++ b/tests/src/index.ts
@@ -188,6 +188,7 @@ async function main(): Promise<void> {
     "ui-profile",
     "mcp-profile",
     "auth-profile",
+    "agent-work",
   ];
 
   const context: ContractContext = {

--- a/tests/src/profiles/agent-work.ts
+++ b/tests/src/profiles/agent-work.ts
@@ -1,0 +1,146 @@
+// Layer 2 contract profile for the agent-work capability.
+//
+// Validates GET /api/agent-work/tasks (list) and
+// GET /api/agent-work/tasks/:taskId (detail) on any BFF that declares
+// capabilities.agentWork.enabled = true.
+//
+// The fixture-backed MVP guarantees at least one task (goose-001) is
+// always present. Tests assert on shape and the fixture's known state
+// without hard-coding fragile field values where possible.
+
+import { assert, parseJsonOrThrow } from "../assertions";
+import { request } from "../http";
+import { ensureServiceAvailable } from "../runtime";
+import type { ContractContext, TestCase } from "../types";
+
+const KNOWN_FIXTURE_TASK_ID = "goose-001";
+const KNOWN_FIXTURE_STATE = "impl-validation-failed";
+
+function isAgentWorkEnabled(context: ContractContext): boolean {
+  return context.stackMetadata?.capabilities?.agentWork?.enabled === true;
+}
+
+export function createAgentWorkTests(context: ContractContext): TestCase[] {
+  if (!isAgentWorkEnabled(context)) {
+    return [];
+  }
+
+  const { bffBaseUrl } = context;
+
+  return [
+    {
+      name: "agent-work:list endpoint returns expected shape",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(new URL("/api/agent-work/tasks", bffBaseUrl));
+
+        assert(response.status >= 200 && response.status < 300, `Expected 2xx, got ${response.status}`);
+
+        const contentType = response.headers["content-type"] ?? "";
+        assert(contentType.includes("application/json"), "agent-work list must return application/json");
+
+        const payload = parseJsonOrThrow(response.body) as Record<string, unknown>;
+        assert(typeof payload.generatedAt === "string", "Response must include generatedAt string");
+        assert(typeof payload.total === "number", "Response must include numeric total");
+        assert(Array.isArray(payload.tasks), "Response must include tasks array");
+        assert(
+          (payload.total as number) >= 1,
+          "At least one fixture task must be present (goose-001)",
+        );
+      },
+    },
+    {
+      name: "agent-work:each task in list has required insight fields",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(new URL("/api/agent-work/tasks", bffBaseUrl));
+        const payload = parseJsonOrThrow(response.body) as Record<string, unknown>;
+        const tasks = payload.tasks as Record<string, unknown>[];
+
+        for (const task of tasks) {
+          const id = task.task_id ?? "(unknown)";
+          assert(typeof task.task_id === "string", `task ${id}: task_id must be a string`);
+          assert(typeof task.state === "string", `task ${id}: state must be a string`);
+          assert(typeof task.slug === "string", `task ${id}: slug must be a string`);
+          assert(typeof task.observation === "string", `task ${id}: observation must be a string`);
+          assert(typeof task.why_it_matters === "string", `task ${id}: why_it_matters must be a string`);
+          assert(typeof task.what_to_do === "string", `task ${id}: what_to_do must be a string`);
+          assert(task.observation.length > 0, `task ${id}: observation must not be empty`);
+          assert(task.why_it_matters.length > 0, `task ${id}: why_it_matters must not be empty`);
+          assert(task.what_to_do.length > 0, `task ${id}: what_to_do must not be empty`);
+        }
+      },
+    },
+    {
+      name: "agent-work:detail endpoint returns full task for known fixture",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(
+          new URL(`/api/agent-work/tasks/${KNOWN_FIXTURE_TASK_ID}`, bffBaseUrl),
+        );
+
+        assert(response.status === 200, `Expected 200 for known fixture, got ${response.status}`);
+
+        const payload = parseJsonOrThrow(response.body) as Record<string, unknown>;
+        assert(typeof payload.generatedAt === "string", "Detail response must include generatedAt");
+        assert(typeof payload.task === "object" && payload.task !== null, "Detail response must include task object");
+
+        const task = payload.task as Record<string, unknown>;
+        assert(task.task_id === KNOWN_FIXTURE_TASK_ID, `task_id must be '${KNOWN_FIXTURE_TASK_ID}'`);
+        assert(task.state === KNOWN_FIXTURE_STATE, `state must be '${KNOWN_FIXTURE_STATE}' for fixture goose-001`);
+        assert(typeof task.worktree_path === "string", "task must include worktree_path");
+        assert(typeof task.heartbeat === "object", "task must include heartbeat object");
+      },
+    },
+    {
+      name: "agent-work:null model/tokens/cost are passed through as null",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(
+          new URL(`/api/agent-work/tasks/${KNOWN_FIXTURE_TASK_ID}`, bffBaseUrl),
+        );
+        const payload = parseJsonOrThrow(response.body) as Record<string, unknown>;
+        const task = payload.task as Record<string, unknown>;
+
+        assert(task.model === null, "model must be null when unavailable — must not be synthesized");
+        assert(task.tokens === null, "tokens must be null when unavailable — must not be synthesized");
+        assert(task.cost === null, "cost must be null when unavailable — must not be synthesized");
+      },
+    },
+    {
+      name: "agent-work:detail endpoint returns 404 for unknown task id",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(
+          new URL("/api/agent-work/tasks/does-not-exist-abc123", bffBaseUrl),
+        );
+
+        assert(response.status === 404, `Expected 404 for unknown task, got ${response.status}`);
+
+        const payload = parseJsonOrThrow(response.body) as Record<string, unknown>;
+        assert(typeof payload.error === "string", "404 response must include error field");
+      },
+    },
+    {
+      name: "agent-work:list state filter returns only matching tasks",
+      run: async () => {
+        await ensureServiceAvailable("BFF server", bffBaseUrl);
+        const response = await request(
+          new URL(`/api/agent-work/tasks?state=${KNOWN_FIXTURE_STATE}`, bffBaseUrl),
+        );
+
+        assert(response.status === 200, `Expected 200, got ${response.status}`);
+
+        const payload = parseJsonOrThrow(response.body) as Record<string, unknown>;
+        const tasks = payload.tasks as Record<string, unknown>[];
+
+        for (const task of tasks) {
+          assert(
+            typeof task.state === "string" && task.state.includes(KNOWN_FIXTURE_STATE),
+            `All filtered tasks must match state filter '${KNOWN_FIXTURE_STATE}', got '${String(task.state)}'`,
+          );
+        }
+      },
+    },
+  ];
+}

--- a/tests/src/profiles/index.ts
+++ b/tests/src/profiles/index.ts
@@ -1,3 +1,4 @@
+import { createAgentWorkTests } from "./agent-work";
 import { createAuthProfileTests } from "./auth-profile";
 import { createCoreTests } from "./core";
 import { createFlowInsightsTests } from "./flow-insights";
@@ -30,6 +31,10 @@ export function buildTestsForProfile(profile: ProfileName, context: ContractCont
 
   if (profile === "flow-insights") {
     return createFlowInsightsTests(context);
+  }
+
+  if (profile === "agent-work") {
+    return createAgentWorkTests(context);
   }
 
   return createUiProfileTests(context);

--- a/tests/src/runtime.ts
+++ b/tests/src/runtime.ts
@@ -26,7 +26,8 @@ function isProfileName(value: string): value is ProfileName {
     value === "ui-profile" ||
     value === "mcp-profile" ||
     value === "auth-profile" ||
-    value === "flow-insights"
+    value === "flow-insights" ||
+    value === "agent-work"
   );
 }
 

--- a/tests/src/types.ts
+++ b/tests/src/types.ts
@@ -5,7 +5,8 @@ export type ProfileName =
   | "ui-profile"
   | "mcp-profile"
   | "auth-profile"
-  | "flow-insights";
+  | "flow-insights"
+  | "agent-work";
 
 export type UiMode = "spa" | "ssr" | "server-rendered";
 
@@ -29,6 +30,9 @@ export type StackMetadata = {
       enabled?: boolean;
     };
     flowInsights?: {
+      enabled?: boolean;
+    };
+    agentWork?: {
       enabled?: boolean;
     };
   };


### PR DESCRIPTION
## Summary

- Adds a second agent task fixture (`goose-002`) for the `impl-validated` state to cover the healthy/success card tone path in the Agent Work UI
- Adds the `agent-work` Layer 2 contract test profile with 6 tests covering list shape, required insight fields, detail endpoint, null passthrough, 404 for unknown ID, and state filter
- Registers the `agent-work` profile across all required locations: `types.ts`, `runtime.ts`, `profiles/index.ts`, `index.ts` (orderedProfiles), `moon.yml`, Makefile, and `stack.json`
- Adds `scripts/ci/agent-goose-task.sh` and the `make agent-goose-task` root target for goose dogfood launcher

## Test plan

- [ ] `make check` in `stacks/nodejs/react-fastify/rest` passes (27 unit tests + all 6 agent-work contract tests)
- [ ] `agent-work:list endpoint returns expected shape` passes
- [ ] `agent-work:each task in list has required insight fields` passes
- [ ] `agent-work:detail endpoint returns full task for known fixture` passes
- [ ] `agent-work:null model/tokens/cost are passed through as null` passes
- [ ] `agent-work:detail endpoint returns 404 for unknown task id` passes
- [ ] `agent-work:list state filter returns only matching tasks` passes

Refs #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)