### PR TITLE
build(backstage): isolate moon tasks from pnpm workspace

### DIFF
--- a/tools/backstage/moon.yml
+++ b/tools/backstage/moon.yml
@@ -2,6 +2,14 @@ language: "typescript"
 layer: "tool"
 stack: "backend"
 
+# Keep Backstage isolated from the repo-root pnpm workspace bootstrap.
+toolchains:
+  default: "system"
+  javascript: false
+  node: false
+  npm: false
+  pnpm: false
+
 project:
   title: "backstage-tools"
   description: "Backstage test harness for Stemix IDP plug-in integration."
@@ -23,7 +31,7 @@ tasks:
     deps: ["install"]
 
   build-stemix:
-    command: ["bash", "-lc", "yarn run build:stemix"]
+    command: ["bash", "-lc", "corepack enable && yarn run build:stemix"]
     deps: ["install"]
 
   clean:


### PR DESCRIPTION
## Summary
- keep Backstage Moon tasks out of the repo-root pnpm workspace bootstrap
- run the Backstage Moon project as a system-toolchain task island so it can use its own Yarn workflow
- enable Corepack before the Stemix bundle build task for consistency with the other Backstage tasks

## Verification
- moon run backstage-tools:check-ci
