### PR TITLE
feat(ci): parallelize Check Container Build into per-image jobs

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -311,12 +311,12 @@ jobs:
           path: .pnpm-store
           key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
-  check-container-build:
-    name: Check Container Build
+  check-container-go-web:
+    name: Check Container (go-web)
     runs-on: ubuntu-latest
     needs: [detect-changes]
     if: >
-      needs.detect-changes.outputs.run_any_containers == 'true'
+      needs.detect-changes.outputs.run_go_containers == 'true'
       && github.event.pull_request.draft == false
     steps:
       - name: Checkout
@@ -326,7 +326,6 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Go web container
-        if: needs.detect-changes.outputs.run_go_containers == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: stacks/go/net-http/rest
@@ -338,15 +337,27 @@ jobs:
           cache-to: type=gha,scope=go-net-http-rest-web,mode=max,ignore-error=true,timeout=10m
 
       - name: Smoke Go web container
-        if: needs.detect-changes.outputs.run_go_containers == 'true'
         env:
           IMAGE: stemix-go-net-http-rest-web:pr-check
           PORT: "3300:3000"
           URL: http://localhost:3300/
         run: bash scripts/ci/smoke-test-container.sh
 
+  check-container-go-bff:
+    name: Check Container (go-bff)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_go_containers == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build Go BFF container
-        if: needs.detect-changes.outputs.run_go_containers == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: stacks/go/net-http/rest
@@ -358,15 +369,27 @@ jobs:
           cache-to: type=gha,scope=go-net-http-rest-bff,mode=max,ignore-error=true,timeout=10m
 
       - name: Smoke Go BFF container
-        if: needs.detect-changes.outputs.run_go_containers == 'true'
         env:
           IMAGE: stemix-go-net-http-rest-bff:pr-check
           PORT: "8300:8000"
           URL: http://localhost:8300/health
         run: bash scripts/ci/smoke-test-container.sh
 
+  check-container-node-web:
+    name: Check Container (nodejs-web)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_node_containers == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build Node.js web container
-        if: needs.detect-changes.outputs.run_node_containers == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -377,7 +400,6 @@ jobs:
           cache-to: type=gha,scope=nodejs-react-fastify-rest-web,mode=max,ignore-error=true,timeout=10m
 
       - name: Smoke Node.js web container
-        if: needs.detect-changes.outputs.run_node_containers == 'true'
         env:
           IMAGE: stemix-nodejs-react-fastify-rest-web:pr-check
           PORT: "3400:3000"
@@ -385,8 +407,21 @@ jobs:
           DOCKER_ARGS: -e BFF_URL=http://localhost:8400
         run: bash scripts/ci/smoke-test-container.sh
 
+  check-container-node-bff:
+    name: Check Container (nodejs-bff)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_node_containers == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build Node.js BFF container
-        if: needs.detect-changes.outputs.run_node_containers == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -397,15 +432,27 @@ jobs:
           cache-to: type=gha,scope=nodejs-react-fastify-rest-bff,mode=max,ignore-error=true,timeout=10m
 
       - name: Smoke Node.js BFF container
-        if: needs.detect-changes.outputs.run_node_containers == 'true'
         env:
           IMAGE: stemix-nodejs-react-fastify-rest-bff:pr-check
           PORT: "8400:8000"
           URL: http://localhost:8400/health
         run: bash scripts/ci/smoke-test-container.sh
 
+  check-container-tests:
+    name: Check Container (contract-tests)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_tests_container == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build contract tests container
-        if: needs.detect-changes.outputs.run_tests_container == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -415,8 +462,21 @@ jobs:
           cache-from: type=gha,scope=contract-tests,timeout=10m
           cache-to: type=gha,scope=contract-tests,mode=max,ignore-error=true,timeout=10m
 
+  check-container-mcp:
+    name: Check Container (mcp)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_mcp_containers == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build MCP server container
-        if: needs.detect-changes.outputs.run_mcp_containers == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -427,7 +487,6 @@ jobs:
           cache-to: type=gha,scope=mcp-tools,mode=max,ignore-error=true,timeout=10m
 
       - name: Smoke MCP server container
-        if: needs.detect-changes.outputs.run_mcp_containers == 'true'
         env:
           IMAGE: stemix-mcp-server:pr-check
           PORT: "8580:8080"
@@ -438,8 +497,21 @@ jobs:
           CURL_DATA: '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.0.1"}}}'
         run: bash scripts/ci/smoke-test-container.sh
 
+  check-container-mock-oauth:
+    name: Check Container (mock-oauth)
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: >
+      needs.detect-changes.outputs.run_mock_oauth_containers == 'true'
+      && github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build mock-oauth container
-        if: needs.detect-changes.outputs.run_mock_oauth_containers == 'true'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: tools/mock-oauth
@@ -450,13 +522,40 @@ jobs:
           cache-to: type=gha,scope=mock-oauth,mode=max,ignore-error=true,timeout=10m
 
       - name: Smoke mock-oauth container
-        if: needs.detect-changes.outputs.run_mock_oauth_containers == 'true'
         env:
           IMAGE: stemix-mock-oauth:pr-check
           PORT: "9900:9000"
           URL: http://localhost:9900/health
           POLL_ATTEMPTS: "10"
         run: bash scripts/ci/smoke-test-container.sh
+
+  check-container-build:
+    name: Check Container Build
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - detect-changes
+      - check-container-go-web
+      - check-container-go-bff
+      - check-container-node-web
+      - check-container-node-bff
+      - check-container-tests
+      - check-container-mcp
+      - check-container-mock-oauth
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify container build results
+        env:
+          RESULT_GO_WEB: ${{ needs.check-container-go-web.result }}
+          RESULT_GO_BFF: ${{ needs.check-container-go-bff.result }}
+          RESULT_NODE_WEB: ${{ needs.check-container-node-web.result }}
+          RESULT_NODE_BFF: ${{ needs.check-container-node-bff.result }}
+          RESULT_TESTS: ${{ needs.check-container-tests.result }}
+          RESULT_MCP: ${{ needs.check-container-mcp.result }}
+          RESULT_MOCK_OAUTH: ${{ needs.check-container-mock-oauth.result }}
+        run: bash scripts/ci/check-pr-container-build-result.sh
 
   check-mock-oauth-build:
     name: Check Mock OAuth Build
@@ -699,6 +798,13 @@ jobs:
       - check-workflow-files
       - check-stack-matrix
       - check-docs-site
+      - check-container-go-web
+      - check-container-go-bff
+      - check-container-node-web
+      - check-container-node-bff
+      - check-container-tests
+      - check-container-mcp
+      - check-container-mock-oauth
       - check-container-build
       - check-mock-oauth-build
       - check-auth-integration

--- a/scripts/ci/check-container-builds.sh
+++ b/scripts/ci/check-container-builds.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Build and smoke-test container images for local triage and CI.
+#
+# Usage:
+#   ./scripts/ci/check-container-builds.sh [name...]
+#
+# Available names:
+#   go-web  go-bff  nodejs-web  nodejs-bff  contract-tests  mcp  mock-oauth
+#
+# If no names are given, all containers are built.
+#
+# Environment variables:
+#   PARALLEL   — true (default) or false (sequential, easier to debug)
+#   TAG_SUFFIX — Docker image tag suffix (default: local-check)
+#   SMOKE      — true (default) or false (build only, skip smoke tests)
+#
+# Exit codes:
+#   0 — All selected containers built (and smoke-tested) successfully
+#   1 — One or more containers failed
+set -euo pipefail
+
+PARALLEL="${PARALLEL:-true}"
+TAG_SUFFIX="${TAG_SUFFIX:-local-check}"
+SMOKE="${SMOKE:-true}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+
+ALL_CONTAINERS=(go-web go-bff nodejs-web nodejs-bff contract-tests mcp mock-oauth)
+
+_tag() { echo "stemix-${1}:${TAG_SUFFIX}"; }
+
+_build() {
+  local name="$1" context="$2" dockerfile="$3"
+  shift 3
+  DOCKER_BUILDKIT=1 docker build \
+    --file "${REPO_ROOT}/${dockerfile}" \
+    "$@" \
+    --tag "$(_tag "${name}")" \
+    "${REPO_ROOT}/${context}"
+}
+
+_smoke() {
+  local name="$1"
+  shift
+  # remaining args are NAME=VALUE pairs forwarded to smoke-test-container.sh
+  IMAGE="$(_tag "${name}")" env "$@" bash "${SCRIPT_DIR}/smoke-test-container.sh"
+}
+
+# --- container definitions ---
+
+container_go_web() {
+  _build go-web stacks/go/net-http/rest stacks/go/net-http/rest/Dockerfile \
+    --build-arg SERVICE=web
+  [[ "${SMOKE}" != "true" ]] && return 0
+  _smoke go-web PORT="3300:3000" URL="http://localhost:3300/"
+}
+
+container_go_bff() {
+  _build go-bff stacks/go/net-http/rest stacks/go/net-http/rest/Dockerfile \
+    --build-arg SERVICE=bff
+  [[ "${SMOKE}" != "true" ]] && return 0
+  _smoke go-bff PORT="8300:8000" URL="http://localhost:8300/health"
+}
+
+container_nodejs_web() {
+  _build nodejs-web . stacks/nodejs/react-fastify/rest/web/Dockerfile
+  [[ "${SMOKE}" != "true" ]] && return 0
+  _smoke nodejs-web \
+    PORT="3400:3000" \
+    URL="http://localhost:3400/" \
+    DOCKER_ARGS="-e BFF_URL=http://localhost:8400"
+}
+
+container_nodejs_bff() {
+  _build nodejs-bff . stacks/nodejs/react-fastify/rest/bff/Dockerfile
+  [[ "${SMOKE}" != "true" ]] && return 0
+  _smoke nodejs-bff PORT="8400:8000" URL="http://localhost:8400/health"
+}
+
+container_contract_tests() {
+  _build contract-tests . tests/Dockerfile
+}
+
+container_mcp() {
+  _build mcp tools/mcp tools/mcp/Dockerfile
+  [[ "${SMOKE}" != "true" ]] && return 0
+  _smoke mcp \
+    PORT="8580:8080" \
+    URL="http://localhost:8580/mcp" \
+    CURL_METHOD="POST" \
+    CURL_CONTENT_TYPE="application/json" \
+    CURL_ACCEPT="application/json, text/event-stream" \
+    CURL_DATA='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke-test","version":"0.0.1"}}}'
+}
+
+container_mock_oauth() {
+  _build mock-oauth tools/mock-oauth tools/mock-oauth/Dockerfile
+  [[ "${SMOKE}" != "true" ]] && return 0
+  _smoke mock-oauth PORT="9900:9000" URL="http://localhost:9900/health" POLL_ATTEMPTS="10"
+}
+
+_dispatch() {
+  case "$1" in
+    go-web)         container_go_web ;;
+    go-bff)         container_go_bff ;;
+    nodejs-web)     container_nodejs_web ;;
+    nodejs-bff)     container_nodejs_bff ;;
+    contract-tests) container_contract_tests ;;
+    mcp)            container_mcp ;;
+    mock-oauth)     container_mock_oauth ;;
+    *) echo "Unknown container: $1" >&2; exit 1 ;;
+  esac
+}
+
+# determine which containers to process
+if [[ $# -eq 0 ]]; then
+  selected=("${ALL_CONTAINERS[@]}")
+else
+  selected=("$@")
+  for name in "${selected[@]}"; do
+    case "${name}" in
+      go-web|go-bff|nodejs-web|nodejs-bff|contract-tests|mcp|mock-oauth) ;;
+      *)
+        echo "Unknown container name: ${name}" >&2
+        echo "Available: ${ALL_CONTAINERS[*]}" >&2
+        exit 1 ;;
+    esac
+  done
+fi
+
+echo "Containers : ${selected[*]}"
+echo "Parallel   : ${PARALLEL} | Smoke: ${SMOKE} | Tag: ${TAG_SUFFIX}"
+echo "---"
+
+if [[ "${PARALLEL}" == "true" && "${#selected[@]}" -gt 1 ]]; then
+  pids=()
+  logfiles=()
+
+  for i in "${!selected[@]}"; do
+    name="${selected[$i]}"
+    logfile="$(mktemp "/tmp/check-container-${name}-XXXXXX.log")"
+    logfiles+=("${logfile}")
+    _dispatch "${name}" > "${logfile}" 2>&1 &
+    pids+=($!)
+    echo "[START] ${name}"
+  done
+
+  failed=()
+  for i in "${!selected[@]}"; do
+    name="${selected[$i]}"
+    if wait "${pids[$i]}"; then
+      echo "[PASS]  ${name}"
+    else
+      echo "[FAIL]  ${name}"
+      failed+=("${name}")
+      echo "--- ${name} output ---"
+      cat "${logfiles[$i]}"
+      echo "--- end ${name} ---"
+    fi
+    rm -f "${logfiles[$i]}" 2>/dev/null || true
+  done
+
+  if [[ "${#failed[@]}" -gt 0 ]]; then
+    echo "---"
+    echo "FAILED: ${failed[*]}"
+    exit 1
+  fi
+else
+  failed=()
+  for name in "${selected[@]}"; do
+    echo "=== ${name} ==="
+    if _dispatch "${name}"; then
+      echo "[PASS] ${name}"
+    else
+      echo "[FAIL] ${name}"
+      failed+=("${name}")
+    fi
+  done
+  if [[ "${#failed[@]}" -gt 0 ]]; then
+    echo "---"
+    echo "FAILED: ${failed[*]}"
+    exit 1
+  fi
+fi
+
+echo "---"
+echo "All selected containers passed."

--- a/scripts/ci/check-pr-container-build-result.sh
+++ b/scripts/ci/check-pr-container-build-result.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Verify that all parallel container build jobs in PR Validate completed successfully.
+# Each job result is passed via an environment variable. A result of "skipped" is
+# treated as passing (the container was not in scope for this PR).
+#
+# Required environment variables (GitHub Actions job result strings):
+#   RESULT_GO_WEB     — check-container-go-web job result
+#   RESULT_GO_BFF     — check-container-go-bff job result
+#   RESULT_NODE_WEB   — check-container-node-web job result
+#   RESULT_NODE_BFF   — check-container-node-bff job result
+#   RESULT_TESTS      — check-container-tests job result
+#   RESULT_MCP        — check-container-mcp job result
+#   RESULT_MOCK_OAUTH — check-container-mock-oauth job result
+#
+# Exit codes:
+#   0 — All required checks passed or were skipped
+#   1 — One or more required checks failed
+set -euo pipefail
+
+: "${RESULT_GO_WEB:?RESULT_GO_WEB is required}"
+: "${RESULT_GO_BFF:?RESULT_GO_BFF is required}"
+: "${RESULT_NODE_WEB:?RESULT_NODE_WEB is required}"
+: "${RESULT_NODE_BFF:?RESULT_NODE_BFF is required}"
+: "${RESULT_TESTS:?RESULT_TESTS is required}"
+: "${RESULT_MCP:?RESULT_MCP is required}"
+: "${RESULT_MOCK_OAUTH:?RESULT_MOCK_OAUTH is required}"
+
+failed=false
+
+for name_result in \
+  "check-container-go-web:${RESULT_GO_WEB}" \
+  "check-container-go-bff:${RESULT_GO_BFF}" \
+  "check-container-node-web:${RESULT_NODE_WEB}" \
+  "check-container-node-bff:${RESULT_NODE_BFF}" \
+  "check-container-tests:${RESULT_TESTS}" \
+  "check-container-mcp:${RESULT_MCP}" \
+  "check-container-mock-oauth:${RESULT_MOCK_OAUTH}"; do
+  name="${name_result%%:*}"
+  result="${name_result#*:}"
+  if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
+    echo "::error::${name} failed (${result})"
+    failed=true
+  fi
+done
+
+if [[ "${failed}" == "true" ]]; then
+  echo "::error::One or more container builds failed"
+  exit 1
+fi
+
+echo "All container builds completed successfully."


### PR DESCRIPTION
## Summary

- Replace the single sequential `check-container-build` job in `pr-validate.yml` with 7 parallel jobs — one per container image — each scoped to its own change-detection flag
- Add a new `check-container-build` aggregator job (`if: always()`) that collects all 7 results, keeping `check-pr-validation-result.sh` and `pr-validation-result` unchanged
- Add `scripts/ci/check-container-builds.sh` — a reusable local dev script that runs all (or filtered) builds + smoke tests in parallel for triage and future iteration
- Add `scripts/ci/check-pr-container-build-result.sh` — the aggregator helper called by the new aggregator job

## Test plan

- [ ] PR touching only `stacks/go/net-http/rest/**` should trigger only `check-container-go-web` and `check-container-go-bff`, not other container jobs
- [ ] PR touching multiple stacks should show all relevant container jobs running simultaneously in Actions UI
- [ ] If one container job fails, the `check-container-build` aggregator fails and blocks `pr-validation-result`
- [ ] `bash scripts/ci/check-container-builds.sh mcp` runs only the MCP build+smoke test locally
- [ ] `PARALLEL=false bash scripts/ci/check-container-builds.sh` runs all builds sequentially for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)