### PR TITLE
ci(dependabot): unblock pnpm lockfile sync + pin backstage security fixes

### DIFF
--- a/.github/workflows/dependabot-pnpm-lockfile-sync.yml
+++ b/.github/workflows/dependabot-pnpm-lockfile-sync.yml
@@ -1,0 +1,122 @@
+name: Dependabot pnpm Lockfile Sync
+
+# Dependabot's npm ecosystem updates per-package `package.json` files for
+# pnpm workspaces but does not regenerate the root `pnpm-lock.yaml`. This
+# breaks every downstream `pnpm install --frozen-lockfile` in CI.
+#
+# This workflow runs on Dependabot PRs, regenerates the lockfile via
+# `pnpm install --lockfile-only`, and commits it back to the PR branch so
+# the standard PR Validate flow can proceed without manual intervention.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/package.json"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROTO_VERSION: "0.57.2"
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+
+jobs:
+  sync-lockfile:
+    name: Sync pnpm-lock.yaml
+    runs-on: ubuntu-latest
+
+    # Only act on Dependabot PRs from this repo (not forks — we cannot push
+    # to fork branches and pull_request from forks does not grant write
+    # permissions to GITHUB_TOKEN anyway).
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Restore proto and moon cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.proto
+            ~/.cache/proto
+            ~/.cache/moon
+            ~/.moon/cache
+            .moon/cache
+          key: proto-moon-v2-${{ runner.os }}-${{ hashFiles('.prototools') }}
+
+      - name: Setup toolchain
+        uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
+        with:
+          proto-version: ${{ env.PROTO_VERSION }}
+          auto-install: true
+
+      - name: Refresh pnpm-lock.yaml
+        run: pnpm install --lockfile-only --no-frozen-lockfile
+
+      - name: Commit and push if lockfile changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "pnpm-lock.yaml already in sync — nothing to do."
+            exit 0
+          fi
+
+          echo "pnpm-lock.yaml is out of date; committing refreshed lockfile."
+
+          # Commit as dependabot[bot] so the commit stays inside the
+          # Dependabot author namespace and merges cleanly with any future
+          # rebase Dependabot performs on this branch.
+          git config user.name 'dependabot[bot]'
+          git config user.email '49699333+dependabot[bot]@users.noreply.github.com'
+
+          git add pnpm-lock.yaml
+          git commit -m "chore(deps): sync pnpm-lock.yaml [dependabot skip]"
+          git push
+
+          # Pushes made with GITHUB_TOKEN do not re-trigger pull_request
+          # workflows (a recursion-prevention safety in GitHub Actions). Leave
+          # a comment so the maintainer knows to re-run PR Validate, and
+          # surface a helpful @dependabot recreate hint as a fallback.
+          gh pr comment "$PR_NUMBER" --body "$(cat <<'EOF'
+          🤖 Synced `pnpm-lock.yaml` to match the updated `package.json`.
+
+          GitHub does not auto-trigger required checks after a `GITHUB_TOKEN`
+          push, so please re-run **PR Validate** from the Checks tab — or
+          comment `@dependabot rebase` to have Dependabot re-push the branch
+          (which will re-trigger validation).
+          EOF
+          )"
+
+      - name: Save proto and moon cache
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.proto
+            ~/.cache/proto
+            ~/.cache/moon
+            ~/.moon/cache
+            .moon/cache
+          key: proto-moon-v2-${{ runner.os }}-${{ hashFiles('.prototools') }}

--- a/tools/backstage/package.json
+++ b/tools/backstage/package.json
@@ -36,7 +36,9 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "koa": "^2.16.4",
+    "underscore": "^1.13.8"
   },
   "prettier": {},
   "engines": {

--- a/tools/backstage/yarn.lock
+++ b/tools/backstage/yarn.lock
@@ -20797,9 +20797,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.15.4":
-  version: 2.15.4
-  resolution: "koa@npm:2.15.4"
+"koa@npm:^2.16.4":
+  version: 2.16.4
+  resolution: "koa@npm:2.16.4"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -20824,7 +20824,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/fd2171b4dba706d35244fe60403a61671717a167453349813757999dad280049ddd0dcdba23cda197a5a3538f4c034cf0fd1f9caeb849be1ca1eecaa78db2f99
+  checksum: 10c0/bf21ffcf409bf847dca3f60349fc64a3b33e725e0ced3f405192a22fa51b4211cac29748f51df9674df82ca87691b3bdda64bbf80755ba6cdc6b2f35e878b0f5
   languageName: node
   linkType: hard
 
@@ -28643,14 +28643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"underscore@npm:1.13.6":
-  version: 1.13.6
-  resolution: "underscore@npm:1.13.6"
-  checksum: 10c0/5f57047f47273044c045fddeb8b141dafa703aa487afd84b319c2495de2e685cecd0b74abec098292320d518b267c0c4598e45aa47d4c3628d0d4020966ba521
-  languageName: node
-  linkType: hard
-
-"underscore@npm:^1.13.3":
+"underscore@npm:^1.13.8":
   version: 1.13.8
   resolution: "underscore@npm:1.13.8"
   checksum: 10c0/6677688daeda30484823e77c0b89ce4dcf29964a77d5a06f37299c007ab4bb1c66a0ff75e0d274620b62a1fe2a6ba29879f8214533ca611d71a1ae504f2bfc9b


### PR DESCRIPTION
## Summary

Empower Dependabot to keep the IDP secure and up to date by fixing two
distinct blockers that were silently breaking the weekly update flow.

### A. pnpm workspace lockfile auto-sync (CI fix)

Dependabot's `npm` ecosystem updates per-package `package.json` files in
pnpm workspaces (`tools/mcp`, `tools/vscode-extension`, `docs`,
`stacks/nodejs/...`) but **does not** regenerate the root `pnpm-lock.yaml`.
Every such PR failed `PR Validate → Detect Changes` with:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/tools/mcp/package.json
```

(See e.g. run 25985614337.)

New workflow `.github/workflows/dependabot-pnpm-lockfile-sync.yml`:

- Triggers on `pull_request` (opened / synchronize / reopened) when paths
  matching `**/package.json`, `pnpm-workspace.yaml`, or `pnpm-lock.yaml`
  change.
- Gated to `github.actor == 'dependabot[bot]'` and same-repo PRs only
  (forks cannot be pushed to, and `GITHUB_TOKEN` has no write perms there).
- Runs `pnpm install --lockfile-only` via the same `moonrepo/setup-toolchain`
  setup pattern other workflows use (action SHA-pinned to v0.6.4).
- Commits the refreshed lockfile as `dependabot[bot]` with `[dependabot skip]`
  so future Dependabot rebases don't undo it.
- Posts an explainer comment on the PR — `GITHUB_TOKEN` pushes do not
  re-trigger `pull_request` workflows (recursion guard), so the maintainer
  needs to either re-run **PR Validate** or comment `@dependabot rebase`.

### B. Pin patched versions for known-vulnerable transitive deps in `tools/backstage`

Dependabot's audit-fix fallback runs `corepack yarn npm audit --fix
--mode update-lockfile`, but **Yarn Berry 4.x does not support `--fix`**:

```
Error: Unknown Syntax Error: Unsupported option name ("--fix").
→ Dependabot::NpmAndYarn::FileUpdater::NoChangeError
→ No files were updated! Package manager: yarn
```

(See e.g. run 25985462521 — security job 1370590565.)

As a result, **every** security update job for `/tools/backstage` failed and
no security PR was ever created. The high-severity advisories had to be
patched manually.

Added Berry `resolutions` in `tools/backstage/package.json`:

- `koa: ^2.16.4` → fixes [GHSA-7gcc-r8m5-44qm](https://github.com/advisories/GHSA-7gcc-r8m5-44qm)
  (Host Header Injection — pulled via `@module-federation/dts-plugin`).
- `underscore: ^1.13.8` → fixes [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw)
  (unlimited recursion DoS — pulled via `jsonpath`).

`yarn npm audit --recursive --severity high` is now clean.

> Remaining moderate findings in `@octokit/*` are major-version bumps that
> would risk Backstage runtime breakage and should land via a Backstage
> dependency upgrade, not a forced resolution.

## Test plan

- [x] `make check-lint-workflows` — passes (validates the new YAML).
- [x] `corepack yarn --cwd tools/backstage install --immutable` — passes.
- [x] `corepack yarn --cwd tools/backstage npm audit --recursive --severity high` — no findings.
- [x] `make -C tools/backstage check-test` — passes (typecheck + plugin tests).
- [ ] After merge: confirm the next weekly Dependabot run produces clean PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)