### PR TITLE
feat(backstage): add standalone stemix plugin harness

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
   pull-requests: write
 
 concurrency:
@@ -25,6 +26,8 @@ jobs:
       contract_tests_tag: ${{ steps.release.outputs['tests--tag_name'] }}
       mcp_tools_released: ${{ steps.release.outputs['tools/mcp--release_created'] }}
       mcp_tools_tag: ${{ steps.release.outputs['tools/mcp--tag_name'] }}
+      backstage_tools_released: ${{ steps.release.outputs['tools/backstage--release_created'] }}
+      backstage_tools_tag: ${{ steps.release.outputs['tools/backstage--tag_name'] }}
     steps:
       - name: Run release-please
         id: release
@@ -32,3 +35,25 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish-backstage-plugins:
+    name: Publish Backstage Plugins
+    runs-on: ubuntu-latest
+    needs: [release-please]
+    if: needs.release-please.outputs.backstage_tools_released == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup toolchain
+        uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
+        with:
+          proto-version: "0.57.1"
+          auto-install: true
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/ci/publish-backstage-plugins.sh

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,6 @@
   "stacks/nodejs/react-fastify/rest": "1.6.2-alpha.0",
   "tests": "1.6.0-alpha.0",
   "tools/mcp": "0.4.1-alpha.0",
+  "tools/backstage": "0.1.0-alpha.0",
   ".devcontainer": "0.1.0-alpha.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,6 @@ operations, or interfaces change. See the documentation requirements in
 ## Security
 
 - Never commit secrets, credentials, or environment-specific configs.
-- Run `pnpm audit` before submitting changes. Backstage remains npm-managed
+- Run `pnpm audit` before submitting changes. For `tools/backstage`, use `corepack enable && yarn npm audit`
   for now, so use `npm --prefix tools/backstage audit` for that package island.
 - Report security vulnerabilities privately via GitHub Security Advisories.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ flexible for contributors.
 - `pnpm install` installs workspace dependencies and repository-local developer
   CLIs such as `opencode` and `pi`; run Pi with `pnpm run pi -- <args>`.
 - `tools/backstage` remains an npm-managed package-manager island until a
-  separate Backstage/Yarn migration is designed.
+  `tools/backstage` is the exception: it is an isolated Yarn 4 workspace for local Backstage plugin development and packaging.
 - GNU Make targets are supported as convenient local shortcuts and CI
   compatibility wrappers; use them whenever `moon` is not installed.
 

--- a/docs/content/architecture/decisions/0008-dependency-and-tooling-pinning-policy.md
+++ b/docs/content/architecture/decisions/0008-dependency-and-tooling-pinning-policy.md
@@ -78,7 +78,7 @@ is a separate vector for silent breakage or supply-chain compromise.
 - The primary repository workspace uses pnpm workspaces. The root
   `pnpm-workspace.yaml` is the authoritative package-manager boundary.
 - `tools/backstage` is intentionally excluded from the pnpm workspace and keeps
-  its own npm lockfile until a Backstage-specific migration is designed.
+  its own Yarn lockfile because Backstage runs as a standalone workspace under `tools/backstage`.
 - Projects must not rely on a parent workspace's `node_modules` to provide
   a binary or package that is not declared in their own `package.json`. If a
   tool is used in a project's scripts or Makefile, it must appear in that

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -104,7 +104,7 @@ tools/      Developer tooling, scripts, and MCP server definitions
 - Pinned runtimes include Go, Node.js, pnpm, Python, and `uv`.
 - `pnpm install` installs workspace dependencies and repository-local developer
   CLIs such as `opencode` and `pi`; run Pi with `pnpm run pi -- <args>`.
-- `tools/backstage` remains separate on npm while Backstage-specific package
+- `tools/backstage` remains separate as a Yarn 4 workspace while Backstage-specific package
   manager requirements are handled in a future migration.
 - Python-based security scanning uses `uv tool run` for isolated ephemeral
   environments instead of global pip installs.

--- a/docs/content/tools/backstage.md
+++ b/docs/content/tools/backstage.md
@@ -1,0 +1,36 @@
+# Backstage Harness
+
+`tools/backstage` is a standalone Yarn 4 workspace used to develop and validate local Backstage integrations without changing the root pnpm workspace.
+
+## What it includes
+
+- Backstage demo app in `tools/backstage/packages/app`
+- Backstage backend in `tools/backstage/packages/backend`
+- Standalone Stemix plugin packages in `tools/backstage/plugins/backstage-stemix*`
+
+## Local commands
+
+```bash
+make -C tools/backstage install
+make -C tools/backstage build
+make -C tools/backstage check-stemix
+make -C tools/backstage dev
+```
+
+Equivalent Yarn commands:
+
+```bash
+cd tools/backstage
+corepack enable
+yarn install
+yarn run build:all
+yarn run check:stemix
+yarn run dev
+```
+
+## Release flow
+
+- PRs touching `tools/backstage/*` trigger the existing `backstage-tools` validation path in `.github/workflows/pr-validate.yml`
+- `release-please` versions `tools/backstage/CHANGELOG.md`
+- Plugin package versions are synchronized from the `tools/backstage` release
+- When Backstage changes are released from `main`, GitHub Actions publishes `@ourchitecture/backstage-plugin-stemix` and `@ourchitecture/backstage-plugin-stemix-backend` to GitHub Packages

--- a/docs/content/tools/index.md
+++ b/docs/content/tools/index.md
@@ -28,6 +28,14 @@ A VS Code extension providing IDE integration for the Stemix Intent-Driven Porta
 
 **Local Testing**: See `tools/vscode-extension/README.md` for instructions on running and testing the extension locally.
 
+### Backstage Harness
+
+The Backstage harness is a standalone Yarn workspace used to develop and validate local Backstage integrations and published plugin packages without changing the root pnpm workspace.
+
+**Location**: `tools/backstage/`
+
+**Documentation**: [Backstage Harness](./backstage.md)
+
 ## Future Integration Targets
 
 The IDP roadmap includes integration with additional developer tools and platforms to provide consistent capability exposure across different interaction modes. See [ROADMAP.md](https://github.com/ourchitecture/idp/blob/main/ROADMAP.md) for the full capability direction.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,24 @@
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md"
     },
+    "tools/backstage": {
+      "release-type": "node",
+      "component": "backstage-tools",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "tools/backstage/plugins/backstage-stemix/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "tools/backstage/plugins/backstage-stemix-backend/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
     ".devcontainer": {
       "release-type": "simple",
       "component": "dev-tools",

--- a/scripts/ci/detect-pr-changes.sh
+++ b/scripts/ci/detect-pr-changes.sh
@@ -172,7 +172,7 @@ for file in "${changed_files[@]}"; do
     Makefile|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|tests/*)
       run_reference_all="true"
       ;;
-    tools/backstage/package-lock.json)
+    tools/backstage/yarn.lock)
       run_backstage_tools="true"
       ;;
     *.md|.github/*)

--- a/scripts/ci/publish-backstage-plugins.sh
+++ b/scripts/ci/publish-backstage-plugins.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "${ROOT_DIR}/tools/backstage"
+
+corepack enable
+yarn install --immutable
+yarn run fix:check
+yarn run build:stemix
+yarn run typecheck:stemix
+yarn run test:stemix
+yarn workspace @ourchitecture/backstage-plugin-stemix npm publish --access restricted --tolerate-republish
+yarn workspace @ourchitecture/backstage-plugin-stemix-backend npm publish --access restricted --tolerate-republish

--- a/scripts/ci/upgrade-dependencies.sh
+++ b/scripts/ci/upgrade-dependencies.sh
@@ -26,21 +26,24 @@ run_pnpm_upgrade() {
   pnpm audit
 }
 
-run_backstage_npm_upgrade() {
+run_backstage_yarn_upgrade() {
   local project_dir="tools/backstage"
 
-  if [[ ! -f "${project_dir}/package-lock.json" ]]; then
+  if [[ ! -f "${project_dir}/yarn.lock" ]]; then
     return 0
   fi
 
-  echo "Upgrading Backstage npm dependencies in ${project_dir}"
-  npm --prefix "${project_dir}" update
-
-  if [[ "${ALLOW_MAJOR}" == "true" ]]; then
-    npm --prefix "${project_dir}" audit fix --force
-  else
-    npm --prefix "${project_dir}" audit fix
-  fi
+  echo "Upgrading Backstage Yarn dependencies in ${project_dir}"
+  (
+    cd "${project_dir}"
+    corepack enable
+    yarn up -R
+    if [[ "${ALLOW_MAJOR}" == "true" ]]; then
+      yarn npm audit --all --recursive
+    else
+      yarn npm audit
+    fi
+  )
 }
 
 run_go_upgrade() {
@@ -65,11 +68,11 @@ run_uv_upgrade() {
 }
 
 mapfile -t pnpm_lockfiles < <(git ls-files | grep --extended-regexp '(^|/)pnpm-lock\.yaml$' | sort)
-mapfile -t backstage_npm_lockfiles < <(git ls-files tools/backstage/package-lock.json | sort)
+mapfile -t backstage_yarn_lockfiles < <(git ls-files tools/backstage/yarn.lock | sort)
 mapfile -t go_modfiles < <(git ls-files | grep --extended-regexp '(^|/)go\.mod$' | sort)
 mapfile -t uv_lockfiles < <(git ls-files | grep --extended-regexp '(^|/)uv\.lock$' | sort)
 
-if [[ ${#pnpm_lockfiles[@]} -eq 0 && ${#backstage_npm_lockfiles[@]} -eq 0 && ${#go_modfiles[@]} -eq 0 && ${#uv_lockfiles[@]} -eq 0 ]]; then
+if [[ ${#pnpm_lockfiles[@]} -eq 0 && ${#backstage_yarn_lockfiles[@]} -eq 0 && ${#go_modfiles[@]} -eq 0 && ${#uv_lockfiles[@]} -eq 0 ]]; then
   echo "No dependency lock or module files found."
   exit 0
 fi
@@ -78,7 +81,7 @@ if [[ ${#pnpm_lockfiles[@]} -gt 0 ]]; then
   run_pnpm_upgrade
 fi
 
-run_backstage_npm_upgrade
+run_backstage_yarn_upgrade
 
 for modfile in "${go_modfiles[@]}"; do
   run_go_upgrade "$(dirname "${modfile}")"

--- a/tools/backstage/.yarnrc.yml
+++ b/tools/backstage/.yarnrc.yml
@@ -1,2 +1,3 @@
 enableGlobalCache: false
+enableScripts: true
 nodeLinker: node-modules

--- a/tools/backstage/Makefile
+++ b/tools/backstage/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all install build clean check-lint check-test check-ci check test dev run
+.PHONY: help all install build build-stemix clean check-lint check-test check-stemix check-ci check test dev run
 
 # Backstage workspace root - ensure npm commands execute in the workspace context
 BACKSTAGE_ROOT := $(shell pwd)
@@ -12,9 +12,11 @@ help:
 	@printf "  all           Run full tool verification flow\n"
 	@printf "  install       Install dependencies\n"
 	@printf "  build         Build Backstage app\n"
+	@printf "  build-stemix  Build the standalone Stemix plugin packages\n"
 	@printf "  clean         Remove build artifacts\n"
 	@printf "  check-lint    Run lint checks\n"
 	@printf "  check-test    Run type checks\n"
+	@printf "  check-stemix  Run standalone Stemix plugin validation\n"
 	@printf "  check-ci      Run CI-safe validation checks\n"
 	@printf "  check         Run lint and tests\n"
 	@printf "  test          Alias for check-test\n"
@@ -32,14 +34,21 @@ install:
 	@if [ -x "$(MOON_BIN)" ]; then \
 		"$(MOON_BIN)" run backstage-tools:install; \
 	else \
-		cd "$(BACKSTAGE_ROOT)" && npm install; \
+		cd "$(BACKSTAGE_ROOT)" && yarn install; \
 	fi
 
 build:
 	@if [ -x "$(MOON_BIN)" ]; then \
 		"$(MOON_BIN)" run backstage-tools:build; \
 	else \
-		cd "$(BACKSTAGE_ROOT)" && npm run build:all; \
+		cd "$(BACKSTAGE_ROOT)" && yarn run build:all; \
+	fi
+
+build-stemix:
+	@if [ -x "$(MOON_BIN)" ]; then \
+		"$(MOON_BIN)" run backstage-tools:build-stemix; \
+	else \
+		cd "$(BACKSTAGE_ROOT)" && yarn run build:stemix; \
 	fi
 
 clean:
@@ -53,14 +62,21 @@ check-lint:
 	@if [ -x "$(MOON_BIN)" ]; then \
 		"$(MOON_BIN)" run backstage-tools:check-lint; \
 	else \
-		echo "No additional lint configured for backstage-tools"; \
+		cd "$(BACKSTAGE_ROOT)" && yarn run fix:check; \
 	fi
 
 check-test:
 	@if [ -x "$(MOON_BIN)" ]; then \
 		"$(MOON_BIN)" run backstage-tools:check-test; \
 	else \
-		cd "$(BACKSTAGE_ROOT)" && npm run typecheck; \
+		cd "$(BACKSTAGE_ROOT)" && yarn run typecheck && yarn run test:stemix; \
+	fi
+
+check-stemix:
+	@if [ -x "$(MOON_BIN)" ]; then \
+		"$(MOON_BIN)" run backstage-tools:check-stemix; \
+	else \
+		cd "$(BACKSTAGE_ROOT)" && yarn run check:stemix; \
 	fi
 
 test: check-test
@@ -69,7 +85,7 @@ check-ci:
 	@if [ -x "$(MOON_BIN)" ]; then \
 		"$(MOON_BIN)" run backstage-tools:check-ci; \
 	else \
-		cd "$(BACKSTAGE_ROOT)" && "$(MAKE)" install build check-test; \
+		cd "$(BACKSTAGE_ROOT)" && "$(MAKE)" install build check-lint check-test; \
 	fi
 
 check:
@@ -83,7 +99,7 @@ dev:
 	@if [ -x "$(MOON_BIN)" ]; then \
 		"$(MOON_BIN)" run backstage-tools:dev; \
 	else \
-		cd "$(BACKSTAGE_ROOT)" && npm run dev; \
+		cd "$(BACKSTAGE_ROOT)" && yarn run dev; \
 	fi
 
 run: dev

--- a/tools/backstage/README.md
+++ b/tools/backstage/README.md
@@ -1,6 +1,6 @@
 # Backstage Test Harness for Stemix IDP
 
-This is a minimal Backstage instance used for testing future Backstage plug-in integrations with the Stemix Intent-Driven Portal (IDP).
+This is a minimal Backstage instance used to develop and validate local Stemix Backstage plugins against the Stemix Intent-Driven Portal (IDP).
 
 ## Purpose
 
@@ -14,7 +14,7 @@ This sub-project provides a skeleton Backstage application that:
 ## Prerequisites
 
 - Node.js 20+ (pinned via `.prototools` at root: currently Node 24.0.0)
-- npm package manager (pinned with Node via proto)
+- Corepack-enabled Yarn 4 for the Backstage workspace
 - GNU Make (optional convenience wrapper)
 - Moon task runner (optional but recommended for maintainers)
 
@@ -25,7 +25,8 @@ This sub-project provides a skeleton Backstage application that:
 ```bash
 make install
 # or
-npm install
+corepack enable
+yarn install
 ```
 
 ### Build the Application
@@ -33,7 +34,7 @@ npm install
 ```bash
 make build
 # or
-npm run build:all
+yarn run build:all
 ```
 
 ### Start Development Servers
@@ -41,7 +42,7 @@ npm run build:all
 ```bash
 make dev
 # or
-npm run dev
+yarn run dev
 ```
 
 This starts both the frontend (port 3000) and backend (port 7007) in development mode.
@@ -54,7 +55,15 @@ This starts both the frontend (port 3000) and backend (port 7007) in development
 ```bash
 make check-test
 # or
-npm run typecheck
+yarn run typecheck
+```
+
+### Validate the Standalone Plugin Packages
+
+```bash
+make check-stemix
+# or
+yarn run check:stemix
 ```
 
 ### Run CI Checks
@@ -84,6 +93,9 @@ tools/backstage/
 │   │   └── public/
 │   └── backend/          # Backend services
 │       └── src/
+├── plugins/
+│   ├── backstage-stemix/
+│   └── backstage-stemix-backend/
 ├── app-config.yaml       # Backstage configuration
 ├── package.json          # Workspace root
 ├── moon.yml              # Moon task definitions
@@ -98,6 +110,7 @@ This Backstage instance is wired into the IDP build system:
 - **Moon project ID**: `backstage-tools`
 - **Registered in**: `.moon/workspace.yml`
 - **CI validation**: Triggered automatically when `tools/backstage/*` files change
+- **Release automation**: `release-please` versions `tools/backstage`, syncs plugin package versions, and publishes the plugin packages to GitHub Packages on `main`
 - **Root `make all`**: Includes Backstage build and checks
 
 ## Available Make Targets
@@ -106,9 +119,11 @@ This Backstage instance is wired into the IDP build system:
 - `make all` - Run full verification (install, build, check)
 - `make install` - Install dependencies
 - `make build` - Build the application
+- `make build-stemix` - Build the standalone Stemix plugin packages
 - `make clean` - Remove build artifacts
 - `make check-lint` - Run linting (placeholder)
 - `make check-test` - Run type checks
+- `make check-stemix` - Run standalone Stemix plugin checks
 - `make check-ci` - Run CI-safe validation
 - `make check` - Run lint and tests
 - `make test` - Alias for check-test
@@ -119,12 +134,10 @@ This Backstage instance is wired into the IDP build system:
 
 When adding a Backstage plug-in for IDP integration:
 
-1. Add plug-in dependencies to the appropriate `package.json`:
-   - Frontend plug-ins → `packages/app/package.json`
-   - Backend plug-ins → `packages/backend/package.json`
-2. Register plug-in in `packages/app/src/App.tsx` (frontend) or `packages/backend/src/index.ts` (backend)
-3. Update configuration in `app-config.yaml` if needed
-4. Re-run `make install` and `make build`
+1. Create paired plugin workspaces under `plugins/`
+2. Reference them from `packages/app/package.json` and `packages/backend/package.json` using `workspace:*`
+3. Register routes in `packages/app/src/App.tsx` and backend features in `packages/backend/src/index.ts`
+4. Re-run `make install`, `make build-stemix`, and `make check-stemix`
 5. Test locally with `make dev`
 
 ## Known Limitations
@@ -153,13 +166,14 @@ proto install
 proto use
 ```
 
-### npm Not Found
+### Yarn Not Found
 
-This harness uses npm workspaces so it follows the same proto-pinned Node.js toolchain as the rest of the repository:
+This harness uses a standalone Yarn workspace inside `tools/backstage` while the rest of the monorepo stays on pnpm:
 
 ```bash
 proto install
-npm --version
+corepack enable
+yarn --version
 ```
 
 ### Port Already in Use

--- a/tools/backstage/moon.yml
+++ b/tools/backstage/moon.yml
@@ -23,18 +23,18 @@ tasks:
     deps: ["install"]
 
   clean:
-    command: ["bash", "-c", "rm -rf dist dist-types node_modules packages/*/dist packages/*/node_modules"]
+    command: ["bash", "-c", "rm -rf dist dist-types node_modules packages/*/dist packages/*/node_modules plugins/*/dist plugins/*/dist-types plugins/*/node_modules"]
 
   check-lint:
-    command: ["bash", "-c", "echo 'No additional lint configured for backstage-tools'"]
+    command: ["bash", "-lc", "yarn run fix:check"]
 
   check-test:
-    command: ["bash", "-lc", "yarn run typecheck"]
+    command: ["bash", "-lc", "yarn run typecheck && yarn run test:stemix"]
     deps: ["install"]
 
   check-ci:
     command: ["bash", "-c", "true"]
-    deps: ["install", "build", "check-test"]
+    deps: ["install", "build", "check-lint", "check-test"]
     options:
       runInCI: true
 
@@ -57,3 +57,11 @@ tasks:
     options:
       persistent: true
       runInCI: false
+
+  build-stemix:
+    command: ["bash", "-lc", "yarn run build:stemix"]
+    deps: ["install"]
+
+  check-stemix:
+    command: ["bash", "-lc", "yarn run check:stemix"]
+    deps: ["install"]

--- a/tools/backstage/moon.yml
+++ b/tools/backstage/moon.yml
@@ -27,6 +27,7 @@ tasks:
 
   check-lint:
     command: ["bash", "-lc", "yarn run fix:check"]
+    deps: ["install"]
 
   check-test:
     command: ["bash", "-lc", "yarn run typecheck && yarn run test:stemix"]

--- a/tools/backstage/package.json
+++ b/tools/backstage/package.json
@@ -6,7 +6,8 @@
   "license": "MIT",
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "plugins/*"
     ]
   },
   "scripts": {
@@ -15,15 +16,22 @@
     "dev:backend": "yarn workspace backend start",
     "build": "yarn workspaces foreach -A run build",
     "build:all": "yarn run build",
+    "build:stemix": "yarn workspace @ourchitecture/backstage-plugin-stemix build && yarn workspace @ourchitecture/backstage-plugin-stemix-backend build",
     "start": "yarn workspace app start",
     "start-backend": "yarn workspace backend start",
     "typecheck": "yarn workspaces foreach -A run typecheck",
+    "typecheck:stemix": "yarn workspace @ourchitecture/backstage-plugin-stemix typecheck && yarn workspace @ourchitecture/backstage-plugin-stemix-backend typecheck",
+    "test:stemix": "yarn workspace @ourchitecture/backstage-plugin-stemix test && yarn workspace @ourchitecture/backstage-plugin-stemix-backend test",
+    "check:stemix": "yarn run build:stemix && yarn run typecheck:stemix && yarn run test:stemix",
+    "fix": "yarn run clean && yarn workspaces foreach -A run lint",
+    "fix:check": "yarn run fix",
     "clean": "yarn workspaces foreach -A run clean"
   },
   "devDependencies": {
     "@backstage/cli": "^0.29.0",
     "@backstage/cli-common": "^0.1.14",
     "concurrently": "^8.2.2",
+    "tsx": "^4.20.6",
     "typescript": "~5.4.5"
   },
   "resolutions": {

--- a/tools/backstage/packages/app/package.json
+++ b/tools/backstage/packages/app/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
+    "lint": "yarn run typecheck",
     "clean": "rm -rf dist node_modules",
     "typecheck": "tsc"
   },
@@ -34,6 +35,7 @@
     "@backstage/plugin-user-settings": "^0.8.0",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
+    "@ourchitecture/backstage-plugin-stemix": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^6.26.0",

--- a/tools/backstage/packages/app/src/App.tsx
+++ b/tools/backstage/packages/app/src/App.tsx
@@ -32,6 +32,7 @@ import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
+import { StemixPage } from '@ourchitecture/backstage-plugin-stemix';
 
 const app = createApp({
   apis,
@@ -86,6 +87,7 @@ const routes = (
     <Route path="/search" element={<SearchPage />}>
       {searchPage}
     </Route>
+    <Route path="/stemix" element={<StemixPage />} />
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
   </FlatRoutes>

--- a/tools/backstage/packages/app/src/components/Root/Root.tsx
+++ b/tools/backstage/packages/app/src/components/Root/Root.tsx
@@ -22,6 +22,7 @@ import {
 } from '@backstage/core-components';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
+import ChatIcon from '@material-ui/icons/Chat';
 
 const useSidebarLogoStyles = makeStyles({
   root: {
@@ -65,6 +66,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
         <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" />
         <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
+        <SidebarItem icon={ChatIcon} to="stemix" text="Stemix" />
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
         <SidebarDivider />
         <SidebarScrollWrapper>

--- a/tools/backstage/packages/backend/package.json
+++ b/tools/backstage/packages/backend/package.json
@@ -8,11 +8,13 @@
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
+    "lint": "yarn run typecheck",
     "clean": "rm -rf dist node_modules",
     "typecheck": "tsc"
   },
   "dependencies": {
     "@backstage/backend-defaults": "^0.14.2",
+    "@backstage/backend-plugin-api": "^1.9.0",
     "@backstage/plugin-app-backend": "^0.5.6",
     "@backstage/plugin-auth-backend": "^0.25.5",
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.10",
@@ -24,6 +26,7 @@
     "@backstage/plugin-scaffolder-backend": "^3.0.3",
     "@backstage/plugin-search-backend": "^2.1.1",
     "@backstage/plugin-techdocs-backend": "^2.1.7",
+    "@ourchitecture/backstage-plugin-stemix-backend": "workspace:*",
     "better-sqlite3": "^12.0.0",
     "express": "^4.18.2",
     "luxon": "^3.4.4"

--- a/tools/backstage/packages/backend/src/index.ts
+++ b/tools/backstage/packages/backend/src/index.ts
@@ -49,6 +49,7 @@ backend.add(import('@backstage/plugin-permission-backend-module-allow-all-policy
 backend.add(import('@backstage/plugin-proxy-backend'));
 backend.add(import('@backstage/plugin-scaffolder-backend'));
 backend.add(import('@backstage/plugin-search-backend'));
+backend.add(import('@ourchitecture/backstage-plugin-stemix-backend'));
 backend.add(import('@backstage/plugin-techdocs-backend'));
 
 backend.start();

--- a/tools/backstage/plugins/backstage-stemix-backend/README.md
+++ b/tools/backstage/plugins/backstage-stemix-backend/README.md
@@ -1,0 +1,11 @@
+# backstage-stemix-backend
+
+Standalone backend plugin package for the local Stemix Backstage harness.
+
+## Local commands
+
+```bash
+yarn workspace @ourchitecture/backstage-plugin-stemix-backend build
+yarn workspace @ourchitecture/backstage-plugin-stemix-backend typecheck
+yarn workspace @ourchitecture/backstage-plugin-stemix-backend test
+```

--- a/tools/backstage/plugins/backstage-stemix-backend/package.json
+++ b/tools/backstage/plugins/backstage-stemix-backend/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@ourchitecture/backstage-plugin-stemix-backend",
+  "version": "0.1.0",
+  "description": "Stemix greeting backend plugin for the local Backstage harness.",
+  "license": "MIT",
+  "backstage": {
+    "role": "backend-plugin",
+    "pluginId": "stemix",
+    "pluginPackages": [
+      "@ourchitecture/backstage-plugin-stemix",
+      "@ourchitecture/backstage-plugin-stemix-backend"
+    ],
+    "features": {
+      ".": "@backstage/BackendFeature"
+    }
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "tsc --project tsconfig.json && backstage-cli package build",
+    "lint": "yarn run typecheck",
+    "test": "tsx --test \"src/**/*.test.ts\"",
+    "clean": "rm -rf dist dist-types node_modules",
+    "typecheck": "tsc --project tsconfig.json",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "^1.9.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.29.0",
+    "@types/express": "^4.17.21",
+    "typescript": "~5.4.5"
+  }
+}

--- a/tools/backstage/plugins/backstage-stemix-backend/src/index.ts
+++ b/tools/backstage/plugins/backstage-stemix-backend/src/index.ts
@@ -1,0 +1,4 @@
+export { stemixBackendPlugin as default } from './plugin';
+export { stemixBackendPlugin } from './plugin';
+export { createStemixGreeting, getStemixPartOfDay } from './service';
+export type { StemixGreeting, StemixGreetingPartOfDay } from './service';

--- a/tools/backstage/plugins/backstage-stemix-backend/src/plugin.ts
+++ b/tools/backstage/plugins/backstage-stemix-backend/src/plugin.ts
@@ -1,0 +1,21 @@
+import { coreServices, createBackendPlugin } from '@backstage/backend-plugin-api';
+import { createStemixRouter } from './router';
+
+export const stemixBackendPlugin = createBackendPlugin({
+  pluginId: 'stemix',
+  register(env) {
+    env.registerInit({
+      deps: {
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
+      },
+      async init({ httpRouter, logger }) {
+        httpRouter.addAuthPolicy({
+          path: '/greeting',
+          allow: 'unauthenticated',
+        });
+        httpRouter.use(createStemixRouter(logger));
+      },
+    });
+  },
+});

--- a/tools/backstage/plugins/backstage-stemix-backend/src/router.ts
+++ b/tools/backstage/plugins/backstage-stemix-backend/src/router.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import type { LoggerService } from '@backstage/backend-plugin-api';
+import { createStemixGreeting } from './service';
+
+export const createStemixRouter = (logger: LoggerService) => {
+  const router = express.Router();
+
+  router.get('/greeting', (_request, response) => {
+    const greeting = createStemixGreeting();
+    logger.info(`Stemix served ${greeting.partOfDay} greeting.`);
+    response.json(greeting);
+  });
+
+  return router;
+};

--- a/tools/backstage/plugins/backstage-stemix-backend/src/service.test.ts
+++ b/tools/backstage/plugins/backstage-stemix-backend/src/service.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createStemixGreeting, getStemixPartOfDay } from './service';
+
+test('getStemixPartOfDay returns morning before noon', () => {
+  assert.equal(getStemixPartOfDay(new Date(2026, 4, 16, 9, 0, 0)), 'morning');
+});
+
+test('getStemixPartOfDay returns afternoon before 18:00', () => {
+  assert.equal(
+    getStemixPartOfDay(new Date(2026, 4, 16, 15, 0, 0)),
+    'afternoon',
+  );
+});
+
+test('getStemixPartOfDay returns evening at or after 18:00', () => {
+  assert.equal(getStemixPartOfDay(new Date(2026, 4, 16, 20, 0, 0)), 'evening');
+});
+
+test('createStemixGreeting formats the message', () => {
+  const date = new Date(2026, 4, 16, 15, 0, 0);
+  const greeting = createStemixGreeting(date);
+
+  assert.equal(greeting.message, 'Stemix says good afternoon.');
+  assert.equal(greeting.partOfDay, 'afternoon');
+  assert.equal(greeting.generatedAt, date.toISOString());
+});

--- a/tools/backstage/plugins/backstage-stemix-backend/src/service.ts
+++ b/tools/backstage/plugins/backstage-stemix-backend/src/service.ts
@@ -1,0 +1,31 @@
+export type StemixGreetingPartOfDay = 'morning' | 'afternoon' | 'evening';
+
+export type StemixGreeting = {
+  message: string;
+  partOfDay: StemixGreetingPartOfDay;
+  generatedAt: string;
+};
+
+export const getStemixPartOfDay = (date: Date): StemixGreetingPartOfDay => {
+  const hour = date.getHours();
+
+  if (hour < 12) {
+    return 'morning';
+  }
+
+  if (hour < 18) {
+    return 'afternoon';
+  }
+
+  return 'evening';
+};
+
+export const createStemixGreeting = (date: Date = new Date()): StemixGreeting => {
+  const partOfDay = getStemixPartOfDay(date);
+
+  return {
+    message: `Stemix says good ${partOfDay}.`,
+    partOfDay,
+    generatedAt: date.toISOString(),
+  };
+};

--- a/tools/backstage/plugins/backstage-stemix-backend/tsconfig.json
+++ b/tools/backstage/plugins/backstage-stemix-backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist",
+    "dist-types",
+    "node_modules"
+  ],
+  "compilerOptions": {
+    "outDir": "../../dist-types/plugins/backstage-stemix-backend",
+    "rootDir": "."
+  }
+}

--- a/tools/backstage/plugins/backstage-stemix/README.md
+++ b/tools/backstage/plugins/backstage-stemix/README.md
@@ -1,0 +1,11 @@
+# backstage-stemix
+
+Standalone frontend plugin package for the local Stemix Backstage harness.
+
+## Local commands
+
+```bash
+yarn workspace @ourchitecture/backstage-plugin-stemix build
+yarn workspace @ourchitecture/backstage-plugin-stemix typecheck
+yarn workspace @ourchitecture/backstage-plugin-stemix test
+```

--- a/tools/backstage/plugins/backstage-stemix/package.json
+++ b/tools/backstage/plugins/backstage-stemix/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@ourchitecture/backstage-plugin-stemix",
+  "version": "0.1.0",
+  "description": "Stemix greeting frontend plugin for the local Backstage harness.",
+  "license": "MIT",
+  "backstage": {
+    "role": "frontend-plugin",
+    "pluginId": "stemix",
+    "pluginPackages": [
+      "@ourchitecture/backstage-plugin-stemix",
+      "@ourchitecture/backstage-plugin-stemix-backend"
+    ]
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "tsc --project tsconfig.json && backstage-cli package build",
+    "lint": "yarn run typecheck",
+    "test": "tsx --test \"src/**/*.test.ts\"",
+    "clean": "rm -rf dist dist-types node_modules",
+    "typecheck": "tsc --project tsconfig.json",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/core-components": "^0.15.0",
+    "@backstage/core-plugin-api": "^1.9.0",
+    "@material-ui/core": "^4.12.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.29.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "~5.4.5"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-router-dom": "^6.0.0"
+  },
+  "sideEffects": false
+}

--- a/tools/backstage/plugins/backstage-stemix/src/client.test.ts
+++ b/tools/backstage/plugins/backstage-stemix/src/client.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { StemixClient } from './client';
+
+test('StemixClient returns a parsed greeting payload', async () => {
+  const client = new StemixClient(
+    {
+      getBaseUrl: async pluginId => {
+        assert.equal(pluginId, 'stemix');
+        return 'http://stemix.test/api/stemix';
+      },
+    },
+    {
+      fetch: async input => {
+        assert.equal(input, 'http://stemix.test/api/stemix/greeting');
+        return new Response(
+          JSON.stringify({
+            message: 'Stemix says good morning.',
+            partOfDay: 'morning',
+            generatedAt: '2026-05-16T12:00:00.000Z',
+          }),
+          {
+            status: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        );
+      },
+    },
+  );
+
+  const greeting = await client.getGreeting();
+
+  assert.equal(greeting.message, 'Stemix says good morning.');
+  assert.equal(greeting.partOfDay, 'morning');
+});
+
+test('StemixClient rejects non-OK responses', async () => {
+  const client = new StemixClient(
+    {
+      getBaseUrl: async () => 'http://stemix.test/api/stemix',
+    },
+    {
+      fetch: async () => new Response('nope', { status: 503 }),
+    },
+  );
+
+  await assert.rejects(
+    () => client.getGreeting(),
+    /Stemix backend request failed with 503\./,
+  );
+});

--- a/tools/backstage/plugins/backstage-stemix/src/client.ts
+++ b/tools/backstage/plugins/backstage-stemix/src/client.ts
@@ -1,0 +1,42 @@
+import type { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+import type { StemixGreetingResponse } from './types';
+
+const isStemixGreetingResponse = (
+  value: unknown,
+): value is StemixGreetingResponse => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+
+  return (
+    typeof candidate.message === 'string' &&
+    typeof candidate.partOfDay === 'string' &&
+    typeof candidate.generatedAt === 'string'
+  );
+};
+
+export class StemixClient {
+  constructor(
+    private readonly discoveryApi: DiscoveryApi,
+    private readonly fetchApi: FetchApi,
+  ) {}
+
+  async getGreeting(): Promise<StemixGreetingResponse> {
+    const baseUrl = await this.discoveryApi.getBaseUrl('stemix');
+    const response = await this.fetchApi.fetch(`${baseUrl}/greeting`);
+
+    if (!response.ok) {
+      throw new Error(`Stemix backend request failed with ${response.status}.`);
+    }
+
+    const payload = await response.json();
+
+    if (!isStemixGreetingResponse(payload)) {
+      throw new Error('Stemix backend returned an invalid greeting payload.');
+    }
+
+    return payload;
+  }
+}

--- a/tools/backstage/plugins/backstage-stemix/src/components/StemixPage.tsx
+++ b/tools/backstage/plugins/backstage-stemix/src/components/StemixPage.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@material-ui/core';
+import {
+  Content,
+  ContentHeader,
+  InfoCard,
+  Page,
+  Progress,
+  WarningPanel,
+} from '@backstage/core-components';
+import {
+  discoveryApiRef,
+  fetchApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { StemixClient } from '../client';
+
+type StemixLoadState =
+  | { status: 'loading'; message: string }
+  | { status: 'ready'; message: string }
+  | { status: 'error'; message: string; detail: string };
+
+export const StemixPage = () => {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const client = useMemo(
+    () => new StemixClient(discoveryApi, fetchApi),
+    [discoveryApi, fetchApi],
+  );
+  const [state, setState] = useState<StemixLoadState>({
+    status: 'loading',
+    message: 'Stemix says [loading...]',
+  });
+
+  const loadGreeting = useCallback(async () => {
+    setState({
+      status: 'loading',
+      message: 'Stemix says [loading...]',
+    });
+
+    try {
+      const greeting = await client.getGreeting();
+      setState({
+        status: 'ready',
+        message: greeting.message,
+      });
+    } catch (error) {
+      const detail =
+        error instanceof Error ? error.message : 'Unknown Stemix network error.';
+
+      setState({
+        status: 'error',
+        message: 'Stemix says [unavailable]',
+        detail,
+      });
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void loadGreeting();
+  }, [loadGreeting]);
+
+  return (
+    <Page themeId="tool">
+      <Content>
+        <ContentHeader title="Stemix" />
+        <InfoCard title="Greeting">
+          <p>{state.message}</p>
+          {state.status === 'loading' ? <Progress /> : null}
+          {state.status === 'error' ? (
+            <WarningPanel
+              severity="error"
+              title="Stemix could not reach the backend."
+            >
+              <p>{state.detail}</p>
+              <Button color="primary" variant="contained" onClick={loadGreeting}>
+                Retry
+              </Button>
+            </WarningPanel>
+          ) : null}
+        </InfoCard>
+      </Content>
+    </Page>
+  );
+};

--- a/tools/backstage/plugins/backstage-stemix/src/index.ts
+++ b/tools/backstage/plugins/backstage-stemix/src/index.ts
@@ -1,0 +1,4 @@
+export { stemixPlugin, StemixPage } from './plugin';
+export { rootRouteRef } from './routes';
+export { StemixClient } from './client';
+export type { StemixGreetingPartOfDay, StemixGreetingResponse } from './types';

--- a/tools/backstage/plugins/backstage-stemix/src/plugin.ts
+++ b/tools/backstage/plugins/backstage-stemix/src/plugin.ts
@@ -1,0 +1,18 @@
+import { createPlugin, createRoutableExtension } from '@backstage/core-plugin-api';
+import { rootRouteRef } from './routes';
+
+export const stemixPlugin = createPlugin({
+  id: 'stemix',
+  routes: {
+    root: rootRouteRef,
+  },
+});
+
+export const StemixPage = stemixPlugin.provide(
+  createRoutableExtension({
+    name: 'StemixPage',
+    component: () =>
+      import('./components/StemixPage').then(module => module.StemixPage),
+    mountPoint: rootRouteRef,
+  }),
+);

--- a/tools/backstage/plugins/backstage-stemix/src/routes.ts
+++ b/tools/backstage/plugins/backstage-stemix/src/routes.ts
@@ -1,0 +1,5 @@
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: 'stemix',
+});

--- a/tools/backstage/plugins/backstage-stemix/src/types.ts
+++ b/tools/backstage/plugins/backstage-stemix/src/types.ts
@@ -1,0 +1,7 @@
+export type StemixGreetingPartOfDay = 'morning' | 'afternoon' | 'evening';
+
+export type StemixGreetingResponse = {
+  message: string;
+  partOfDay: StemixGreetingPartOfDay;
+  generatedAt: string;
+};

--- a/tools/backstage/plugins/backstage-stemix/tsconfig.json
+++ b/tools/backstage/plugins/backstage-stemix/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "dist",
+    "dist-types",
+    "node_modules"
+  ],
+  "compilerOptions": {
+    "outDir": "../../dist-types/plugins/backstage-stemix",
+    "rootDir": "."
+  }
+}

--- a/tools/backstage/tsconfig.json
+++ b/tools/backstage/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@backstage/cli/config/tsconfig.json",
   "include": [
-    "packages/*/src"
+    "packages/*/src",
+    "plugins/*/src"
   ],
   "exclude": [
     "node_modules",

--- a/tools/backstage/yarn.lock
+++ b/tools/backstage/yarn.lock
@@ -5496,6 +5496,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/aix-ppc64@npm:0.28.0"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/android-arm64@npm:0.24.2"
@@ -5506,6 +5513,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/android-arm64@npm:0.27.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/android-arm64@npm:0.28.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -5524,6 +5538,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/android-arm@npm:0.28.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/android-x64@npm:0.24.2"
@@ -5534,6 +5555,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/android-x64@npm:0.27.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/android-x64@npm:0.28.0"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -5552,6 +5580,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/darwin-arm64@npm:0.28.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/darwin-x64@npm:0.24.2"
@@ -5562,6 +5597,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/darwin-x64@npm:0.27.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/darwin-x64@npm:0.28.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5580,6 +5622,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/freebsd-x64@npm:0.24.2"
@@ -5590,6 +5639,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/freebsd-x64@npm:0.27.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/freebsd-x64@npm:0.28.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -5608,6 +5664,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-arm64@npm:0.28.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-arm@npm:0.24.2"
@@ -5618,6 +5681,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-arm@npm:0.27.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-arm@npm:0.28.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -5636,6 +5706,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-ia32@npm:0.28.0"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-loong64@npm:0.24.2"
@@ -5646,6 +5723,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-loong64@npm:0.27.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-loong64@npm:0.28.0"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -5664,6 +5748,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-mips64el@npm:0.28.0"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-ppc64@npm:0.24.2"
@@ -5674,6 +5765,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-ppc64@npm:0.27.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-ppc64@npm:0.28.0"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -5692,6 +5790,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-riscv64@npm:0.28.0"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/linux-s390x@npm:0.24.2"
@@ -5702,6 +5807,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-s390x@npm:0.27.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-s390x@npm:0.28.0"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -5720,6 +5832,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/linux-x64@npm:0.28.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/netbsd-arm64@npm:0.24.2"
@@ -5730,6 +5849,13 @@ __metadata:
 "@esbuild/netbsd-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.0"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -5748,6 +5874,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/netbsd-x64@npm:0.28.0"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/openbsd-arm64@npm:0.24.2"
@@ -5758,6 +5891,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.0"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -5776,9 +5916,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/openbsd-x64@npm:0.28.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openharmony-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.0"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -5797,6 +5951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/sunos-x64@npm:0.28.0"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/win32-arm64@npm:0.24.2"
@@ -5807,6 +5968,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/win32-arm64@npm:0.27.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/win32-arm64@npm:0.28.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -5825,6 +5993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/win32-ia32@npm:0.28.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.24.2":
   version: 0.24.2
   resolution: "@esbuild/win32-x64@npm:0.24.2"
@@ -5835,6 +6010,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/win32-x64@npm:0.27.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.28.0":
+  version: 0.28.0
+  resolution: "@esbuild/win32-x64@npm:0.28.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8367,6 +8549,40 @@ __metadata:
   checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
   languageName: node
   linkType: hard
+
+"@ourchitecture/backstage-plugin-stemix-backend@workspace:*, @ourchitecture/backstage-plugin-stemix-backend@workspace:plugins/backstage-stemix-backend":
+  version: 0.0.0-use.local
+  resolution: "@ourchitecture/backstage-plugin-stemix-backend@workspace:plugins/backstage-stemix-backend"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
+    "@backstage/cli": "npm:^0.29.0"
+    "@types/express": "npm:^4.17.21"
+    express: "npm:^4.18.2"
+    typescript: "npm:~5.4.5"
+  languageName: unknown
+  linkType: soft
+
+"@ourchitecture/backstage-plugin-stemix@workspace:*, @ourchitecture/backstage-plugin-stemix@workspace:plugins/backstage-stemix":
+  version: 0.0.0-use.local
+  resolution: "@ourchitecture/backstage-plugin-stemix@workspace:plugins/backstage-stemix"
+  dependencies:
+    "@backstage/cli": "npm:^0.29.0"
+    "@backstage/core-components": "npm:^0.15.0"
+    "@backstage/core-plugin-api": "npm:^1.9.0"
+    "@material-ui/core": "npm:^4.12.4"
+    "@types/react": "npm:^18.3.3"
+    "@types/react-dom": "npm:^18.3.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    react-router-dom: "npm:^6.26.0"
+    typescript: "npm:~5.4.5"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.0.0
+  languageName: unknown
+  linkType: soft
 
 "@peculiar/asn1-cms@npm:^2.6.0, @peculiar/asn1-cms@npm:^2.7.0":
   version: 2.7.0
@@ -13481,6 +13697,7 @@ __metadata:
     "@backstage/plugin-user-settings": "npm:^0.8.0"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
+    "@ourchitecture/backstage-plugin-stemix": "workspace:*"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     react: "npm:^18.3.1"
@@ -14100,6 +14317,7 @@ __metadata:
   resolution: "backend@workspace:packages/backend"
   dependencies:
     "@backstage/backend-defaults": "npm:^0.14.2"
+    "@backstage/backend-plugin-api": "npm:^1.9.0"
     "@backstage/plugin-app-backend": "npm:^0.5.6"
     "@backstage/plugin-auth-backend": "npm:^0.25.5"
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.10"
@@ -14111,6 +14329,7 @@ __metadata:
     "@backstage/plugin-scaffolder-backend": "npm:^3.0.3"
     "@backstage/plugin-search-backend": "npm:^2.1.1"
     "@backstage/plugin-techdocs-backend": "npm:^2.1.7"
+    "@ourchitecture/backstage-plugin-stemix-backend": "workspace:*"
     "@types/express": "npm:^4.17.21"
     "@types/luxon": "npm:^3.4.2"
     better-sqlite3: "npm:^12.0.0"
@@ -17516,6 +17735,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.28.0":
+  version: 0.28.0
+  resolution: "esbuild@npm:0.28.0"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.28.0"
+    "@esbuild/android-arm": "npm:0.28.0"
+    "@esbuild/android-arm64": "npm:0.28.0"
+    "@esbuild/android-x64": "npm:0.28.0"
+    "@esbuild/darwin-arm64": "npm:0.28.0"
+    "@esbuild/darwin-x64": "npm:0.28.0"
+    "@esbuild/freebsd-arm64": "npm:0.28.0"
+    "@esbuild/freebsd-x64": "npm:0.28.0"
+    "@esbuild/linux-arm": "npm:0.28.0"
+    "@esbuild/linux-arm64": "npm:0.28.0"
+    "@esbuild/linux-ia32": "npm:0.28.0"
+    "@esbuild/linux-loong64": "npm:0.28.0"
+    "@esbuild/linux-mips64el": "npm:0.28.0"
+    "@esbuild/linux-ppc64": "npm:0.28.0"
+    "@esbuild/linux-riscv64": "npm:0.28.0"
+    "@esbuild/linux-s390x": "npm:0.28.0"
+    "@esbuild/linux-x64": "npm:0.28.0"
+    "@esbuild/netbsd-arm64": "npm:0.28.0"
+    "@esbuild/netbsd-x64": "npm:0.28.0"
+    "@esbuild/openbsd-arm64": "npm:0.28.0"
+    "@esbuild/openbsd-x64": "npm:0.28.0"
+    "@esbuild/openharmony-arm64": "npm:0.28.0"
+    "@esbuild/sunos-x64": "npm:0.28.0"
+    "@esbuild/win32-arm64": "npm:0.28.0"
+    "@esbuild/win32-ia32": "npm:0.28.0"
+    "@esbuild/win32-x64": "npm:0.28.0"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/8acd95c238ec6c4a9d16163277faf228a8994b642d187b3fe667ffbb469008e6748cde144fdc3c175bf8e78ee49e15a0ed9b9f183fdb5fcea1772f87fb1372a4
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -18860,7 +19168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -18870,7 +19178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -28874,6 +29182,7 @@ __metadata:
     "@backstage/cli": "npm:^0.29.0"
     "@backstage/cli-common": "npm:^0.1.14"
     concurrently: "npm:^8.2.2"
+    tsx: "npm:^4.20.6"
     typescript: "npm:~5.4.5"
   languageName: unknown
   linkType: soft
@@ -30129,6 +30438,21 @@ __metadata:
   version: 1.0.6
   resolution: "tsscmp@npm:1.0.6"
   checksum: 10c0/2f79a9455e7e3e8071995f98cdf3487ccfc91b760bec21a9abb4d90519557eafaa37246e87c92fa8bf3fef8fd30cfd0cc3c4212bb929baa9fb62494bfa4d24b2
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.20.6":
+  version: 4.22.0
+  resolution: "tsx@npm:4.22.0"
+  dependencies:
+    esbuild: "npm:~0.28.0"
+    fsevents: "npm:~2.3.3"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/cc7474ac13eebf6bb4d87ce21bdd79213261a37a6e247a74d7920b3e0ce7b704b42e7642e7978e2f3de5762981b3b74ed0ae14cf60934107aa0b1390f25e46ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add standalone `backstage-stemix` frontend and backend plugin packages under `tools/backstage/plugins`
- integrate the plugin into the local Backstage demo app, backend, moon, make, release, and GitHub Actions flows
- document the Yarn-island Backstage workflow and GitHub Packages publishing path

## Validation
- moon run backstage-tools:check-ci
- moon run repo:check-lint-md
- moon run repo:check-lint-workflows